### PR TITLE
Remove unsupported feature

### DIFF
--- a/src/razor/src/completion/razorCompletionItemProvider.ts
+++ b/src/razor/src/completion/razorCompletionItemProvider.ts
@@ -90,7 +90,7 @@ export class RazorCompletionItemProvider extends RazorLanguageFeatureBase implem
                 if (doc && doc.value) {
                     // Without this, the documentation doesn't get rendered in the editor.
                     const newDoc = new vscode.MarkdownString(doc.value);
-                    newDoc.isTrusted = doc.isTrusted;
+                    newDoc.isTrusted = false;
                     completionItem.documentation = newDoc;
                 }
 


### PR DESCRIPTION
we don't support commands in our markdown documentation for completion, so just remove it entirely

Tested in a cshtml and .razor file: 

* CSharp completion
* HTML completion (links to MDN still work)
* Razor completion