### PR TITLE
Adjusts csharp semantic token scopes to match 1.26 outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4736,6 +4736,12 @@
       {
         "language": "csharp",
         "scopes": {
+          "typeParameter": [
+            "entity.name.type.type-parameter"
+          ],
+          "keyword": [
+            "keyword.cs"
+          ],
           "excludedCode": [
             "support.other.excluded.cs"
           ],

--- a/package.json
+++ b/package.json
@@ -4737,40 +4737,40 @@
         "language": "csharp",
         "scopes": {
           "namespace": [
-            "entity.name.type.namespace.cs"
+            "entity.name.namespace"
           ],
           "type": [
             "entity.name.type"
           ],
           "class": [
-            "entity.name.type.class.cs"
+            "entity.name.type.class"
           ],
           "enum": [
-            "entity.name.type.enum.cs"
+            "entity.name.type.enum"
           ],
           "interface": [
-            "entity.name.type.interface.cs"
+            "entity.name.type.interface"
           ],
           "struct": [
-            "entity.name.type.struct.cs"
+            "entity.name.type.struct"
           ],
           "typeParameter": [
             "entity.name.type.type-parameter.cs"
           ],
           "parameter": [
-            "entity.name.variable.parameter.cs"
+            "variable.parameter"
           ],
           "variable": [
             "entity.name.variable.local.cs"
           ],
           "property": [
-            "variable.other.property.cs"
+            "variable.other.property"
           ],
           "enumMember": [
-            "variable.other.enummember.cs"
+            "variable.other.enummember"
           ],
           "method": [
-            "entity.name.function.member.cs"
+            "entity.name.function.member"
           ],
           "macro": [
             "keyword.preprocessor.cs"
@@ -4809,7 +4809,7 @@
             "entity.name.variable.field.cs"
           ],
           "constant": [
-            "variable.other.constant.cs"
+            "variable.other.constant"
           ],
           "extensionMethod": [
             "entity.name.function.extension.cs"

--- a/package.json
+++ b/package.json
@@ -4736,48 +4736,6 @@
       {
         "language": "csharp",
         "scopes": {
-          "namespace": [
-            "entity.name.namespace"
-          ],
-          "type": [
-            "entity.name.type"
-          ],
-          "class": [
-            "entity.name.type.class"
-          ],
-          "enum": [
-            "entity.name.type.enum"
-          ],
-          "interface": [
-            "entity.name.type.interface"
-          ],
-          "struct": [
-            "entity.name.type.struct"
-          ],
-          "typeParameter": [
-            "entity.name.type.type-parameter.cs"
-          ],
-          "parameter": [
-            "variable.parameter"
-          ],
-          "variable": [
-            "entity.name.variable.local.cs"
-          ],
-          "property": [
-            "variable.other.property"
-          ],
-          "enumMember": [
-            "variable.other.enummember"
-          ],
-          "method": [
-            "entity.name.function.member"
-          ],
-          "macro": [
-            "keyword.preprocessor.cs"
-          ],
-          "keyword": [
-            "keyword.cs"
-          ],
           "excludedCode": [
             "support.other.excluded.cs"
           ],


### PR DESCRIPTION
This PR adjusts the semantic token scopes to match those in earlier versions, 1.26 etc.

Directly relates to Issue #5731

I've compared the foreground outputs using the Inspect Editor Tokens in version 1.26.0 and in this version an confirmed the primary foreground now matches for all of the updated scopes in this PR.

For example the two listed in the original issue:

**Namespace in 1.26.0**:

![image](https://github.com/dotnet/vscode-csharp/assets/15952551/d89ed192-53ed-4e2f-9706-d974db293a0c)

**Namespace in latest**:

![image](https://github.com/dotnet/vscode-csharp/assets/15952551/83f34314-69bf-4a87-8158-0ea3a8631148)

**Parameter in 1.26.0**:

![image](https://github.com/dotnet/vscode-csharp/assets/15952551/18ad58a8-16d3-466e-ab7a-567089829f58)

**Parameter in latest**:

![image](https://github.com/dotnet/vscode-csharp/assets/15952551/7f2a83ef-65f0-4c23-aae1-8c0ba8dd0574)





