### PR TITLE
Add determineBrowserType to CSharpExtensionExports

### DIFF
--- a/src/csharpExtensionExports.ts
+++ b/src/csharpExtensionExports.ts
@@ -20,4 +20,5 @@ export interface CSharpExtensionExports {
     initializationFinished: () => Promise<void>;
     logDirectory: string;
     profferBrokeredServices: (container: GlobalBrokeredServiceContainer) => void;
+    determineBrowserType: () => Promise<string | undefined>;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,7 @@ import Descriptors from './lsptoolshost/services/descriptors';
 import { GlobalBrokeredServiceContainer } from '@microsoft/servicehub-framework';
 import { CSharpExtensionExports, OmnisharpExtensionExports } from './csharpExtensionExports';
 import { csharpDevkitExtensionId, getCSharpDevKit } from './utils/getCSharpDevKit';
+import { BlazorDebugConfigurationProvider } from './razor/src/blazorDebug/blazorDebugConfigurationProvider';
 
 export async function activate(
     context: vscode.ExtensionContext
@@ -288,6 +289,7 @@ export async function activate(
             },
             profferBrokeredServices: (container) => profferBrokeredServices(context, container),
             logDirectory: context.logUri.fsPath,
+            determineBrowserType: BlazorDebugConfigurationProvider.determineBrowserType,
         };
     } else {
         return {

--- a/src/razor/src/blazorDebug/blazorDebugConfigurationProvider.ts
+++ b/src/razor/src/blazorDebug/blazorDebugConfigurationProvider.ts
@@ -15,9 +15,9 @@ import showInformationMessage from '../../../shared/observers/utils/showInformat
 import showErrorMessage from '../../../observers/utils/showErrorMessage';
 
 export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-    private readonly autoDetectUserNotice = `Run and Debug: auto-detection found {0} for a launch browser`;
-    private readonly edgeBrowserType = 'pwa-msedge';
-    private readonly chromeBrowserType = 'pwa-chrome';
+    private static readonly autoDetectUserNotice = `Run and Debug: auto-detection found {0} for a launch browser`;
+    private static readonly edgeBrowserType = 'pwa-msedge';
+    private static readonly chromeBrowserType = 'pwa-chrome';
 
     constructor(private readonly logger: RazorLogger, private readonly vscodeType: typeof vscode) {}
 
@@ -125,10 +125,10 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
         const configBrowser = configuration.browser;
         const browserType =
             configBrowser === 'edge'
-                ? this.edgeBrowserType
+                ? BlazorDebugConfigurationProvider.edgeBrowserType
                 : configBrowser === 'chrome'
-                ? this.chromeBrowserType
-                : await this.determineBrowserType();
+                ? BlazorDebugConfigurationProvider.chromeBrowserType
+                : await BlazorDebugConfigurationProvider.determineBrowserType();
         if (!browserType) {
             return;
         }
@@ -172,7 +172,7 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
         }
     }
 
-    private async determineBrowserType() {
+    public static async determineBrowserType() {
         // There was no browser specified by the user, so we will do some auto-detection to find a browser,
         // favoring chrome if multiple valid options are installed.
         const chromeBrowserFinder = new ChromeBrowserFinder(process.env, promises, null);


### PR DESCRIPTION
This PR exports the
`BlazorDebugConfigurationProvider.determineBrowserType` method that it could be used in `vscode-dotnettools` to help determine the browser the user wants to use.