### PR TITLE
Separate Razor server and Typescript versions (O# and non-O#)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ out
 .vs/
 .debugger/
 .razor/
+.razoromnisharp/
 .vscode-test/
 dist/
 *.razor.json

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,7 @@
 !.roslyn/**
 !.omnisharp/**
 !.razor/**
+!.razoromnisharp/**
 .rpt2_cache/**
 .github/**
 .vscode/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "http-proxy-agent": "4.0.1",
         "https-proxy-agent": "5.0.0",
         "jsonc-parser": "3.0.0",
+        "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/0af42abab690d5de903a4a814d6aedc1/microsoft.aspnetcore.razor.vscode-7.0.0-preview.23363.1.tgz",
         "nerdbank-gitversioning": "^3.6.79-alpha",
         "node-machine-id": "1.1.12",
         "ps-list": "7.2.0",
@@ -7775,6 +7776,64 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/microsoft.aspnetcore.razor.vscode": {
+      "version": "7.0.0-preview.23363.1",
+      "resolved": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/0af42abab690d5de903a4a814d6aedc1/microsoft.aspnetcore.razor.vscode-7.0.0-preview.23363.1.tgz",
+      "integrity": "sha512-h1fquhBbLDlxiAB2vD2XWfydTIfLtBgnaXOYcUSCWqITHWGg6fVfqEbYEK/yd0Y5nnxZPr7hGN/J4lqAFOlllA==",
+      "dependencies": {
+        "ps-list": "7.2.0",
+        "vscode-html-languageservice": "^5.0.1",
+        "vscode-languageclient": "8.0.2",
+        "vscode-languageserver-textdocument": "^1.0.5"
+      },
+      "engines": {
+        "vscode": "1.69.0"
+      }
+    },
+    "node_modules/microsoft.aspnetcore.razor.vscode/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/microsoft.aspnetcore.razor.vscode/node_modules/vscode-jsonrpc": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/microsoft.aspnetcore.razor.vscode/node_modules/vscode-languageclient": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+      "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+      "dependencies": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.5",
+        "vscode-languageserver-protocol": "3.17.2"
+      },
+      "engines": {
+        "vscode": "^1.67.0"
+      }
+    },
+    "node_modules/microsoft.aspnetcore.razor.vscode/node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "dependencies": {
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
       }
     },
     "node_modules/mime": {
@@ -18296,6 +18355,50 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "microsoft.aspnetcore.razor.vscode": {
+      "version": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/0af42abab690d5de903a4a814d6aedc1/microsoft.aspnetcore.razor.vscode-7.0.0-preview.23363.1.tgz",
+      "integrity": "sha512-h1fquhBbLDlxiAB2vD2XWfydTIfLtBgnaXOYcUSCWqITHWGg6fVfqEbYEK/yd0Y5nnxZPr7hGN/J4lqAFOlllA==",
+      "requires": {
+        "ps-list": "7.2.0",
+        "vscode-html-languageservice": "^5.0.1",
+        "vscode-languageclient": "8.0.2",
+        "vscode-languageserver-textdocument": "^1.0.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "vscode-jsonrpc": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+          "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+        },
+        "vscode-languageclient": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+          "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+          "requires": {
+            "minimatch": "^3.0.4",
+            "semver": "^7.3.5",
+            "vscode-languageserver-protocol": "3.17.2"
+          }
+        },
+        "vscode-languageserver-protocol": {
+          "version": "3.17.2",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+          "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+          "requires": {
+            "vscode-jsonrpc": "8.0.2",
+            "vscode-languageserver-types": "3.17.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "defaults": {
     "roslyn": "4.8.0-1.23367.7",
     "omniSharp": "1.39.7",
-    "razor": "7.0.0-preview.23301.2"
+    "razor": "7.0.0-preview.23328.2"
   },
   "main": "./dist/extension",
   "brokeredServices": [
@@ -590,46 +590,43 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/c51fc9fae3f6fa2b1992df6dd16f50d2/razorlanguageserver-win-x64-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/3b7fc7c2f06e48d78bec2125adcc41aa/razorlanguageserver-win-x64-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86_64"
-      ],
-      "integrity": "BE0001FDAEB075CE4F9148308C09CF97E85DB3BCBFBE0C2A3D70987D8D265047"
+      ]
     },
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / x86)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/17ba6e72f65b30a6ddd68dade60343e8/razorlanguageserver-win-x86-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/d1b37bd821529147e7ffec08f98be17c/razorlanguageserver-win-x86-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "x86"
-      ],
-      "integrity": "0B423120E2D59DCB80E2D0C0728CDA89C6F57C34A587317E561BE031896D3A03"
+      ]
     },
     {
       "id": "Razor",
       "description": "Razor Language Server (Windows / ARM64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/0b1fb7614fbe7a9a9cd2c5470c8865fa/razorlanguageserver-win-arm64-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/b2aa92ccbdf03761b6783bf123bfbe22/razorlanguageserver-win-arm64-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "win32"
       ],
       "architectures": [
         "arm64"
-      ],
-      "integrity": "D6252149E17C1A4B7E84814DBFAC0375C5A3854462A3E48D1ED76608311CCECE"
+      ]
     },
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/c22da9d1dbcbf7fd50bd893d845414d7/razorlanguageserver-linux-x64-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/68986857aef04be58efab25ffd338a93/razorlanguageserver-linux-x64-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -639,13 +636,12 @@
       ],
       "binaries": [
         "./rzls"
-      ],
-      "integrity": "793D8848E7DEB4B425443C7432EAB80AA377FB17325FB535083632349C64A8D7"
+      ]
     },
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux ARM64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/6301924acc5020d6545f4573bbb70b88/razorlanguageserver-linux-arm64-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/c74964f4e130b50f9aef47d430c34a97/razorlanguageserver-linux-arm64-7.0.0-preview.23328.2.zipp",
       "installPath": ".razor",
       "platforms": [
         "linux"
@@ -655,13 +651,12 @@
       ],
       "binaries": [
         "./rzls"
-      ],
-      "integrity": "4238ADC8127496554DA12242AB3EB116129A367D94DF9CF85559C973F8A6F61B"
+      ]
     },
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux musl / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/28003bc9d9c7fdfc288dd113be8fe64d/razorlanguageserver-linux-musl-x64-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/c204acfa0fd9d0e06fbcc3aac3ba846e/razorlanguageserver-linux-musl-x64-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "linux-musl"
@@ -671,13 +666,12 @@
       ],
       "binaries": [
         "./rzls"
-      ],
-      "integrity": "62761B4DDDA46636B011BF486D501C3A7128C067D7ED21D61FDB1B9D267CEC63"
+      ]
     },
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux musl ARM64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/4e07791acfef2a373dbe497ab2477d55/razorlanguageserver-linux-musl-arm64-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/7ad5dd2c8780d3e4eaaafb5352a21afa/razorlanguageserver-linux-musl-arm64-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "linux-musl"
@@ -687,13 +681,12 @@
       ],
       "binaries": [
         "./rzls"
-      ],
-      "integrity": "01F5F6F3C20120168EE271CACB9BB9E2E39AD8789CCFB35758A82B85BC0C829C"
+      ]
     },
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS / x64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/814246e6af4cf35db8151d0ee0e82021/razorlanguageserver-osx-x64-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/d7017a3e07d15f057353ab21b8710714/razorlanguageserver-osx-x64-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"
@@ -703,13 +696,12 @@
       ],
       "binaries": [
         "./rzls"
-      ],
-      "integrity": "F9C8B47DF76FE93BFAD400FECD5A811AFC98CFA517F7127AB29ED777290577A0"
+      ]
     },
     {
       "id": "Razor",
       "description": "Razor Language Server (macOS ARM64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/fddc6f7e-083a-44bd-9a8d-200a4146b13b/4be79e180c7421f9234ffdbed655a83c/razorlanguageserver-osx-arm64-7.0.0-preview.23301.2.zip",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/a31700a64049f7c770a525662ef74f3c/razorlanguageserver-osx-arm64-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "darwin"
@@ -719,8 +711,7 @@
       ],
       "binaries": [
         "./rzls"
-      ],
-      "integrity": "9E259438B2485D9AA0D65C9E55247C418FCB045BD2E01FBE5E3A9CBFB430F874"
+      ]
     },
     {
       "id": "RazorOmnisharp",

--- a/package.json
+++ b/package.json
@@ -641,7 +641,7 @@
     {
       "id": "Razor",
       "description": "Razor Language Server (Linux ARM64)",
-      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/c74964f4e130b50f9aef47d430c34a97/razorlanguageserver-linux-arm64-7.0.0-preview.23328.2.zipp",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/51d2bf3c-cb3c-4385-b59f-d4d6c9a96743/c74964f4e130b50f9aef47d430c34a97/razorlanguageserver-linux-arm64-7.0.0-preview.23328.2.zip",
       "installPath": ".razor",
       "platforms": [
         "linux"

--- a/package.json
+++ b/package.json
@@ -718,7 +718,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (Windows / x64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/8d42e62ea4051381c219b3e31bc4eced/razorlanguageserver-win-x64-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "win32"
       ],
@@ -730,7 +730,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (Windows / x86)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/e440c4f3a4a96334fe177513935fa010/razorlanguageserver-win-x86-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "win32"
       ],
@@ -742,7 +742,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (Windows / ARM64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/4ef26e45cf32fe8d51c0e7dd21f1fef6/razorlanguageserver-win-arm64-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "win32"
       ],
@@ -754,7 +754,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (Linux / x64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/6d4e23a3c7cf0465743950a39515a716/razorlanguageserver-linux-x64-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "linux"
       ],
@@ -769,7 +769,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (Linux ARM64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/85deebd44647ebf65724cc291d722283/razorlanguageserver-linux-arm64-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "linux"
       ],
@@ -784,7 +784,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (Linux musl / x64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/4f0caa94ae182785655efb15eafcef23/razorlanguageserver-linux-musl-x64-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "linux-musl"
       ],
@@ -799,7 +799,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (Linux musl ARM64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/0a24828206a6f3b4bc743d058ef88ce7/razorlanguageserver-linux-musl-arm64-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "linux-musl"
       ],
@@ -814,7 +814,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (macOS / x64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/2afcafaf41082989efcc10405abb9314/razorlanguageserver-osx-x64-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "darwin"
       ],
@@ -829,7 +829,7 @@
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (macOS ARM64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/8bf2ed2f00d481a5987e3eb5165afddd/razorlanguageserver-osx-arm64-7.0.0-preview.23363.1.zip",
-      "installPath": ".razor/omnisharp",
+      "installPath": ".razoromnisharp",
       "platforms": [
         "darwin"
       ],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "defaults": {
     "roslyn": "4.8.0-1.23367.7",
     "omniSharp": "1.39.7",
-    "razor": "7.0.0-preview.23328.2"
+    "razor": "7.0.0-preview.23328.2",
+    "razorOmnisharp": "7.0.0-preview.23363.1"
   },
   "main": "./dist/extension",
   "brokeredServices": [

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "http-proxy-agent": "4.0.1",
     "https-proxy-agent": "5.0.0",
     "jsonc-parser": "3.0.0",
+    "microsoft.aspnetcore.razor.vscode": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/0af42abab690d5de903a4a814d6aedc1/microsoft.aspnetcore.razor.vscode-7.0.0-preview.23363.1.tgz",
     "nerdbank-gitversioning": "^3.6.79-alpha",
     "node-machine-id": "1.1.12",
     "ps-list": "7.2.0",
@@ -720,6 +721,132 @@
         "./rzls"
       ],
       "integrity": "9E259438B2485D9AA0D65C9E55247C418FCB045BD2E01FBE5E3A9CBFB430F874"
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (Windows / x64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/8d42e62ea4051381c219b3e31bc4eced/razorlanguageserver-win-x64-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "win32"
+      ],
+      "architectures": [
+        "x86_64"
+      ]
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (Windows / x86)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/e440c4f3a4a96334fe177513935fa010/razorlanguageserver-win-x86-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "win32"
+      ],
+      "architectures": [
+        "x86"
+      ]
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (Windows / ARM64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/4ef26e45cf32fe8d51c0e7dd21f1fef6/razorlanguageserver-win-arm64-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "win32"
+      ],
+      "architectures": [
+        "arm64"
+      ]
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (Linux / x64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/6d4e23a3c7cf0465743950a39515a716/razorlanguageserver-linux-x64-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "linux"
+      ],
+      "architectures": [
+        "x86_64"
+      ],
+      "binaries": [
+        "./rzls"
+      ]
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (Linux ARM64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/85deebd44647ebf65724cc291d722283/razorlanguageserver-linux-arm64-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "linux"
+      ],
+      "architectures": [
+        "arm64"
+      ],
+      "binaries": [
+        "./rzls"
+      ]
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (Linux musl / x64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/4f0caa94ae182785655efb15eafcef23/razorlanguageserver-linux-musl-x64-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "linux-musl"
+      ],
+      "architectures": [
+        "x86_64"
+      ],
+      "binaries": [
+        "./rzls"
+      ]
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (Linux musl ARM64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/0a24828206a6f3b4bc743d058ef88ce7/razorlanguageserver-linux-musl-arm64-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "linux-musl"
+      ],
+      "architectures": [
+        "arm64"
+      ],
+      "binaries": [
+        "./rzls"
+      ]
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (macOS / x64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/2afcafaf41082989efcc10405abb9314/razorlanguageserver-osx-x64-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "darwin"
+      ],
+      "architectures": [
+        "x86_64"
+      ],
+      "binaries": [
+        "./rzls"
+      ]
+    },
+    {
+      "id": "RazorOmnisharp",
+      "description": "Razor Language Server for OmniSharp (macOS ARM64)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/8bf2ed2f00d481a5987e3eb5165afddd/razorlanguageserver-osx-arm64-7.0.0-preview.23363.1.zip",
+      "installPath": ".razor/omnisharp",
+      "platforms": [
+        "darwin"
+      ],
+      "architectures": [
+        "arm64"
+      ],
+      "binaries": [
+        "./rzls"
+      ]
     }
   ],
   "engines": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -255,7 +255,7 @@ export async function activate(
             );
 
             await razorOmnisharpDownloader.DownloadAndInstallRazorOmnisharp(
-                context.extension.packageJSON.defaults.razor
+                context.extension.packageJSON.defaults.razorOmnisharp
             );
             omnisharpRazorPromise = activateRazorExtension(
                 context,

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ import { GlobalBrokeredServiceContainer } from '@microsoft/servicehub-framework'
 import { CSharpExtensionExports, OmnisharpExtensionExports } from './csharpExtensionExports';
 import { csharpDevkitExtensionId, getCSharpDevKit } from './utils/getCSharpDevKit';
 import { BlazorDebugConfigurationProvider } from './razor/src/blazorDebug/blazorDebugConfigurationProvider';
+import { RazorOmnisharpDownloader } from './razor/razorOmnisharpDownloader';
 
 export async function activate(
     context: vscode.ExtensionContext
@@ -126,7 +127,12 @@ export async function activate(
         // Roslyn starts up and registers Razor-specific didOpen/didClose/didChange commands and sends request to Razor
         //     for dynamic file info once project system is ready ->
         // Razor sends didOpen commands to Roslyn for generated docs and responds to request with dynamic file info
-        await activateRazorExtension(context, context.extension.extensionPath, eventStream);
+        await activateRazorExtension(
+            context,
+            context.extension.extensionPath,
+            eventStream,
+            /* useOmnisharpServer */ false
+        );
 
         context.subscriptions.push(optionProvider);
         context.subscriptions.push(
@@ -239,7 +245,24 @@ export async function activate(
         eventStream.subscribe(razorObserver.post);
 
         if (!razorOptions.razorDevMode) {
-            omnisharpRazorPromise = activateRazorExtension(context, context.extension.extensionPath, eventStream);
+            // Download Razor O# server
+            const razorOmnisharpDownloader = new RazorOmnisharpDownloader(
+                networkSettingsProvider,
+                eventStream,
+                context.extension.packageJSON,
+                platformInfo,
+                context.extension.extensionPath
+            );
+
+            await razorOmnisharpDownloader.DownloadAndInstallRazorOmnisharp(
+                context.extension.packageJSON.defaults.razor
+            );
+            omnisharpRazorPromise = activateRazorExtension(
+                context,
+                context.extension.extensionPath,
+                eventStream,
+                /* useOmnisharpServer */ true
+            );
         }
     }
 

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -433,7 +433,7 @@ export class OmniSharpServer {
                 ? razorOptions.razorPluginPath
                 : path.join(
                       this.extensionPath,
-                      '.razor',
+                      '.razor/omnisharp',
                       'OmniSharpPlugin',
                       'Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll'
                   );

--- a/src/omnisharp/server.ts
+++ b/src/omnisharp/server.ts
@@ -433,7 +433,7 @@ export class OmniSharpServer {
                 ? razorOptions.razorPluginPath
                 : path.join(
                       this.extensionPath,
-                      '.razor/omnisharp',
+                      '.razoromnisharp',
                       'OmniSharpPlugin',
                       'Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll'
                   );

--- a/src/razor/razor.ts
+++ b/src/razor/razor.ts
@@ -22,7 +22,7 @@ export async function activateRazorExtension(
         configuredLanguageServerDir.length > 0
             ? configuredLanguageServerDir
             : useOmnisharpServer
-            ? path.join(extensionPath, '.razor/omnisharp')
+            ? path.join(extensionPath, '.razoromnisharp')
             : path.join(extensionPath, '.razor');
 
     if (fs.existsSync(languageServerDir)) {

--- a/src/razor/razorOmnisharpDownloader.ts
+++ b/src/razor/razorOmnisharpDownloader.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PlatformInformation } from '../shared/platform';
+import { PackageInstallation, LogPlatformInfo, InstallationSuccess } from '../omnisharp/loggingEvents';
+import { EventStream } from '../eventStream';
+import { NetworkSettingsProvider } from '../networkSettings';
+import { downloadAndInstallPackages } from '../packageManager/downloadAndInstallPackages';
+import { getRuntimeDependenciesPackages } from '../tools/runtimeDependencyPackageUtils';
+import { getAbsolutePathPackagesToInstall } from '../packageManager/getAbsolutePathPackagesToInstall';
+import { isValidDownload } from '../packageManager/isValidDownload';
+
+export class RazorOmnisharpDownloader {
+    public constructor(
+        private networkSettingsProvider: NetworkSettingsProvider,
+        private eventStream: EventStream,
+        private packageJSON: any,
+        private platformInfo: PlatformInformation,
+        private extensionPath: string
+    ) {}
+
+    public async DownloadAndInstallRazorOmnisharp(version: string): Promise<boolean> {
+        const runtimeDependencies = getRuntimeDependenciesPackages(this.packageJSON);
+        const razorPackages = runtimeDependencies.filter((inputPackage) => inputPackage.id === 'RazorOmnisharp');
+        const packagesToInstall = await getAbsolutePathPackagesToInstall(
+            razorPackages,
+            this.platformInfo,
+            this.extensionPath
+        );
+
+        if (packagesToInstall.length > 0) {
+            this.eventStream.post(new PackageInstallation(`Razor OmniSharp Version = ${version}`));
+            this.eventStream.post(new LogPlatformInfo(this.platformInfo));
+            if (
+                await downloadAndInstallPackages(
+                    packagesToInstall,
+                    this.networkSettingsProvider,
+                    this.eventStream,
+                    isValidDownload
+                )
+            ) {
+                this.eventStream.post(new InstallationSuccess());
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
**Problem:** We have been recently unable to update Razor's language server version in this repo to the newest bits due to incompatibilities between O# and rzls.

**Solution:** This PR enables O# users to utilize older versions of the TS and rzls code, while the normal C# extension can utilize newer versions. The O# rzls bits will only be downloaded at runtime if the user explicitly selects the O# option, so it should hopefully not add too much overhead for the majority of users. We do automatically download the TS O# bits, but that seems unavoidable.

**Follow-up:** In the next few days, I plan to remove `OmnisharpPlugin` from the main branch of the Razor repo entirely. It is unnecessary since we have a separate O# branch in the Razor repo (`release/omnisharp-vscode`) where we can maintain both `OmnisharpPlugin` and an older version of rzls for O# compatibility.