### PR TITLE
Use dotnet --list-runtimes instead of version from dotnet --info

### DIFF
--- a/omnisharptest/omnisharpIntegrationTests/coreclrDebug/targetArchitecture.test.ts
+++ b/omnisharptest/omnisharpIntegrationTests/coreclrDebug/targetArchitecture.test.ts
@@ -19,6 +19,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '5.0.0',
                 RuntimeId: 'win10-x64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
@@ -32,6 +33,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '6.0.0',
                 RuntimeId: 'win10-x64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
@@ -45,6 +47,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '6.0.0',
                 RuntimeId: 'win10-arm64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
@@ -60,6 +63,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '5.0.0',
                 RuntimeId: 'linux-x64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
@@ -75,6 +79,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '5.0.0',
                 RuntimeId: 'osx.11.0-x64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
@@ -88,6 +93,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '5.0.0',
                 RuntimeId: 'osx.11.0-x64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
@@ -101,6 +107,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '6.0.0',
                 RuntimeId: 'osx.11.0-arm64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
@@ -114,6 +121,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '6.0.0',
                 RuntimeId: 'osx.11.0-x64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, undefined, dotnetInfo);
@@ -127,6 +135,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '6.0.0',
                 RuntimeId: 'osx.11.0-arm64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, 'arm64', dotnetInfo);
@@ -140,6 +149,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '6.0.0',
                 RuntimeId: 'osx.11.0-x86_64',
+                Runtimes: {},
             };
 
             const targetArchitecture = getTargetArchitecture(platformInfo, 'x86_64', dotnetInfo);
@@ -153,6 +163,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '6.0.0',
                 RuntimeId: 'osx.11.0-x86_64',
+                Runtimes: {},
             };
 
             const fn = function () {
@@ -170,6 +181,7 @@ suite('getTargetArchitecture Tests', () => {
                 FullInfo: 'Irrelevant',
                 Version: '6.0.0',
                 RuntimeId: 'osx.11.0-FUTURE_ISA',
+                Runtimes: {},
             };
 
             const fn = function () {

--- a/omnisharptest/omnisharpUnitTests/features/reportIssue.test.ts
+++ b/omnisharptest/omnisharpUnitTests/features/reportIssue.test.ts
@@ -44,6 +44,7 @@ suite(`${reportIssue.name}`, () => {
         FullInfo: 'myDotnetInfo',
         Version: '1.0.x',
         RuntimeId: 'win10-x64',
+        Runtimes: {},
     };
 
     let fakeMonoResolver: FakeMonoResolver;

--- a/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
+++ b/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
@@ -27,7 +27,7 @@ interface IDotnetAcquireResult {
  * Resolves the dotnet runtime for a server executable from given options and the dotnet runtime VSCode extension.
  */
 export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
-    private readonly minimumDotnetVersion = '7.0.100';
+    private readonly minimumDotnetRuntimeVersion = '7.0';
     constructor(
         private platformInfo: PlatformInformation,
         /**
@@ -132,7 +132,6 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
     private async findDotnetFromPath(): Promise<string | undefined> {
         try {
             const dotnetInfo = await getDotnetInfo([]);
-            const dotnetVersionStr = dotnetInfo.Version;
 
             const extensionArchitecture = await this.getArchitectureFromTargetPlatform();
             const dotnetArchitecture = dotnetInfo.Architecture;
@@ -145,14 +144,25 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
                 );
             }
 
-            const dotnetVersion = semver.parse(dotnetVersionStr);
-            if (!dotnetVersion) {
-                throw new Error(`Unknown result output from 'dotnet --version'. Received ${dotnetVersionStr}`);
+            // Verify that the dotnet we found includes a runtime version that is compatible with our requirement.
+            const requiredRuntimeVersion = semver.parse(`${this.minimumDotnetRuntimeVersion}.0`);
+            if (!requiredRuntimeVersion) {
+                throw new Error(`Unable to parse minimum required version ${this.minimumDotnetRuntimeVersion}`);
             }
 
-            if (semver.lt(dotnetVersion, this.minimumDotnetVersion)) {
+            const coreRuntimeVersions = dotnetInfo.Runtimes['Microsoft.NETCore.App'];
+            let foundRuntimeVersion = false;
+            for (const version of coreRuntimeVersions) {
+                // We consider a match if the runtime is greater than or equal to the required version since we roll forward.
+                if (semver.gt(version, requiredRuntimeVersion)) {
+                    foundRuntimeVersion = true;
+                    break;
+                }
+            }
+
+            if (!foundRuntimeVersion) {
                 throw new Error(
-                    `Found dotnet version ${dotnetVersion}. Minimum required version is ${this.minimumDotnetVersion}.`
+                    `No compatible .NET runtime found. Minimum required version is ${this.minimumDotnetRuntimeVersion}.`
                 );
             }
 

--- a/src/shared/utils/dotnetInfo.ts
+++ b/src/shared/utils/dotnetInfo.ts
@@ -3,6 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as semver from 'semver';
+
+type RuntimeVersionMap = { [runtime: string]: semver.SemVer[] };
 export interface DotnetInfo {
     CliPath?: string;
     FullInfo: string;
@@ -10,4 +13,5 @@ export interface DotnetInfo {
     /* a runtime-only install of dotnet will not output a runtimeId in dotnet --info. */
     RuntimeId?: string;
     Architecture?: string;
+    Runtimes: RuntimeVersionMap;
 }


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6167

The version that the old O# was picking up from dotnet --info actually was the runtime version.  This happened to work for many of us because we had .net 8 installed which is higher than .net 7.  

Instead of using SDK version and the version output by dotnet --info, we should actually just look at `dotnet --list-runtimes` (which is meant to be machine readable) to find a runtime higher than our desired runtime.  Adapted from https://devdiv.visualstudio.com/DevDiv/_git/vs-green/pullrequest/491545