### PR TITLE
Ship prerelease builds out of main instead of separate branch

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
     - main
-    - prerelease
 pr: none
 
 variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,12 +3,10 @@ trigger:
   branches:
     include:
     - feature/*
-    - prerelease
     - main
 
 pr:
 - feature/*
-- prerelease
 - main
 
 variables:

--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
 	"version": "2.0",
 	"publicReleaseRefSpec": [
 		"^refs/heads/release$",
-		"^refs/heads/prerelease$"
+		"^refs/heads/main$"
 	],
 	"cloudBuild": {
 		"buildNumber": {


### PR DESCRIPTION
Aligns to the new publishing workflow where we publish weekly builds out of main instead of from a separate prerelease branch.

This removes the automatic CI for the prerelease branch and updates main to produce correctly versioned vsix's.  Once we do next weeks publishing, I'll delete the prerelease branch itself.