### PR TITLE
Localize razor configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1558,14 +1558,14 @@
           "razor.languageServer.directory": {
             "type": "string",
             "scope": "machine-overridable",
-            "description": "Overrides the path to the Razor Language Server directory.",
+            "description": "%configuration.razor.languageServer.directory%",
             "order": 90
           },
           "razor.languageServer.debug": {
             "type": "boolean",
             "scope": "machine-overridable",
             "default": false,
-            "description": "Specifies whether to wait for debug attach when launching the language server.",
+            "description": "%configuration.razor.languageServer.debug%",
             "order": 90
           },
           "razor.trace": {
@@ -1577,11 +1577,11 @@
               "Verbose"
             ],
             "enumDescriptions": [
-              "Does not log messages from the Razor extension",
-              "Logs only some messages from the Razor extension",
-              "Logs all messages from the Razor extension"
+              "%configuration.razor.trace.off%",
+              "%configuration.razor.trace.messages%",
+              "%configuration.razor.trace.verbose%"
             ],
-            "description": "Specifies whether to output all messages [Verbose], some messages [Messages] or not at all [Off].",
+            "description": "%configuration.razor.trace%",
             "order": 90
           },
           "csharp.debug.stopAtEntry": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -42,6 +42,12 @@
   "configuration.dotnet.quickInfo.showRemarksInQuickInfo": "Show remarks information when display symbol.",
   "configuration.dotnet.symbolSearch.searchReferenceAssemblies": "Search symbols in reference assemblies. It affects features requires symbol searching, such as add imports.",
   "configuration.dotnet.unitTestDebuggingOptions": "Options to use with the debugger when launching for unit test debugging.",
+  "configuration.razor.languageServer.directory": "Overrides the path to the Razor Language Server directory.",
+  "configuration.razor.languageServer.debug": "Specifies whether to wait for debug attach when launching the language server.",
+  "configuration.razor.trace": "Specifies whether to output all messages [Verbose], some messages [Messages] or not at all [Off].",
+  "configuration.razor.trace.off": "Does not log messages from the Razor extension",
+  "configuration.razor.trace.messages": "Logs only some messages from the Razor extension",
+  "configuration.razor.trace.verbose": "Logs all messages from the Razor extension",
   "debuggers.dotnet.launch.projectPath.description": "Path to the .csproj file.",
   "debuggers.dotnet.launch.launchConfigurationId.description": "The launch configuration id to use. Empty string will use the current active configuration.",
   "viewsWelcome.debug.contents": {


### PR DESCRIPTION
After this all configurations under C# is should be localized.
Then we need to onboard the configurations under O# and command.