### PR TITLE
Add BuildOnlyDiagnosticIdsRequest type

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -712,6 +712,15 @@ export class RoslynLanguageServer {
                 throw new Error(`Invalid log level ${logLevel}`);
         }
     }
+
+    public async getBuildOnlyDiagnosticIds(token: vscode.CancellationToken): Promise<string[]> {
+        const response = await _languageServer.sendRequest0(RoslynProtocol.BuildOnlyDiagnosticIdsRequest.type, token);
+        if (response) {
+            return response.ids;
+        }
+
+        throw new Error('Unable to retrieve build-only diagnostic ids for current solution.');
+    }
 }
 
 /**

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -131,6 +131,10 @@ export interface ShowToastNotificationParams {
     commands: Command[];
 }
 
+export interface BuildOnlyDiagnosticIdsResult {
+    ids: string[];
+}
+
 export namespace WorkspaceDebugConfigurationRequest {
     export const method = 'workspace/debugConfiguration';
     export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
@@ -191,4 +195,10 @@ export namespace OpenProjectNotification {
     export const method = 'project/open';
     export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
     export const type = new lsp.NotificationType<OpenProjectParams>(method);
+}
+
+export namespace BuildOnlyDiagnosticIdsRequest {
+    export const method = 'workspace/buildOnlyDiagnosticIds';
+    export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
+    export const type = new lsp.RequestType0<BuildOnlyDiagnosticIdsResult, void>(method);
 }


### PR DESCRIPTION
Work towards #5728. Follow-up to https://github.com/dotnet/roslyn/pull/69475.

C# extension can now invoke `getBuildOnlyDiagnosticIds` API after each explicit build/rebuild command to identify build-only diagnostic IDs.