### PR TITLE
Download Razor before start OmniSharp

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -225,6 +225,24 @@ export async function activate(
             eventStream.subscribe(omnisharpDebugModeLoggerObserver.post);
         }
 
+        const razorObserver = new RazorLoggerObserver(csharpChannel);
+        eventStream.subscribe(razorObserver.post);
+
+        if (!razorOptions.razorDevMode) {
+            // Download Razor O# server
+            const razorOmnisharpDownloader = new RazorOmnisharpDownloader(
+                networkSettingsProvider,
+                eventStream,
+                context.extension.packageJSON,
+                platformInfo,
+                context.extension.extensionPath
+            );
+
+            await razorOmnisharpDownloader.DownloadAndInstallRazorOmnisharp(
+                context.extension.packageJSON.defaults.razorOmnisharp
+            );
+        }
+
         // activate language services
         omnisharpLangServicePromise = OmniSharp.activate(
             context,
@@ -250,22 +268,7 @@ export async function activate(
             })
         );
 
-        const razorObserver = new RazorLoggerObserver(csharpChannel);
-        eventStream.subscribe(razorObserver.post);
-
         if (!razorOptions.razorDevMode) {
-            // Download Razor O# server
-            const razorOmnisharpDownloader = new RazorOmnisharpDownloader(
-                networkSettingsProvider,
-                eventStream,
-                context.extension.packageJSON,
-                platformInfo,
-                context.extension.extensionPath
-            );
-
-            await razorOmnisharpDownloader.DownloadAndInstallRazorOmnisharp(
-                context.extension.packageJSON.defaults.razorOmnisharp
-            );
             omnisharpRazorPromise = activateRazorExtension(
                 context,
                 context.extension.extensionPath,


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1864007

Now that Razor is back to being a runtime dependency, we were failing to load on a clean machine because we were initializing OmniSharp, and telling it about the Razor OmniSharpPlugin.dll, before we had even started trying to download it. This change frontloads that download, and waits for it to finish before activating O#.

Worth noting, if we don't take this PR then whilst the first run of VS Code is broken for Razor, subsequent runs (or window reloads) work fine. The Razor download is currently sitting at 70mb. I leave it up to you to decide if the current behavior is a bug, or by design :)