### PR TITLE
generateOptionsSchema: a few improvements for debugging logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -290,6 +290,17 @@
               "NEW_DEPS_ID": "Razor"
           },
           "cwd": "${workspaceFolder}"
-      }
+      },
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Generate debugger options schema",
+        "preLaunchTask": "build",
+        "program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
+        "args": [
+            "generateOptionsSchema"
+        ],
+        "cwd": "${workspaceFolder}"
+    }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1406,21 +1406,6 @@
                     "markdownDescription": "%generateOptionsSchema.logging.programOutput.markdownDescription%",
                     "default": true
                   },
-                  "engineLogging": {
-                    "type": "boolean",
-                    "markdownDescription": "%generateOptionsSchema.logging.engineLogging.markdownDescription%",
-                    "default": false
-                  },
-                  "browserStdOut": {
-                    "type": "boolean",
-                    "markdownDescription": "%generateOptionsSchema.logging.browserStdOut.markdownDescription%",
-                    "default": true
-                  },
-                  "elapsedTiming": {
-                    "type": "boolean",
-                    "markdownDescription": "%generateOptionsSchema.logging.elapsedTiming.markdownDescription%",
-                    "default": false
-                  },
                   "threadExit": {
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.threadExit.markdownDescription%",

--- a/src/tools/generateOptionsSchema.ts
+++ b/src/tools/generateOptionsSchema.ts
@@ -217,6 +217,22 @@ function generateLocForProperty(key: string, prop: any, keyToLocString: any): vo
         prop.settingsDescription = `%${settingsDescriptionKey}%`;
     }
 
+    if (prop.deprecationMessage) {
+        const descriptionKey = `${key}.deprecationMessage`;
+        if (!keyToLocString[descriptionKey]) {
+            const comments: string[] = generateCommentArrayForDescription(prop.deprecationMessage);
+            if (comments.length > 0) {
+                keyToLocString[descriptionKey] = {
+                    message: prop.deprecationMessage,
+                    comments: comments,
+                };
+            } else {
+                keyToLocString[descriptionKey] = prop.deprecationMessage;
+            }
+        }
+        prop.deprecationMessage = `%${descriptionKey}%`;
+    }
+
     if (prop.enum && prop.enumDescriptions) {
         for (let i = 0; i < prop.enum.length; i++) {
             const enumName = prop.enum[i];
@@ -325,6 +341,19 @@ export function GenerateOptionsSchema() {
     delete unitTestDebuggingOptions.processName;
     delete unitTestDebuggingOptions.processId;
     delete unitTestDebuggingOptions.pipeTransport;
+
+    // Remove diagnostic log logging options -- these should be set using the global option
+    const allowedLoggingOptions = ['exceptions', 'moduleLoad', 'programOutput', 'threadExit', 'processExit'];
+    const diagnosticLogOptions = Object.keys(unitTestDebuggingOptions.logging.properties).filter((x) => {
+        if (allowedLoggingOptions.indexOf(x) >= 0) {
+            return false;
+        }
+        return true;
+    });
+    for (const key of diagnosticLogOptions) {
+        delete unitTestDebuggingOptions.logging.properties[key];
+    }
+
     // Add the additional options we do want
     unitTestDebuggingOptions['type'] = {
         type: 'string',


### PR DESCRIPTION
This PR makes three small improvements to `generateOptionsSchema` in preparation for improvements to debugger logging:

1. Instead of exposing all of the debugger logging options for unit tests, just expose the non-diagnostic logic options. These options can be turned on for unit tests like any other kind of debugging (ex: `csharp.debug.logging.engineLogging`).
2. Support `deprecationMessage`. This is VSCode's way of deprecating settings.
3. Add a launch.json configuration for debugging the `generateOptionsSchema` code