### PR TITLE
Pass the configured VSCode language to the server

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -423,6 +423,9 @@ export class RoslynLanguageServer {
         // shouldn't this arg only be set if it's running with CSDevKit?
         args.push("--telemetryLevel", this.telemetryReporter.telemetryLevel);
 
+        let language = vscode.env.language;
+        args.push("--language", language);
+
         let childProcess: cp.ChildProcessWithoutNullStreams;
         let cpOptions: cp.SpawnOptionsWithoutStdio = {
             detached: true,


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/5716

Now uses VSCode's configured language instead of the OS language when launching the language server.

For example, in the following screenshot my OS is configured in English, but I've set VSCode's display language to Japanese.  Previously we would have output strings in the OS language (English), but now we output them in VSCode's display language.
![image](https://github.com/dotnet/vscode-csharp/assets/5749229/ae8640af-1062-4198-bcd1-fb9beb85f8c6)

Note that this is not full localization support - strings defined on the client extension side are not localized yet.  This just fixes the server outputting the wrong localization.

Requires a server update with https://github.com/dotnet/roslyn/pull/68739