### PR TITLE
Add official build pipeline definition

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -1,0 +1,25 @@
+trigger:
+  branches:
+    include:
+    - main
+    - prerelease
+pr: none
+
+variables:
+  - name: prereleaseFlag
+    value: '--prerelease'
+
+stages:
+- stage: Build
+  dependsOn: []
+  jobs:
+  - job: Build
+    steps:
+    - template: azure-pipelines/build.yml
+      parameters:
+        prereleaseFlag: $(prereleaseFlag)
+    pool:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+
+# TODO: add compliance, signing.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,5 +42,3 @@ stages:
       demands: $(demandsName)
     steps:
     - template: azure-pipelines/test.yml
-
-# TODO: add compliance stage


### PR DESCRIPTION
Adds a definition for an official build pipeline.  Currently its the same as the normal build, but we'll be adding signing / other compliance steps here.

This will also run in the dnceng internal instance.  The pipeline doesn't exist yet, but the yaml needs to be merged in order to create the pipeline.