### PR TITLE
Fix Razor completion tooltip documentation

### DIFF
--- a/src/razor/src/Completion/RazorCompletionItemProvider.ts
+++ b/src/razor/src/Completion/RazorCompletionItemProvider.ts
@@ -47,6 +47,11 @@ export class RazorCompletionItemProvider
                     position: projectedPosition
                 };
 
+                // For CSharp, completions need to keep the "data" field on the
+                // completion item for lazily resolving the edits in the
+                // resolveCompletionItem step. Using the vs code command drops
+                // that field because it doesn't exist in the declared vs code
+                // CompletionItem type.
                 completions = await vscode
                     .commands
                     .executeCommand<vscode.CompletionList | vscode.CompletionItem[]>(
@@ -67,11 +72,6 @@ export class RazorCompletionItemProvider
                     : completions ? completions.items       // was vscode.CompletionList
                         : [];
             
-            // For CSharp, completions need to keep the "data" field
-            // on the completion item for lazily resolving the edits in
-            // the resolveCompletionItem step. Using the vs code command
-            // drops that field because it doesn't exist in the declared vs code
-            // CompletionItem type.
             const data = (<CompletionList>completions)?.itemDefaults?.data;
 
             // There are times when the generated code will not line up with the content of the .razor/.cshtml file.
@@ -131,7 +131,9 @@ export class RazorCompletionItemProvider
                     }
                 }
 
-                (<CompletionItem>completionItem).data = data;
+                if (!(<CompletionItem>completionItem).data) {
+                    (<CompletionItem>completionItem).data = data;
+                }
             }
 
             const isIncomplete = completions instanceof Array ? false

--- a/src/razor/src/Completion/RazorCompletionItemProvider.ts
+++ b/src/razor/src/Completion/RazorCompletionItemProvider.ts
@@ -211,7 +211,7 @@ export class RazorCompletionItemProvider
             item = newItem;
 
             // The documentation object Roslyn returns is a MarkupContent,
-            // which we need to convert to a MarkupString.
+            // which we need to convert to a MarkdownString.
             const markupContent = <MarkupContent>(<unknown>(item.documentation));
             if (markupContent && markupContent.value) {
                 item.documentation = new vscode.MarkdownString(markupContent.value);

--- a/src/razor/src/Completion/RazorCompletionItemProvider.ts
+++ b/src/razor/src/Completion/RazorCompletionItemProvider.ts
@@ -13,7 +13,7 @@ import { getUriPath } from '../UriPaths';
 import { ProvisionalCompletionOrchestrator } from './ProvisionalCompletionOrchestrator';
 import { LanguageKind } from '../RPC/LanguageKind';
 import { RoslynLanguageServer } from '../../../lsptoolshost/roslynLanguageServer';
-import { CompletionItem, CompletionList, CompletionParams, CompletionTriggerKind } from 'vscode-languageclient';
+import { CompletionItem, CompletionList, CompletionParams, CompletionTriggerKind, MarkupContent } from 'vscode-languageclient';
 import { UriConverter } from '../../../lsptoolshost/uriConverter';
 import * as RazorConventions from '../RazorConventions';
 import { MappingHelpers } from '../Mapping/MappingHelpers';
@@ -210,11 +210,11 @@ export class RazorCompletionItemProvider
 
             item = newItem;
 
-            // The documentation object Roslyn returns can have a different
-            // shape than what the client expects, so we do a conversion here.
-            const markdownString = <vscode.MarkdownString>(item.documentation);
-            if (markdownString && markdownString.value) {
-                item.documentation = new vscode.MarkdownString(markdownString.value);
+            // The documentation object Roslyn returns is a MarkupContent,
+            // which we need to convert to a MarkupString.
+            const markupContent = <MarkupContent>(<unknown>(item.documentation));
+            if (markupContent && markupContent.value) {
+                item.documentation = new vscode.MarkdownString(markupContent.value);
             }
 
             if (item.command && item.command.arguments?.length === 4) {


### PR DESCRIPTION
Razor completion tooltips were previously missing for C# items and HTML snippets.
The tooltips are sometimes cut off (see screenshot), but this is a problem with C# files as well and is likely an editor issue.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1831344/

Before:
![image](https://github.com/dotnet/vscode-csharp/assets/16968319/a91a4bf8-7f07-4e7a-9ffb-9ad375408851)

After:
![image](https://github.com/dotnet/vscode-csharp/assets/16968319/c0b89aa6-4bb2-4c91-814f-e1adadf0874e)
