### PR TITLE
Auto publish artifacts when build pipeline succeed

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -68,13 +68,13 @@ jobs:
 
       $additionalPublishArgs = , "publish"
       # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
-      If (("${{ parameters.branch }}" -eq "prerelease") -or ("$(resources.pipeline.CI.sourceBranch)" -eq "refs/heads/prerelease")) {
+      If (("${{ parameters.branch }}" -eq "prerelease") -or ("$(resources.pipeline.releaseCI.sourceBranch)" -eq "refs/heads/prerelease")) {
         $additionalPublishArgs += "--pre-release"
         Write-Host "Publish to pre-release channel."
-      } ElseIf (("${{ parameters.branch }}" -eq "release") -or ("$(resources.pipeline.CI.sourceBranch)" -eq "refs/heads/release")) {
+      } ElseIf (("${{ parameters.branch }}" -eq "release") -or ("$(resources.pipeline.releaseCI.sourceBranch)" -eq "refs/heads/release")) {
         Write-Host "Publish to release channel."
       } Else {
-        throw "Unexpected branch name: ${{ parameters.branch }} or $(resources.pipeline.CI.sourceBranch)."
+        throw "Unexpected branch name: ${{ parameters.branch }} or $(resources.pipeline.releaseCI.sourceBranch)."
       }
       $additionalPublishArgs += '--packagePath'
 

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -52,51 +52,77 @@ jobs:
         branchName: '$(resources.pipeline.releaseCI.sourceBranch)'
   - ${{ else }}:
     - pwsh: |
-        Write-Host "##vso[task.logissue type=error]Release should only be triggered by build pipeline or manually run." ; Exit 1
+        Write-Host "##vso[task.logissue type=error]Release should only be triggered by build pipeline or manually run."; Exit 1
   - pwsh: |
       npm install --global vsce
     displayName: 'Install vsce'
   - pwsh: |
-      # Our build pipeline would generated build based on attempt number. Publishing the latest attempt.
-      $allArtifacts = Get-ChildItem -Path "VSIXs - Attempt*" | Sort-Object -Descending
-      if ($allArtifacts.Length -eq 0) {
-        throw "No Artifacts is downloaded."
-      }
+      function Publish-To-Marketplace() {
+        param(
+          [bool]$PublishToPreRelease,
+          [bool]$Test
+        )
+        # Our build pipeline would generated build based on attempt number. Publishing the latest attempt.
+        $allArtifacts = Get-ChildItem -Path "VSIXs - Attempt*" | Sort-Object -Descending
+        if ($allArtifacts.Length -eq 0) {
+          throw "No Artifacts is downloaded."
+        }
 
-      $publishArtifacts = $allArtifacts[0]
-      Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
+        $publishArtifacts = $allArtifacts[0]
+        Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
 
-      $additionalPublishArgs = , "publish"
-      # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
-      If (("${{ parameters.branch }}" -eq "prerelease") -or ("$(resources.pipeline.releaseCI.sourceBranch)" -eq "refs/heads/prerelease")) {
-        $additionalPublishArgs += "--pre-release"
-        Write-Host "Publish to pre-release channel."
-      } ElseIf (("${{ parameters.branch }}" -eq "release") -or ("$(resources.pipeline.releaseCI.sourceBranch)" -eq "refs/heads/release")) {
-        Write-Host "Publish to release channel."
-      } Else {
-        throw "Unexpected branch name: ${{ parameters.branch }} or $(resources.pipeline.releaseCI.sourceBranch)."
-      }
-      $additionalPublishArgs += '--packagePath'
+        $additionalPublishArgs = , "publish"
+        # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
 
-      $platforms = "arm64", "x64", "ia32"
-      $allVsixs = Get-ChildItem $publishArtifacts *.vsix
-      foreach ($vsix in $allVsixs) {
-        foreach ($plat in $platforms) {
-          if ($vsix.Name.Contains($plat)) {
-              $additionalPublishArgs += $vsix
+        If($PublishToPreRelease)  {
+          $additionalPublishArgs += "--pre-release"
+          Write-Host "Publish to pre-release channel."
+        } Else {
+          Write-Host "Publish to release channel."
+        }
+
+        $additionalPublishArgs += '--packagePath'
+
+        $platforms = "arm64", "x64", "ia32"
+        $allVsixs = Get-ChildItem $publishArtifacts *.vsix
+        foreach ($vsix in $allVsixs) {
+          foreach ($plat in $platforms) {
+            if ($vsix.Name.Contains($plat)) {
+                $additionalPublishArgs += $vsix
+            }
           }
+        }
+
+        Write-Host "Command run is: vsce $($additionalPublishArgs)."
+        If ($Test) {
+          Write-Host "In test mode, command is printed instead of run."
+          Write-Host "🔒 Verify PAT."
+          vsce verify-pat ms-dotnettools
+        }
+        Else {
+          vsce @additionalPublishArgs
         }
       }
 
-      Write-Host "Command run is: vsce $($additionalPublishArgs)."
-      If (("${{ parameters.test }}" -eq "true") -and ("$(Build.Reason)" -eq 'Manual')) {
-        Write-Host "In test mode, command is printed instead of run."
-        Write-Host "🔒 Verify PAT."
-        vsce verify-pat ms-dotnettools
+      $isInTestMode = ("$(Build.Reason)" -eq "Manual") -and "${{ parameters.test }}";
+      $prereleaseArtifacts
+      if (("$(Build.Reason)" -eq "Manual") -and ("${{ parameters.branch }}" -eq "prerelease")) {
+        $prereleaseArtifacts = $true;
+      } elseif (("$(Build.Reason)" -eq "Manual") -and ("${{ parameters.branch }}" -eq "release")) {
+        $prereleaseArtifacts = $false;
       }
-      Else {
-        vsce @additionalPublishArgs
+      elseif (("$(Build.Reason)" -eq "ResourceTrigger") -and ("$(resources.pipeline.releaseCI.sourceBranch)" -eq "refs/heads/prerelease")) {
+        $prereleaseArtifacts = $true;
       }
+      elseif (("$(Build.Reason)" -eq "ResourceTrigger") -and ("$(resources.pipeline.releaseCI.sourceBranch)" -eq "refs/heads/release")) {
+        $prereleaseArtifacts = $false;
+      }
+      else {
+        Write-Host "##vso[task.logissue type=error] Unexpected $(Build.Reason), ${{ parameters.branch }} and $(resources.pipeline.releaseCI.sourceBranch).";
+        Exit 1
+      }
+
+      Publish-To-Marketplace -PublishToPreRelease $prereleaseArtifacts -Test $isInTestMode;
     displayName: 🚀 Publish to Marketplace
     workingDirectory: $(Pipeline.Workspace)
     env:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -1,6 +1,16 @@
 trigger: none
 pr: none
 
+resources:
+  pipelines:
+    - pipeline: releaseCI
+      source: dotnet-vscode-csharp
+      trigger:
+        branches:
+          include:
+            - prerelease
+            - release
+
 parameters:
   - name: test
     type: boolean
@@ -22,58 +32,62 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - task: DownloadPipelineArtifact@2
-    displayName: '📦 Download artifacts from build pipeline.'
+    displayName: '[Manual release]📦 Download artifacts from build pipeline. .'
+    condition: eq(variables['Build.Reason'], 'Manual')
     inputs:
       buildType: 'specific'
       project: 'internal'
       definition: 1264
       buildVersionToDownload: 'latestFromBranch'
       branchName: 'refs/heads/${{ parameters.branch }}'
+  - download: releaseCI
+    displayName: '[Auto release]📦 Download artifacts from build pipeline..'
+    condition: eq(variables['Build.Reason'], 'ResourceTrigger')
   - pwsh: |
       npm install --global vsce
     displayName: 'Install vsce'
-  - pwsh: |
-      # Our build pipeline would generated build based on attempt number. Publishing the latest attempt.
-      $allArtifacts = Get-ChildItem -Path "VSIXs - Attempt*" | Sort-Object -Descending
-      if ($allArtifacts.Length -eq 0) {
-        throw "No Artifacts is downloaded."
-      }
+  # - pwsh: |
+  #     # Our build pipeline would generated build based on attempt number. Publishing the latest attempt.
+  #     $allArtifacts = Get-ChildItem -Path "VSIXs - Attempt*" | Sort-Object -Descending
+  #     if ($allArtifacts.Length -eq 0) {
+  #       throw "No Artifacts is downloaded."
+  #     }
 
-      $publishArtifacts = $allArtifacts[0]
-      Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
+  #     $publishArtifacts = $allArtifacts[0]
+  #     Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
 
-      $additionalPublishArgs = , "publish"
-      # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
-      If ("${{ parameters.branch }}" -eq "prerelease") {
-        $additionalPublishArgs += "--pre-release"
-        Write-Host "Publish to pre-release channel."
-      } ElseIf ("${{ parameters.branch }}" -eq "release") {
-        Write-Host "Publish to release channel."
-      } Else {
-        throw "Unexpected branch name: ${{ parameters.branch }}."
-      }
-      $additionalPublishArgs += '--packagePath'
+  #     $additionalPublishArgs = , "publish"
+  #     # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+  #     If ("${{ parameters.branch }}" -eq "prerelease") {
+  #       $additionalPublishArgs += "--pre-release"
+  #       Write-Host "Publish to pre-release channel."
+  #     } ElseIf ("${{ parameters.branch }}" -eq "release") {
+  #       Write-Host "Publish to release channel."
+  #     } Else {
+  #       throw "Unexpected branch name: ${{ parameters.branch }}."
+  #     }
+  #     $additionalPublishArgs += '--packagePath'
 
-      $platforms = "arm64", "x64", "ia32"
-      $allVsixs = Get-ChildItem $publishArtifacts *.vsix
-      foreach ($vsix in $allVsixs) {
-        foreach ($plat in $platforms) {
-          if ($vsix.Name.Contains($plat)) {
-              $additionalPublishArgs += $vsix
-          }
-        }
-      }
+  #     $platforms = "arm64", "x64", "ia32"
+  #     $allVsixs = Get-ChildItem $publishArtifacts *.vsix
+  #     foreach ($vsix in $allVsixs) {
+  #       foreach ($plat in $platforms) {
+  #         if ($vsix.Name.Contains($plat)) {
+  #             $additionalPublishArgs += $vsix
+  #         }
+  #       }
+  #     }
 
-      Write-Host "Command run is: vsce $($additionalPublishArgs)."
-      If ("${{ parameters.test }}" -eq "true") {
-        Write-Host "In test mode, command is printed instead of run."
-        Write-Host "🔒 Verify PAT."
-        vsce verify-pat ms-dotnettools
-      }
-      Else {
-        vsce @additionalPublishArgs
-      }
-    displayName: 🚀 Publish to Marketplace
-    workingDirectory: $(Pipeline.Workspace)
-    env:
-      VSCE_PAT: $(VSCodeMarketplacePAT)
+  #     Write-Host "Command run is: vsce $($additionalPublishArgs)."
+  #     If ("${{ parameters.test }}" -eq "true") {
+  #       Write-Host "In test mode, command is printed instead of run."
+  #       Write-Host "🔒 Verify PAT."
+  #       vsce verify-pat ms-dotnettools
+  #     }
+  #     Else {
+  #       vsce @additionalPublishArgs
+  #     }
+  #   displayName: 🚀 Publish to Marketplace
+  #   workingDirectory: $(Pipeline.Workspace)
+  #   env:
+  #     VSCE_PAT: $(VSCodeMarketplacePAT)

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -11,6 +11,7 @@ resources:
             - prerelease
             - release
 
+# Only used when manually run
 parameters:
   - name: test
     type: boolean
@@ -48,53 +49,54 @@ jobs:
         project: 'internal'
         definition: 1264
         buildVersionToDownload: 'latestFromBranch'
-        branchName: 'refs/heads/$(resources.pipeline.releaseCI.sourceBranch)'
+        branchName: '$(resources.pipeline.releaseCI.sourceBranch)'
   - ${{ else }}:
     - pwsh: |
         Write-Host "##vso[task.logissue type=error]Release should only be triggered by build pipeline or manually run." ; Exit 1
   - pwsh: |
       npm install --global vsce
+    displayName: 'Install vsce'
   - pwsh: |
-      # # Our build pipeline would generated build based on attempt number. Publishing the latest attempt.
-      # $allArtifacts = Get-ChildItem -Path "VSIXs - Attempt*" | Sort-Object -Descending
-      # if ($allArtifacts.Length -eq 0) {
-      #   throw "No Artifacts is downloaded."
-      # }
+      # Our build pipeline would generated build based on attempt number. Publishing the latest attempt.
+      $allArtifacts = Get-ChildItem -Path "VSIXs - Attempt*" | Sort-Object -Descending
+      if ($allArtifacts.Length -eq 0) {
+        throw "No Artifacts is downloaded."
+      }
 
-      # $publishArtifacts = $allArtifacts[0]
-      # Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
+      $publishArtifacts = $allArtifacts[0]
+      Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
 
-      # $additionalPublishArgs = , "publish"
-      # # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
-      # If ("${{ parameters.branch }}" -eq "prerelease") {
-      #   $additionalPublishArgs += "--pre-release"
-      #   Write-Host "Publish to pre-release channel."
-      # } ElseIf ("${{ parameters.branch }}" -eq "release") {
-      #   Write-Host "Publish to release channel."
-      # } Else {
-      #   throw "Unexpected branch name: ${{ parameters.branch }}."
-      # }
-      # $additionalPublishArgs += '--packagePath'
+      $additionalPublishArgs = , "publish"
+      # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+      If (("${{ parameters.branch }}" -eq "prerelease") -or ("$(resources.pipeline.CI.sourceBranch)" -eq "refs/heads/prerelease")) {
+        $additionalPublishArgs += "--pre-release"
+        Write-Host "Publish to pre-release channel."
+      } ElseIf (("${{ parameters.branch }}" -eq "release") -or ("$(resources.pipeline.CI.sourceBranch)" -eq "refs/heads/release")) {
+        Write-Host "Publish to release channel."
+      } Else {
+        throw "Unexpected branch name: ${{ parameters.branch }} or $(resources.pipeline.CI.sourceBranch)."
+      }
+      $additionalPublishArgs += '--packagePath'
 
-      # $platforms = "arm64", "x64", "ia32"
-      # $allVsixs = Get-ChildItem $publishArtifacts *.vsix
-      # foreach ($vsix in $allVsixs) {
-      #   foreach ($plat in $platforms) {
-      #     if ($vsix.Name.Contains($plat)) {
-      #         $additionalPublishArgs += $vsix
-      #     }
-      #   }
-      # }
+      $platforms = "arm64", "x64", "ia32"
+      $allVsixs = Get-ChildItem $publishArtifacts *.vsix
+      foreach ($vsix in $allVsixs) {
+        foreach ($plat in $platforms) {
+          if ($vsix.Name.Contains($plat)) {
+              $additionalPublishArgs += $vsix
+          }
+        }
+      }
 
-      # Write-Host "Command run is: vsce $($additionalPublishArgs)."
-      # If ("${{ parameters.test }}" -eq "true") {
-      #   Write-Host "In test mode, command is printed instead of run."
-      #   Write-Host "🔒 Verify PAT."
-      #   vsce verify-pat ms-dotnettools
-      # }
-      # Else {
-      #   vsce @additionalPublishArgs
-      # }
+      Write-Host "Command run is: vsce $($additionalPublishArgs)."
+      If (("${{ parameters.test }}" -eq "true") -and ("$(Build.Reason)" -eq 'Manual')) {
+        Write-Host "In test mode, command is printed instead of run."
+        Write-Host "🔒 Verify PAT."
+        vsce verify-pat ms-dotnettools
+      }
+      Else {
+        vsce @additionalPublishArgs
+      }
     displayName: 🚀 Publish to Marketplace
     workingDirectory: $(Pipeline.Workspace)
     env:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -31,63 +31,71 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   steps:
-  - task: DownloadPipelineArtifact@2
-    displayName: '[Manual release]📦 Download artifacts from build pipeline. .'
-    condition: eq(variables['Build.Reason'], 'Manual')
-    inputs:
-      buildType: 'specific'
-      project: 'internal'
-      definition: 1264
-      buildVersionToDownload: 'latestFromBranch'
-      branchName: 'refs/heads/${{ parameters.branch }}'
-  - download: releaseCI
-    displayName: '[Auto release]📦 Download artifacts from build pipeline..'
-    condition: eq(variables['Build.Reason'], 'ResourceTrigger')
+  - ${{ if eq(variables['Build.Reason'], 'Manual') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: '[Manual release]📦 Download artifacts from build pipeline. .'
+      inputs:
+        buildType: 'specific'
+        project: 'internal'
+        definition: 1264
+        buildVersionToDownload: 'latestFromBranch'
+        branchName: 'refs/heads/${{ parameters.branch }}'
+  - ${{ elseif eq(variables['Build.Reason'], 'ResourceTrigger') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: '[Auto release]📦 Download artifacts from build pipeline. .'
+      inputs:
+        buildType: 'specific'
+        project: 'internal'
+        definition: 1264
+        buildVersionToDownload: 'latestFromBranch'
+        branchName: 'refs/heads/$(resources.pipeline.releaseCI.sourceBranch)'
+  - ${{ else }}:
+    - pwsh: |
+        Write-Host "##vso[task.logissue type=error]Release should only be triggered by build pipeline or manually run." ; Exit 1
   - pwsh: |
       npm install --global vsce
-    displayName: 'Install vsce'
-  # - pwsh: |
-  #     # Our build pipeline would generated build based on attempt number. Publishing the latest attempt.
-  #     $allArtifacts = Get-ChildItem -Path "VSIXs - Attempt*" | Sort-Object -Descending
-  #     if ($allArtifacts.Length -eq 0) {
-  #       throw "No Artifacts is downloaded."
-  #     }
+  - pwsh: |
+      # # Our build pipeline would generated build based on attempt number. Publishing the latest attempt.
+      # $allArtifacts = Get-ChildItem -Path "VSIXs - Attempt*" | Sort-Object -Descending
+      # if ($allArtifacts.Length -eq 0) {
+      #   throw "No Artifacts is downloaded."
+      # }
 
-  #     $publishArtifacts = $allArtifacts[0]
-  #     Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
+      # $publishArtifacts = $allArtifacts[0]
+      # Write-Host "All artifacts: $($allArtifacts). Publishing $($publishArtifacts)."
 
-  #     $additionalPublishArgs = , "publish"
-  #     # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
-  #     If ("${{ parameters.branch }}" -eq "prerelease") {
-  #       $additionalPublishArgs += "--pre-release"
-  #       Write-Host "Publish to pre-release channel."
-  #     } ElseIf ("${{ parameters.branch }}" -eq "release") {
-  #       Write-Host "Publish to release channel."
-  #     } Else {
-  #       throw "Unexpected branch name: ${{ parameters.branch }}."
-  #     }
-  #     $additionalPublishArgs += '--packagePath'
+      # $additionalPublishArgs = , "publish"
+      # # Artifacts are published to either pre-release or release based on the build branch, https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+      # If ("${{ parameters.branch }}" -eq "prerelease") {
+      #   $additionalPublishArgs += "--pre-release"
+      #   Write-Host "Publish to pre-release channel."
+      # } ElseIf ("${{ parameters.branch }}" -eq "release") {
+      #   Write-Host "Publish to release channel."
+      # } Else {
+      #   throw "Unexpected branch name: ${{ parameters.branch }}."
+      # }
+      # $additionalPublishArgs += '--packagePath'
 
-  #     $platforms = "arm64", "x64", "ia32"
-  #     $allVsixs = Get-ChildItem $publishArtifacts *.vsix
-  #     foreach ($vsix in $allVsixs) {
-  #       foreach ($plat in $platforms) {
-  #         if ($vsix.Name.Contains($plat)) {
-  #             $additionalPublishArgs += $vsix
-  #         }
-  #       }
-  #     }
+      # $platforms = "arm64", "x64", "ia32"
+      # $allVsixs = Get-ChildItem $publishArtifacts *.vsix
+      # foreach ($vsix in $allVsixs) {
+      #   foreach ($plat in $platforms) {
+      #     if ($vsix.Name.Contains($plat)) {
+      #         $additionalPublishArgs += $vsix
+      #     }
+      #   }
+      # }
 
-  #     Write-Host "Command run is: vsce $($additionalPublishArgs)."
-  #     If ("${{ parameters.test }}" -eq "true") {
-  #       Write-Host "In test mode, command is printed instead of run."
-  #       Write-Host "🔒 Verify PAT."
-  #       vsce verify-pat ms-dotnettools
-  #     }
-  #     Else {
-  #       vsce @additionalPublishArgs
-  #     }
-  #   displayName: 🚀 Publish to Marketplace
-  #   workingDirectory: $(Pipeline.Workspace)
-  #   env:
-  #     VSCE_PAT: $(VSCodeMarketplacePAT)
+      # Write-Host "Command run is: vsce $($additionalPublishArgs)."
+      # If ("${{ parameters.test }}" -eq "true") {
+      #   Write-Host "In test mode, command is printed instead of run."
+      #   Write-Host "🔒 Verify PAT."
+      #   vsce verify-pat ms-dotnettools
+      # }
+      # Else {
+      #   vsce @additionalPublishArgs
+      # }
+    displayName: 🚀 Publish to Marketplace
+    workingDirectory: $(Pipeline.Workspace)
+    env:
+      VSCE_PAT: $(VSCodeMarketplacePAT)


### PR DESCRIPTION
Use https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/resources-pipelines-pipeline-trigger-branches?view=azure-pipelines to trigger the release pipeline.

Also, keep the ability to manually run the release pipeline in case it is needed.
I have tested it in test mode/manually, https://dev.azure.com/dnceng/internal/_build/results?buildId=2239158&view=results
 but can't tested the auto release function since the auto trigger yml is on main branch.
