### PR TITLE
Read LSP path from environment

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -787,7 +787,11 @@ function getServerPath(options: Options, platformInfo: PlatformInformation) {
     if (serverPath) {
         _channel.appendLine(`Using server path override from DOTNET_ROSLYN_SERVER_PATH: ${serverPath}`);
     } else {
-        serverPath = options.commonOptions.serverPath ?? getInstalledServerPath(platformInfo);
+        serverPath = options.commonOptions.serverPath;
+        if (!serverPath) {
+            // Option not set, use the path from the extension.
+            serverPath = getInstalledServerPath(platformInfo);
+        }
     }
 
     if (!fs.existsSync(serverPath)) {

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -782,10 +782,12 @@ export async function activateRoslynLanguageServer(
 }
 
 function getServerPath(options: Options, platformInfo: PlatformInformation) {
-    let serverPath = options.commonOptions.serverPath;
-    if (!serverPath) {
-        // Option not set, use the path from the extension.
-        serverPath = getInstalledServerPath(platformInfo);
+    let serverPath = process.env.DOTNET_ROSLYN_SERVER_PATH;
+
+    if (serverPath) {
+        _channel.appendLine(`Using server path override from DOTNET_ROSLYN_SERVER_PATH: ${serverPath}`);
+    } else {
+        serverPath = options.commonOptions.serverPath ?? getInstalledServerPath(platformInfo);
     }
 
     if (!fs.existsSync(serverPath)) {


### PR DESCRIPTION
Allows the user to set `DOTNET_ROSLYN_SERVER_PATH` to an LSP server build, which will override any setting from the vscode instance.
