### PR TITLE
Increase release CI timeout

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Release CI is timing out occasionally - this is problematic because a simple re-run will not fix the issue - instead we'll get errors when we try and upload artifacts because there may be duplicate artifacts already uploaded by the timed out run.  For example see https://github.com/OmniSharp/omnisharp-vscode/actions/runs/4420722136/attempts/2