### PR TITLE
Fix quoting bug

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -527,7 +527,7 @@ export class RoslynLanguageServer {
         }
 
         for (const extensionPath of this.additionalExtensionPaths) {
-            args.push('--extension', `${extensionPath}`);
+            args.push('--extension', extensionPath);
         }
 
         // Get the brokered service pipe name from C# Dev Kit (if installed).

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -527,7 +527,7 @@ export class RoslynLanguageServer {
         }
 
         for (const extensionPath of this.additionalExtensionPaths) {
-            args.push('--extension', `"${extensionPath}"`);
+            args.push('--extension', `${extensionPath}`);
         }
 
         // Get the brokered service pipe name from C# Dev Kit (if installed).
@@ -581,9 +581,18 @@ export class RoslynLanguageServer {
         if (serverPath.endsWith('.dll')) {
             // If we were given a path to a dll, launch that via dotnet.
             const argsWithPath = [serverPath].concat(args);
+
+            if (logLevel && [Trace.Messages, Trace.Verbose].includes(this.GetTraceLevel(logLevel))) {
+                _channel.appendLine(`Server arguments ${argsWithPath.join(' ')}`);
+            }
+
             childProcess = cp.spawn(dotnetExecutablePath, argsWithPath, cpOptions);
         } else {
             // Otherwise assume we were given a path to an executable.
+            if (logLevel && [Trace.Messages, Trace.Verbose].includes(this.GetTraceLevel(logLevel))) {
+                _channel.appendLine(`Server arguments ${args.join(' ')}`);
+            }
+
             childProcess = cp.spawn(serverPath, args, cpOptions);
         }
 


### PR DESCRIPTION
The server was not expecting paths to be quoted, but we were doing so on the client. I've also added a trace-level print of the actual arguments we will use to start the server, which helped me figure this out.
