### PR TITLE
Trigger localization weekly & when PR merged

### DIFF
--- a/azure-pipelines/loc.yml
+++ b/azure-pipelines/loc.yml
@@ -1,5 +1,19 @@
-trigger: none
+trigger:
+  branches:
+    include:
+    - main
+
 pr: none
+
+# localization result might not be ready when PR triggered the pipeline.
+# Run this weekly to make sure everything is localized.
+schedules:
+- cron: '0 12 * * 0'
+  displayName: Weekly localization run
+  always: true
+  branches:
+    include:
+    - main
 
 parameters:
   - name: publishLocalizationFile


### PR DESCRIPTION
The localization pipeline looks fine now so change it to be triggered
1. Whenever PR gets merged.
2. Weekly. (This is needed because sometime when new strings will not be localized by OneLocBuild, it would be 'gradually' localized latter, so set it run weekly as a clean up run)