### PR TITLE
Call Uri.file instead of Uri.parse for file paths

### DIFF
--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -302,7 +302,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         // vscode.workspace.openTextDocument may send a textDocument/didOpen
         // request to the C# language server. We need to keep track of
         // this to make sure we don't send a duplicate request later on.
-        const razorUri = vscode.Uri.parse('file:' + document.path, true);
+        const razorUri = vscode.Uri.file(document.path);
         if (!this.isRazorDocumentOpenInCSharpWorkspace(razorUri)) {
             this.didOpenRazorCSharpDocument(razorUri);
 

--- a/src/razor/src/dynamicFile/dynamicFileInfoHandler.ts
+++ b/src/razor/src/dynamicFile/dynamicFileInfoHandler.ts
@@ -40,13 +40,13 @@ export class DynamicFileInfoHandler {
         const uris = request.razorFiles;
         const virtualUris = new Array<DocumentUri | null>();
         try {
-            for (const razorDocumentUri of uris) {
-                const vscodeUri = vscode.Uri.parse('file:' + razorDocumentUri, true);
+            for (const razorDocumentPath of uris) {
+                const vscodeUri = vscode.Uri.file(razorDocumentPath);
                 const razorDocument = await this.documentManager.getDocument(vscodeUri);
                 if (razorDocument === undefined) {
                     virtualUris.push(null);
                     this.logger.logWarning(
-                        `Could not find Razor document ${razorDocumentUri}; adding null as a placeholder in URI array.`
+                        `Could not find Razor document ${razorDocumentPath}; adding null as a placeholder in URI array.`
                     );
                 } else {
                     // Retrieve generated doc URIs for each Razor URI we are given
@@ -70,8 +70,8 @@ export class DynamicFileInfoHandler {
     private async removeDynamicFileInfo(request: RemoveDynamicFileParams) {
         try {
             const uris = request.razorFiles;
-            for (const razorDocumentUri of uris) {
-                const vscodeUri = vscode.Uri.parse('file:' + razorDocumentUri, true);
+            for (const razorDocumentPath of uris) {
+                const vscodeUri = vscode.Uri.file(razorDocumentPath);
                 if (this.documentManager.isRazorDocumentOpenInCSharpWorkspace(vscodeUri)) {
                     this.documentManager.didCloseRazorCSharpDocument(vscodeUri);
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-dotnettools/issues/368

Hilariously the API docs for `Uri.file` call out exactly why it exists, and why we should have been calling it all along, with an example that matches exactly the scenario the user reported: https://github.com/microsoft/vscode-uri/blob/5af89bac2109c0dc7f904b20cc88cac0568747b1/src/uri.ts#L281-L298
🤣🤣