### PR TITLE
Cherry-pick of `Fix '"file" argument must be of type string' error (#5931)`

### DIFF
--- a/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
+++ b/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
@@ -88,18 +88,17 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
     /**
      * Acquires the .NET runtime and any other dependencies required to spawn a particular .NET executable.
      * @param path The path to the entrypoint assembly. Typically a .dll.
-     * @returns The path to the `dotnet` command to use to spawn the process.
      */
-    private async acquireDotNetProcessDependencies(path: string) {
-        const dotnetPath = await this.acquireRuntime();
+    private async acquireDotNetProcessDependencies(path: string): Promise<HostExecutableInformation> {
+        const dotnetInfo = await this.acquireRuntime();
 
         const args = [path];
         // This will install any missing Linux dependencies.
         await vscode.commands.executeCommand('dotnet.ensureDotnetDependencies', {
-            command: dotnetPath,
+            command: dotnetInfo.path,
             arguments: args,
         });
 
-        return dotnetPath;
+        return dotnetInfo;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-csharp/issues/5920 Fixes https://github.com/dotnet/vscode-dotnet-runtime/issues/1007

(and many, many more duplicates)