### PR TITLE
Fix completionComplexEdit: Use fsPath instead of path

### DIFF
--- a/src/lsptoolshost/commands.ts
+++ b/src/lsptoolshost/commands.ts
@@ -103,7 +103,7 @@ async function completionComplexEdit(
 ): Promise<void> {
     let success = false;
     const uri = UriConverter.deserialize(uriStr);
-    const editor = vscode.window.visibleTextEditors.find((editor) => editor.document.uri.path === uri.path);
+    const editor = vscode.window.visibleTextEditors.find((editor) => editor.document.uri.fsPath === uri.fsPath);
 
     if (editor !== undefined) {
         const newRange = editor.document.validateRange(


### PR DESCRIPTION
Trying to fix #6011 .

Found that `completionComplexEdit` should find editors according to `fsPath` instead of `path`, similar to other places. `path` might be different on Windows, e.g.

uri.path:
<img width="278" alt="b4f7f0d33c06de5c9a3fa27972f3fc74" src="https://github.com/dotnet/vscode-csharp/assets/22252491/6b899f71-6522-4a01-af96-692304fb9200">

editor.document.uri.path:
<img width="258" alt="b8f87cc9ab6d8640baff90288fef5117" src="https://github.com/dotnet/vscode-csharp/assets/22252491/60764637-a2b0-4e5d-bb60-0204eee3bc9a">

After this fix, the autocomplete works properly with mouse clicks / tab autocomplete. However, it still does not respond to enter key (it simply adds a new line instead of inserting the autocompletion).