### PR TITLE
Do not cache calls to dotnet info

### DIFF
--- a/src/shared/utils/getDotnetInfo.ts
+++ b/src/shared/utils/getDotnetInfo.ts
@@ -9,14 +9,8 @@ import { execChildProcess } from '../../common';
 import { CoreClrDebugUtil } from '../../coreclrDebug/util';
 import { DotnetInfo } from './dotnetInfo';
 
-let _dotnetInfo: DotnetInfo | undefined;
-
 // This function calls `dotnet --info` and returns the result as a DotnetInfo object.
 export async function getDotnetInfo(dotNetCliPaths: string[]): Promise<DotnetInfo> {
-    if (_dotnetInfo !== undefined) {
-        return _dotnetInfo;
-    }
-
     const dotnetExecutablePath = getDotNetExecutablePath(dotNetCliPaths);
 
     try {
@@ -62,7 +56,7 @@ export async function getDotnetInfo(dotNetCliPaths: string[]): Promise<DotnetInf
         }
 
         if (version !== undefined) {
-            _dotnetInfo = {
+            const dotnetInfo: DotnetInfo = {
                 CliPath: cliPath,
                 FullInfo: fullInfo,
                 Version: version,
@@ -70,7 +64,7 @@ export async function getDotnetInfo(dotNetCliPaths: string[]): Promise<DotnetInf
                 Architecture: architecture,
                 Runtimes: runtimeVersions,
             };
-            return _dotnetInfo;
+            return dotnetInfo;
         }
 
         throw new Error('Failed to parse dotnet version information');


### PR DESCRIPTION
Now that we call dotnet info on startup, we can cache a different value than other callers are expecting (different callers pass in different CLI paths which should output different dotnet info).

The fix is to not cache this because the inputs can change.  We do not call this that often that we should need to cache it either.

Also updates the logging to indicate why a potential call to dotnet info failed.

Possibly related to https://github.com/dotnet/vscode-csharp/issues/6179 and https://github.com/dotnet/vscode-csharp/issues/6177 .  It doesn't entirely fix them, but it resolves some potential problems.