### PR TITLE
Support opening of source-generated files over LSP

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -61,6 +61,7 @@ import { IDisposable } from '../disposable';
 import { registerNestedCodeActionCommands } from './nestedCodeAction';
 import { registerRestoreCommands } from './restore';
 import { BuildDiagnosticsService } from './buildDiagnosticsService';
+import { registerSourceGeneratedFilesContentProvider } from './sourceGeneratedFilesContentProvider';
 
 let _channel: vscode.OutputChannel;
 let _traceChannel: vscode.OutputChannel;
@@ -899,6 +900,8 @@ export async function activateRoslynLanguageServer(
     registerDebugger(context, languageServer, languageServerEvents, platformInfo, _channel);
 
     registerRestoreCommands(context, languageServer, dotnetChannel);
+
+    registerSourceGeneratedFilesContentProvider(context, languageServer);
 
     registerOnAutoInsert(languageServer);
 

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -170,6 +170,14 @@ export interface ProjectNeedsRestoreName {
     projectFilePaths: string[];
 }
 
+export interface SourceGeneratorGetRequestParams {
+    textDocument: lsp.TextDocumentIdentifier;
+}
+
+export interface SourceGeneratedDocumentText {
+    text: string;
+}
+
 export namespace WorkspaceDebugConfigurationRequest {
     export const method = 'workspace/debugConfiguration';
     export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
@@ -272,4 +280,10 @@ export namespace ProjectNeedsRestoreRequest {
     export const method = 'workspace/_roslyn_projectNeedsRestore';
     export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.serverToClient;
     export const type = new lsp.RequestType<ProjectNeedsRestoreName, void, void>(method);
+}
+
+export namespace SourceGeneratorGetTextRequest {
+    export const method = 'sourceGeneratedFile/_roslyn_getText';
+    export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
+    export const type = new lsp.RequestType<SourceGeneratorGetRequestParams, SourceGeneratedDocumentText, void>(method);
 }

--- a/src/lsptoolshost/sourceGeneratedFilesContentProvider.ts
+++ b/src/lsptoolshost/sourceGeneratedFilesContentProvider.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as RoslynProtocol from './roslynProtocol';
+import { RoslynLanguageServer } from './roslynLanguageServer';
+import { UriConverter } from './uriConverter';
+import * as lsp from 'vscode-languageserver-protocol';
+
+export function registerSourceGeneratedFilesContentProvider(
+    context: vscode.ExtensionContext,
+    languageServer: RoslynLanguageServer
+) {
+    context.subscriptions.push(
+        vscode.workspace.registerTextDocumentContentProvider(
+            'roslyn-source-generated',
+            new (class implements vscode.TextDocumentContentProvider {
+                async provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): Promise<string> {
+                    const result = await languageServer.sendRequest(
+                        RoslynProtocol.SourceGeneratorGetTextRequest.type,
+                        { textDocument: lsp.TextDocumentIdentifier.create(UriConverter.serialize(uri)) },
+                        token
+                    );
+                    return result.text;
+                }
+            })()
+        )
+    );
+}


### PR DESCRIPTION
This depends on https://github.com/dotnet/roslyn/pull/68771 for the server-side piece. But, if you don't have the server side piece, we won't return a URI that will trigger this code, so it's fine to have it in now.