### PR TITLE
Workaround for 'coreclr' dotnetWorkspaceConfigurationProvider

### DIFF
--- a/src/lsptoolshost/debugger.ts
+++ b/src/lsptoolshost/debugger.ts
@@ -36,23 +36,22 @@ export function registerDebugger(
     });
     context.subscriptions.push(disposable);
 
+    const dotnetWorkspaceConfigurationProvider = new DotnetWorkspaceConfigurationProvider(
+        workspaceInformationProvider,
+        platformInfo,
+        optionProvider,
+        csharpOutputChannel
+    );
+
     // Register ConfigurationProvider
     context.subscriptions.push(
         vscode.debug.registerDebugConfigurationProvider(
             'dotnet',
-            new DotnetConfigurationResolver(workspaceInformationProvider)
+            new DotnetConfigurationResolver(workspaceInformationProvider, dotnetWorkspaceConfigurationProvider)
         )
     );
     context.subscriptions.push(
-        vscode.debug.registerDebugConfigurationProvider(
-            'coreclr',
-            new DotnetWorkspaceConfigurationProvider(
-                workspaceInformationProvider,
-                platformInfo,
-                optionProvider,
-                csharpOutputChannel
-            )
-        )
+        vscode.debug.registerDebugConfigurationProvider('coreclr', dotnetWorkspaceConfigurationProvider)
     );
     context.subscriptions.push(
         vscode.commands.registerCommand('dotnet.generateAssets', async (selectedIndex) =>

--- a/src/shared/dotnetConfigurationProvider.ts
+++ b/src/shared/dotnetConfigurationProvider.ts
@@ -14,6 +14,7 @@ import {
     IDotnetDebugConfigurationService,
     IDotnetDebugConfigurationServiceResult,
 } from '../lsptoolshost/services/IDotnetDebugConfigurationService';
+import { DotnetWorkspaceConfigurationProvider } from './workspaceConfigurationProvider';
 
 // User errors that can be shown to the user.
 class LaunchServiceError extends Error {}
@@ -54,7 +55,10 @@ function resolveWorkspaceFolderToken(projectPath: string, folderPath: string): s
 }
 
 export class DotnetConfigurationResolver implements vscode.DebugConfigurationProvider {
-    constructor(private workspaceDebugInfoProvider: IWorkspaceDebugInformationProvider) {}
+    constructor(
+        private workspaceDebugInfoProvider: IWorkspaceDebugInformationProvider,
+        private dotnetWorkspaceConfigurationProvider: DotnetWorkspaceConfigurationProvider
+    ) {}
 
     //#region vscode.DebugConfigurationProvider
 
@@ -198,5 +202,18 @@ export class DotnetConfigurationResolver implements vscode.DebugConfigurationPro
             }
         }
         throw new Error(`Unable to determine debug settings for project '${projectPath}'`);
+    }
+
+    // Workaround for VS Code not calling into the 'coreclr' resolveDebugConfigurationWithSubstitutedVariables
+    async resolveDebugConfigurationWithSubstitutedVariables(
+        folder: vscode.WorkspaceFolder | undefined,
+        debugConfiguration: vscode.DebugConfiguration,
+        token?: vscode.CancellationToken
+    ): Promise<vscode.DebugConfiguration | null | undefined> {
+        return this.dotnetWorkspaceConfigurationProvider.resolveDebugConfigurationWithSubstitutedVariables(
+            folder,
+            debugConfiguration,
+            token
+        );
     }
 }


### PR DESCRIPTION
VS Code handles resolveDebugConfiguration for converting the 'dotnet' type to 'coreclr'. However, it will call resolveDebugConfigurationWithSubstitutedVariables on the 'dotnet' type and never call the 'coreclr' one.

This workaround will take the 'coreclr' dotnetWorkspaceConfigurationProvider in the 'dotnet' ConfigurationProvider and just call into it as a workaround.

See https://github.com/microsoft/vscode/issues/188979