### PR TITLE
Open the specified settings item after click open button

### DIFF
--- a/src/coreclr-debug/activate.ts
+++ b/src/coreclr-debug/activate.ts
@@ -115,7 +115,7 @@ function showDotnetToolsWarning(message: string): void {
                     let dotnetcoreURL = 'https://dot.net/core-sdk-vscode';
                     vscode.env.openExternal(vscode.Uri.parse(dotnetcoreURL));
                 } else if (value === goToSettingsMessage) {
-                    vscode.commands.executeCommand('workbench.action.openGlobalSettings');
+                    vscode.commands.executeCommand('workbench.action.openSettings', 'csharp.suppressDotnetInstallWarning');
                 } else if (value == helpMessage) {
                     let helpURL = 'https://aka.ms/VSCode-CS-DotnetNotFoundHelp';
                     vscode.env.openExternal(vscode.Uri.parse(helpURL));

--- a/src/observers/BaseStatusBarItemObserver.ts
+++ b/src/observers/BaseStatusBarItemObserver.ts
@@ -11,7 +11,7 @@ export abstract class BaseStatusBarItemObserver {
     constructor(private statusBarItem: StatusBarItem) {
     }
 
-    public SetAndShowStatusBar(text: string, command: string, color?: string, tooltip?: string) {
+    public SetAndShowStatusBar(text: string, command?: string, color?: string, tooltip?: string) {
         this.statusBarItem.text = text;
         this.statusBarItem.command = command;
         this.statusBarItem.color = color;

--- a/src/observers/OmnisharpStatusBarObserver.ts
+++ b/src/observers/OmnisharpStatusBarObserver.ts
@@ -36,17 +36,17 @@ export class OmnisharpStatusBarObserver extends BaseStatusBarItemObserver {
                 this.SetAndShowStatusBar('$(flame)', 'o.showOutput', undefined, 'OmniSharp server is running');
                 break;
             case EventType.DownloadStart:
-                this.SetAndShowStatusBar("$(cloud-download) Downloading packages", '', '', `Downloading package '${(<DownloadStart>event).packageDescription}...' `);
+                this.SetAndShowStatusBar("$(cloud-download) Downloading packages", undefined, undefined, `Downloading package '${(<DownloadStart>event).packageDescription}...' `);
                 break;
             case EventType.InstallationStart:
-                this.SetAndShowStatusBar("$(desktop-download) Installing packages...", '', '', `Installing package '${(<InstallationStart>event).packageDescription}'`);
+                this.SetAndShowStatusBar("$(desktop-download) Installing packages...", undefined, undefined, `Installing package '${(<InstallationStart>event).packageDescription}'`);
                 break;
             case EventType.InstallationSuccess:
                 this.ResetAndHideStatusBar();
                 break;
             case EventType.DownloadProgress:
                 let progressEvent = <DownloadProgress>event;
-                this.SetAndShowStatusBar("$(cloud-download) Downloading packages", '', '', `Downloading package '${progressEvent.packageDescription}'... ${progressEvent.downloadPercentage}%`);
+                this.SetAndShowStatusBar("$(cloud-download) Downloading packages", undefined, undefined, `Downloading package '${progressEvent.packageDescription}'... ${progressEvent.downloadPercentage}%`);
                 break;
         }
     }

--- a/src/omnisharp/requirementCheck.ts
+++ b/src/omnisharp/requirementCheck.ts
@@ -27,7 +27,7 @@ export async function validateRequirements(options: Options): Promise<boolean> {
             let dotnetcoreURL = 'https://dot.net/core-sdk-vscode';
             vscode.env.openExternal(vscode.Uri.parse(dotnetcoreURL));
         } else if (downloadSdk === PromptResult.No) {
-            vscode.commands.executeCommand('workbench.action.openGlobalSettings');
+            vscode.commands.executeCommand('workbench.action.openSettings', 'omnisharp.dotnetPath');
         }
 
         return false;
@@ -42,7 +42,7 @@ export async function validateRequirements(options: Options): Promise<boolean> {
             let monoURL = 'https://www.mono-project.com/download/stable/';
             vscode.env.openExternal(vscode.Uri.parse(monoURL));
         } else if (downloadMono === PromptResult.No) {
-            vscode.commands.executeCommand('workbench.action.openGlobalSettings');
+            vscode.commands.executeCommand('workbench.action.openSettings', 'omnisharp.monoPath');
         }
 
         return false;


### PR DESCRIPTION
I had used this extension with Company network, and found some issue about downloading packages, I made some small improvements for this extension:

- Open `settings` with configuraion ID, according to https://github.com/microsoft/vscode/issues/84324.
- Remove empty command to avoid error when click the status bar during download package.