### PR TITLE
Respect the newly added Background analysis scope option in OmniSharp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1252,11 +1252,6 @@
             "default": false,
             "description": "If true, MSBuild project system will only load projects for files that were opened in the editor. This setting is useful for big C# codebases and allows for faster initialization of code navigation features only for projects that are relevant to code that is being edited. With this setting enabled OmniSharp may load fewer projects and may thus display incomplete reference lists for symbols."
           },
-          "omnisharp.enableRoslynAnalyzers": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enables support for roslyn analyzers, code fixes and rulesets."
-          },
           "omnisharp.enableEditorConfigSupport": {
             "type": "boolean",
             "default": true,
@@ -1282,11 +1277,6 @@
             "type": "boolean",
             "default": false,
             "description": "(EXPERIMENTAL) Enables support for resolving completion edits asynchronously. This can speed up time to show the completion list, particularly override and partial method completion lists, at the cost of slight delays after inserting a completion item. Most completion items will have no noticeable impact with this feature, but typing immediately after inserting an override or partial method completion, before the insert is completed, can have unpredictable results."
-          },
-          "omnisharp.analyzeOpenDocumentsOnly": {
-            "type": "boolean",
-            "default": false,
-            "description": "Only run analyzers against open files when 'enableRoslynAnalyzers' is true"
           },
           "omnisharp.testRunSettings": {
             "type": "string",

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -135,14 +135,16 @@ class OmniSharpDiagnosticsProvider extends AbstractSupport {
     ) {
         super(server, languageMiddlewareFeature);
 
+        const analyzersEnabledLegacyOption = vscode.workspace.getConfiguration('omnisharp').get('enableRoslynAnalyzers', false);
         const useOmnisharpServer = vscode.workspace.getConfiguration('dotnet').get('server.useOmnisharp', false);
-        this._analyzersEnabled =
+        const analyzersEnabledNewOption =
             vscode.workspace
                 .getConfiguration('dotnet')
                 .get<string>(
                     'backgroundAnalysis.analyzerDiagnosticsScope',
                     useOmnisharpServer ? 'none' : 'openFiles'
                 ) != 'none';
+        this._analyzersEnabled = analyzersEnabledLegacyOption || analyzersEnabledNewOption;
         this._validationAdvisor = validationAdvisor;
         this._diagnostics = vscode.languages.createDiagnosticCollection('csharp');
         this._suppressHiddenDiagnostics = vscode.workspace

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -135,7 +135,9 @@ class OmniSharpDiagnosticsProvider extends AbstractSupport {
     ) {
         super(server, languageMiddlewareFeature);
 
-        const analyzersEnabledLegacyOption = vscode.workspace.getConfiguration('omnisharp').get('enableRoslynAnalyzers', false);
+        const analyzersEnabledLegacyOption = vscode.workspace
+            .getConfiguration('omnisharp')
+            .get('enableRoslynAnalyzers', false);
         const useOmnisharpServer = vscode.workspace.getConfiguration('dotnet').get('server.useOmnisharp', false);
         const analyzersEnabledNewOption =
             vscode.workspace

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -135,7 +135,11 @@ class OmniSharpDiagnosticsProvider extends AbstractSupport {
     ) {
         super(server, languageMiddlewareFeature);
 
-        this._analyzersEnabled = vscode.workspace.getConfiguration('omnisharp').get('enableRoslynAnalyzers', false);
+        const scopeOption = vscode.workspace
+            .getConfiguration('dotnet')
+            .get<string>('backgroundAnalysis.analyzerDiagnosticsScope', 'openFiles');
+        this._analyzersEnabled =
+            vscode.workspace.getConfiguration('omnisharp').get('enableRoslynAnalyzers', false) && scopeOption != 'none';
         this._validationAdvisor = validationAdvisor;
         this._diagnostics = vscode.languages.createDiagnosticCollection('csharp');
         this._suppressHiddenDiagnostics = vscode.workspace

--- a/src/features/diagnosticsProvider.ts
+++ b/src/features/diagnosticsProvider.ts
@@ -135,11 +135,14 @@ class OmniSharpDiagnosticsProvider extends AbstractSupport {
     ) {
         super(server, languageMiddlewareFeature);
 
-        const scopeOption = vscode.workspace
-            .getConfiguration('dotnet')
-            .get<string>('backgroundAnalysis.analyzerDiagnosticsScope', 'openFiles');
+        const useOmnisharpServer = vscode.workspace.getConfiguration('dotnet').get('server.useOmnisharp', false);
         this._analyzersEnabled =
-            vscode.workspace.getConfiguration('omnisharp').get('enableRoslynAnalyzers', false) && scopeOption != 'none';
+            vscode.workspace
+                .getConfiguration('dotnet')
+                .get<string>(
+                    'backgroundAnalysis.analyzerDiagnosticsScope',
+                    useOmnisharpServer ? 'none' : 'openFiles'
+                ) != 'none';
         this._validationAdvisor = validationAdvisor;
         this._diagnostics = vscode.languages.createDiagnosticCollection('csharp');
         this._suppressHiddenDiagnostics = vscode.workspace

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -122,11 +122,9 @@ export class Options {
         const diagnosticAnalysisScope = Options.readOption<string>(
             config,
             'dotnet.backgroundAnalysis.analyzerDiagnosticsScope',
-            'openFiles'
+            useOmnisharpServer ? 'none' : 'openFiles'
         );
-        const enableRoslynAnalyzers =
-            Options.readOption<boolean>(config, 'omnisharp.enableRoslynAnalyzers', false) &&
-            diagnosticAnalysisScope != 'none';
+        const enableRoslynAnalyzers = diagnosticAnalysisScope != 'none';
         const enableEditorConfigSupport = Options.readOption<boolean>(
             config,
             'omnisharp.enableEditorConfigSupport',
@@ -145,9 +143,7 @@ export class Options {
             'omnisharp.enableImportCompletion'
         );
         const enableAsyncCompletion = Options.readOption<boolean>(config, 'omnisharp.enableAsyncCompletion', false);
-        const analyzeOpenDocumentsOnly =
-            Options.readOption<boolean>(config, 'omnisharp.analyzeOpenDocumentsOnly', false) ||
-            diagnosticAnalysisScope == 'openFiles';
+        const analyzeOpenDocumentsOnly = diagnosticAnalysisScope == 'openFiles';
         const organizeImportsOnFormat = Options.readOption<boolean>(config, 'omnisharp.organizeImportsOnFormat', false);
         const disableMSBuildDiagnosticWarning = Options.readOption<boolean>(
             config,

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -119,12 +119,14 @@ export class Options {
             'omnisharp.useEditorFormattingSettings',
             true
         );
+        const enableRoslynAnalyzersLegacyOption = Options.readOption<boolean>(config, 'omnisharp.enableRoslynAnalyzers', false);
         const diagnosticAnalysisScope = Options.readOption<string>(
             config,
             'dotnet.backgroundAnalysis.analyzerDiagnosticsScope',
             useOmnisharpServer ? 'none' : 'openFiles'
         );
-        const enableRoslynAnalyzers = diagnosticAnalysisScope != 'none';
+        const enableRoslynAnalyzersNewOption = diagnosticAnalysisScope != 'none';
+        const enableRoslynAnalyzers = enableRoslynAnalyzersLegacyOption || enableRoslynAnalyzersNewOption;
         const enableEditorConfigSupport = Options.readOption<boolean>(
             config,
             'omnisharp.enableEditorConfigSupport',
@@ -143,7 +145,13 @@ export class Options {
             'omnisharp.enableImportCompletion'
         );
         const enableAsyncCompletion = Options.readOption<boolean>(config, 'omnisharp.enableAsyncCompletion', false);
-        const analyzeOpenDocumentsOnly = diagnosticAnalysisScope == 'openFiles';
+        const analyzeOpenDocumentsOnlyLegacyOption = Options.readOption<boolean>(
+            config,
+            'omnisharp.analyzeOpenDocumentsOnly',
+            false
+        );
+        const analyzeOpenDocumentsOnlyNewOption = diagnosticAnalysisScope == 'openFiles';
+        const analyzeOpenDocumentsOnly = analyzeOpenDocumentsOnlyLegacyOption || analyzeOpenDocumentsOnlyNewOption;
         const organizeImportsOnFormat = Options.readOption<boolean>(config, 'omnisharp.organizeImportsOnFormat', false);
         const disableMSBuildDiagnosticWarning = Options.readOption<boolean>(
             config,

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -119,7 +119,14 @@ export class Options {
             'omnisharp.useEditorFormattingSettings',
             true
         );
-        const enableRoslynAnalyzers = Options.readOption<boolean>(config, 'omnisharp.enableRoslynAnalyzers', false);
+        const diagnosticAnalysisScope = Options.readOption<string>(
+            config,
+            'dotnet.backgroundAnalysis.analyzerDiagnosticsScope',
+            'openFiles'
+        );
+        const enableRoslynAnalyzers =
+            Options.readOption<boolean>(config, 'omnisharp.enableRoslynAnalyzers', false) &&
+            diagnosticAnalysisScope != 'none';
         const enableEditorConfigSupport = Options.readOption<boolean>(
             config,
             'omnisharp.enableEditorConfigSupport',
@@ -138,11 +145,9 @@ export class Options {
             'omnisharp.enableImportCompletion'
         );
         const enableAsyncCompletion = Options.readOption<boolean>(config, 'omnisharp.enableAsyncCompletion', false);
-        const analyzeOpenDocumentsOnly = Options.readOption<boolean>(
-            config,
-            'omnisharp.analyzeOpenDocumentsOnly',
-            false
-        );
+        const analyzeOpenDocumentsOnly =
+            Options.readOption<boolean>(config, 'omnisharp.analyzeOpenDocumentsOnly', false) ||
+            diagnosticAnalysisScope == 'openFiles';
         const organizeImportsOnFormat = Options.readOption<boolean>(config, 'omnisharp.organizeImportsOnFormat', false);
         const disableMSBuildDiagnosticWarning = Options.readOption<boolean>(
             config,

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -119,7 +119,11 @@ export class Options {
             'omnisharp.useEditorFormattingSettings',
             true
         );
-        const enableRoslynAnalyzersLegacyOption = Options.readOption<boolean>(config, 'omnisharp.enableRoslynAnalyzers', false);
+        const enableRoslynAnalyzersLegacyOption = Options.readOption<boolean>(
+            config,
+            'omnisharp.enableRoslynAnalyzers',
+            false
+        );
         const diagnosticAnalysisScope = Options.readOption<string>(
             config,
             'dotnet.backgroundAnalysis.analyzerDiagnosticsScope',

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -37,7 +37,7 @@ suite('Options tests', () => {
         options.omnisharpOptions.enableDecompilationSupport.should.equal(false);
         options.omnisharpOptions.enableImportCompletion.should.equal(false);
         options.omnisharpOptions.enableAsyncCompletion.should.equal(false);
-        options.omnisharpOptions.analyzeOpenDocumentsOnly.should.equal(true);
+        options.omnisharpOptions.analyzeOpenDocumentsOnly.should.equal(false);
         options.omnisharpOptions.testRunSettings.should.equal('');
     });
 

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -32,7 +32,7 @@ suite('Options tests', () => {
         options.omnisharpOptions.minFindSymbolsFilterLength.should.equal(0);
         options.omnisharpOptions.maxFindSymbolsItems.should.equal(1000);
         options.omnisharpOptions.enableMsBuildLoadProjectsOnDemand.should.equal(false);
-        options.omnisharpOptions.enableRoslynAnalyzers.should.equal(false);
+        options.omnisharpOptions.enableRoslynAnalyzers.should.equal(true);
         options.omnisharpOptions.enableEditorConfigSupport.should.equal(true);
         options.omnisharpOptions.enableDecompilationSupport.should.equal(false);
         options.omnisharpOptions.enableImportCompletion.should.equal(false);

--- a/test/unitTests/options.test.ts
+++ b/test/unitTests/options.test.ts
@@ -37,7 +37,7 @@ suite('Options tests', () => {
         options.omnisharpOptions.enableDecompilationSupport.should.equal(false);
         options.omnisharpOptions.enableImportCompletion.should.equal(false);
         options.omnisharpOptions.enableAsyncCompletion.should.equal(false);
-        options.omnisharpOptions.analyzeOpenDocumentsOnly.should.equal(false);
+        options.omnisharpOptions.analyzeOpenDocumentsOnly.should.equal(true);
         options.omnisharpOptions.testRunSettings.should.equal('');
     });
 


### PR DESCRIPTION
Closes #5998

This ensures that the Background analysis scope option becomes the source of truth for both C# extension and OmniSharp. We should drive the users to use the below two options even when OmniSharp server is enabled. They are the replacement for the existing options `Enable support for roslyn analyzers, code fixes and rulesets` and `Analyze open documents only` and enable configuring these separately for compiler and analyzer diagnostics.

![image](https://github.com/dotnet/vscode-csharp/assets/10605811/08f8ca25-4274-4d88-a203-86c780ba153e)

![image](https://github.com/dotnet/vscode-csharp/assets/10605811/c3dc63ae-4482-4cbc-bf94-8276407f9254)

NOTE: I ran into https://github.com/dotnet/vscode-csharp/issues/6057 quite often while playing around with this space, I'll send a separate Roslyn PR for fixing that issue.
