### PR TITLE
Add support for passing a runsettings path to the server

### DIFF
--- a/omnisharptest/omnisharpUnitTests/fakes/fakeOptions.ts
+++ b/omnisharptest/omnisharpUnitTests/fakes/fakeOptions.ts
@@ -15,6 +15,7 @@ export function getEmptyOptions(): Options {
             excludePaths: [],
             defaultSolution: '',
             unitTestDebuggingOptions: {},
+            runSettingsPath: '',
         },
         {
             useModernNet: false,
@@ -40,7 +41,6 @@ export function getEmptyOptions(): Options {
             sdkPath: '',
             sdkVersion: '',
             sdkIncludePrereleases: false,
-            testRunSettings: '',
             dotNetCliPaths: [],
             useFormatting: false,
             showReferencesCodeLens: false,

--- a/omnisharptest/omnisharpUnitTests/options.test.ts
+++ b/omnisharptest/omnisharpUnitTests/options.test.ts
@@ -38,7 +38,7 @@ suite('Options tests', () => {
         options.omnisharpOptions.enableImportCompletion.should.equal(false);
         options.omnisharpOptions.enableAsyncCompletion.should.equal(false);
         options.omnisharpOptions.analyzeOpenDocumentsOnly.should.equal(true);
-        options.omnisharpOptions.testRunSettings.should.equal('');
+        options.commonOptions.runSettingsPath.should.equal('');
     });
 
     test('Verify return no excluded paths when files.exclude empty', () => {
@@ -128,8 +128,6 @@ suite('Options tests', () => {
 
         const options = Options.Read(vscode);
 
-        options.omnisharpOptions.testRunSettings.should.equal(
-            'some_valid_path\\some_valid_runsettings_files.runsettings'
-        );
+        options.commonOptions.runSettingsPath.should.equal('some_valid_path\\some_valid_runsettings_files.runsettings');
     });
 });

--- a/package.json
+++ b/package.json
@@ -1081,10 +1081,6 @@
             "default": false,
             "description": "(EXPERIMENTAL) Enables support for resolving completion edits asynchronously. This can speed up time to show the completion list, particularly override and partial method completion lists, at the cost of slight delays after inserting a completion item. Most completion items will have no noticeable impact with this feature, but typing immediately after inserting an override or partial method completion, before the insert is completed, can have unpredictable results."
           },
-          "omnisharp.testRunSettings": {
-            "type": "string",
-            "description": "Path to the .runsettings file which should be used when running unit tests."
-          },
           "omnisharp.dotNetCliPaths": {
             "type": "array",
             "items": {
@@ -1357,6 +1353,10 @@
             "default": true,
             "description": "%configuration.dotnet.symbolSearch.searchReferenceAssemblies%",
             "order": 80
+          },
+          "dotnet.unitTests.runSettingsPath": {
+            "type": "string",
+            "description": "Path to the .runsettings file which should be used when running unit tests."
           },
           "dotnet.unitTestDebuggingOptions": {
             "type": "object",

--- a/src/features/dotnetTest.ts
+++ b/src/features/dotnetTest.ts
@@ -233,7 +233,7 @@ export default class TestManager extends AbstractProvider {
     }
 
     private _getRunSettings(filename: string): string | undefined {
-        const testSettingsPath = this.optionProvider.GetLatestOptions().omnisharpOptions.testRunSettings;
+        const testSettingsPath = this.optionProvider.GetLatestOptions().commonOptions.runSettingsPath;
         if (testSettingsPath.length === 0) {
             return undefined;
         }

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -825,7 +825,7 @@ export async function activateRoslynLanguageServer(
 
     registerRazorCommands(context, _languageServer);
 
-    registerUnitTestingCommands(context, _languageServer, dotnetTestChannel);
+    registerUnitTestingCommands(context, _languageServer, dotnetTestChannel, optionProvider);
 
     // Register any needed debugger components that need to communicate with the language server.
     registerDebugger(context, _languageServer, platformInfo, optionProvider, _channel);

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -83,6 +83,11 @@ export interface RunTestsParams extends lsp.WorkDoneProgressParams, lsp.PartialR
      * Whether the request should attempt to call back to the client to attach a debugger before running the tests.
      */
     attachDebugger: boolean;
+
+    /**
+     * The absolute path to a .runsettings file to configure the test run.
+     */
+    runSettingsPath?: string;
 }
 
 export interface TestProgress {

--- a/src/shared/migrateOptions.ts
+++ b/src/shared/migrateOptions.ts
@@ -70,6 +70,10 @@ export const migrateOptions = [
         omnisharpOption: 'csharp.unitTestDebuggingOptions',
         roslynOption: 'dotnet.unitTestDebuggingOptions',
     },
+    {
+        omnisharpOption: 'omnisharp.testRunSettings',
+        roslynOption: 'dotnet.unitTests.runSettingsPath',
+    },
 ];
 
 export async function MigrateOptions(vscode: vscode): Promise<void> {

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -97,6 +97,12 @@ export class Options {
             {},
             'csharp.unitTestDebuggingOptions'
         );
+        const runSettingsPath = Options.readOption<string>(
+            config,
+            'dotnet.unitTests.runSettingsPath',
+            '',
+            'omnisharp.testRunSettings'
+        );
 
         // Omnisharp Server Options
 
@@ -179,7 +185,6 @@ export class Options {
             'omnisharp.enableMsBuildLoadProjectsOnDemand',
             false
         );
-        const testRunSettings = Options.readOption<string>(config, 'omnisharp.testRunSettings', '');
         const dotNetCliPaths = Options.readOption<string[]>(config, 'omnisharp.dotNetCliPaths', []);
 
         const useFormatting = Options.readOption<boolean>(config, 'csharp.format.enable', true);
@@ -312,6 +317,7 @@ export class Options {
                 excludePaths: excludePaths,
                 defaultSolution: defaultSolution,
                 unitTestDebuggingOptions: unitTestDebuggingOptions,
+                runSettingsPath: runSettingsPath,
             },
             {
                 useModernNet: useModernNet,
@@ -337,7 +343,6 @@ export class Options {
                 sdkPath: sdkPath,
                 sdkVersion: sdkVersion,
                 sdkIncludePrereleases: sdkIncludePrereleases,
-                testRunSettings: testRunSettings,
                 dotNetCliPaths: dotNetCliPaths,
                 useFormatting: useFormatting,
                 showReferencesCodeLens: showReferencesCodeLens,
@@ -425,6 +430,7 @@ export interface CommonOptions {
     /** The default solution; this has been normalized to a full file path from the workspace folder it was configured in, or the string "disable" if that has been disabled */
     defaultSolution: string;
     unitTestDebuggingOptions: object;
+    runSettingsPath: string;
 }
 
 export const CommonOptionsThatTriggerReload: ReadonlyArray<keyof CommonOptions> = [
@@ -458,7 +464,6 @@ export interface OmnisharpServerOptions {
     sdkPath: string;
     sdkVersion: string;
     sdkIncludePrereleases: boolean;
-    testRunSettings: string;
     dotNetCliPaths: string[];
     useFormatting: boolean;
     showReferencesCodeLens: boolean;


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/5719 as the final (known) issue.

Server side PR - https://github.com/dotnet/roslyn/pull/69792

Draft until the server side merges and I can add integration test support here.