### PR TITLE
Add static loc strings to package.nls.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4349,12 +4349,12 @@
             "properties": {
               "projectPath": {
                 "type": "string",
-                "description": "Path to the .csproj file.",
+                "description": "%debuggers.dotnet.launch.projectPath.description%",
                 "default": "${workspaceFolder}/<insert-project-name-here>.csproj"
               },
               "launchConfigurationId": {
                 "type": "string",
-                "description": "The launch configuration id to use. Empty string will use the current active configuration."
+                "description": "%debuggers.dotnet.launch.launchConfigurationId.description%"
               }
             }
           }
@@ -4984,7 +4984,7 @@
     "viewsWelcome": [
       {
         "view": "debug",
-        "contents": "[Generate C# Assets for Build and Debug](command:dotnet.generateAssets)\n\nTo learn more about launch.json, see [Configuring launch.json for C# debugging](https://aka.ms/VSCode-CS-LaunchJson).",
+        "contents": "%viewsWelcome.debug.contents%",
         "when": "debugStartLanguage == csharp && !dotnet.debug.serviceBrokerAvailable"
       }
     ]

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,13 @@
 {
   "configuration.dotnet.defaultSolution.description": "The path of the default solution to be opened in the workspace, or set to 'disable' to skip it.",
+  "debuggers.dotnet.launch.projectPath.description": "Path to the .csproj file.",
+  "debuggers.dotnet.launch.launchConfigurationId.description": "The launch configuration id to use. Empty string will use the current active configuration.",
+  "viewsWelcome.debug.contents": {
+    "message": "[Generate C# Assets for Build and Debug](command:dotnet.generateAssets)\n\nTo learn more about launch.json, see [Configuring launch.json for C# debugging](https://aka.ms/VSCode-CS-LaunchJson).",
+    "comments": [
+      "Do not translate 'command:dotnet.generateAssets' and 'https://aka.ms/VSCode-CS-LaunchJson'"
+    ]
+  },
   "generateOptionsSchema.program.markdownDescription": {
     "message": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: `${workspaceFolder}/bin/Debug/(target-framework)/(project-name.dll)`\n\nExample: `${workspaceFolder}/bin/Debug/netcoreapp1.1/MyProject.dll`\n\nWhere:\n`(target-framework)` is the framework that the debugged project is being built for. This is normally found in the project file as the `TargetFramework` property.\n\n`(project-name.dll)` is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
     "comments": [

--- a/src/tools/generateOptionsSchema.ts
+++ b/src/tools/generateOptionsSchema.ts
@@ -303,12 +303,12 @@ export function GenerateOptionsSchema() {
         keyToLocString
     );
 
+    // Override existing package.nls.json key/values with ones from OptionsSchema.
+    Object.assign(packageNlsJSON, keyToLocString);
+
     writeToFile(packageNlsJSON, 'package.nls.json');
 
     // #endregion
-
-    // Override existing package.nls.json key/values with ones from OptionsSchema.
-    Object.assign(packageNlsJSON, keyToLocString);
 
     // Hard Code adding in configurationAttributes launch and attach.
     // .NET Core


### PR DESCRIPTION
This PR adds the static strings for the `dotnet` debugger and the welcome page.

https://github.com/dotnet/vscode-csharp/pull/6088 also has a bug where it would merge the objects after writing to the file. This also fixes it. 