### PR TITLE
Fix static variables used in determineBrowserType

### DIFF
--- a/src/razor/src/blazorDebug/blazorDebugConfigurationProvider.ts
+++ b/src/razor/src/blazorDebug/blazorDebugConfigurationProvider.ts
@@ -15,9 +15,9 @@ import showInformationMessage from '../../../shared/observers/utils/showInformat
 import showErrorMessage from '../../../observers/utils/showErrorMessage';
 
 export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-    private static readonly autoDetectUserNotice = `Run and Debug: auto-detection found {0} for a launch browser`;
-    private static readonly edgeBrowserType = 'msedge';
-    private static readonly chromeBrowserType = 'chrome';
+    private static readonly autoDetectUserNotice: string = `Run and Debug: auto-detection found {0} for a launch browser`;
+    private static readonly edgeBrowserType: string = 'msedge';
+    private static readonly chromeBrowserType: string = 'chrome';
 
     constructor(private readonly logger: RazorLogger, private readonly vscodeType: typeof vscode) {}
 
@@ -172,21 +172,27 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
         }
     }
 
-    public static async determineBrowserType() {
+    public static async determineBrowserType(): Promise<string | undefined> {
         // There was no browser specified by the user, so we will do some auto-detection to find a browser,
         // favoring chrome if multiple valid options are installed.
         const chromeBrowserFinder = new ChromeBrowserFinder(process.env, promises, null);
         const chromeInstallations = await chromeBrowserFinder.findAll();
         if (chromeInstallations.length > 0) {
-            showInformationMessage(vscode, this.autoDetectUserNotice.replace('{0}', `'Chrome'`));
-            return this.chromeBrowserType;
+            showInformationMessage(
+                vscode,
+                BlazorDebugConfigurationProvider.autoDetectUserNotice.replace('{0}', `'Chrome'`)
+            );
+            return BlazorDebugConfigurationProvider.chromeBrowserType;
         }
 
         const edgeBrowserFinder = new EdgeBrowserFinder(process.env, promises, null);
         const edgeInstallations = await edgeBrowserFinder.findAll();
         if (edgeInstallations.length > 0) {
-            showInformationMessage(vscode, this.autoDetectUserNotice.replace('{0}', `'Edge'`));
-            return this.edgeBrowserType;
+            showInformationMessage(
+                vscode,
+                BlazorDebugConfigurationProvider.autoDetectUserNotice.replace('{0}', `'Edge'`)
+            );
+            return BlazorDebugConfigurationProvider.edgeBrowserType;
         }
 
         showErrorMessage(vscode, 'Run and Debug: A valid browser is not installed');


### PR DESCRIPTION
This PR fixes the 'this' to be 'BlazorDebugConfigurationProvider' for the new static variables from https://github.com/dotnet/vscode-csharp/pull/5911

5911 introduces a bug as it will throw an exception as `undefined` does not have a `replace` method and it will always be returning `undefined`