### PR TITLE
Set text to lf for bundle.l10.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# This is a generated file from vscode-l10n tool, and it always uses 'lf' and line ending. Set it to 'lf' so we don't get warning every time when localization file get changed.
+l10n/bundle.l10n.json text eol=lf


### PR DESCRIPTION
According to https://github.com/microsoft/vscode-l10n/issues/129, there is no way to config bundle.l10n.json's line ending.
In order not to get the git warning again, set the line ending of bundle.l10n.json to `lf` explicitly.