### PR TITLE
Make complexEdit command more robust

### DIFF
--- a/src/lsptoolshost/commands.ts
+++ b/src/lsptoolshost/commands.ts
@@ -31,7 +31,11 @@ export function registerCommands(
     // so we don't accidentally pass them directly into vscode APIs.
     context.subscriptions.push(vscode.commands.registerCommand('roslyn.client.peekReferences', peekReferencesCallback));
     context.subscriptions.push(
-        vscode.commands.registerCommand('roslyn.client.completionComplexEdit', completionComplexEdit)
+        vscode.commands.registerCommand(
+            'roslyn.client.completionComplexEdit',
+            async (uriStr, textEdit, isSnippetString, newOffset) =>
+                completionComplexEdit(uriStr, textEdit, isSnippetString, newOffset, outputChannel)
+        )
     );
     context.subscriptions.push(
         vscode.commands.registerCommand('dotnet.restartServer', async () => restartServer(languageServer))
@@ -99,11 +103,14 @@ async function completionComplexEdit(
     uriStr: string,
     textEdit: vscode.TextEdit,
     isSnippetString: boolean,
-    newOffset: number
+    newOffset: number,
+    outputChannel: vscode.OutputChannel
 ): Promise<void> {
     let success = false;
     const uri = UriConverter.deserialize(uriStr);
-    const editor = vscode.window.visibleTextEditors.find((editor) => editor.document.uri.fsPath === uri.fsPath);
+    const editor = vscode.window.visibleTextEditors.find(
+        (editor) => editor.document.uri.path === uri.path || editor.document.uri.fsPath === uri.fsPath
+    );
 
     if (editor !== undefined) {
         const newRange = editor.document.validateRange(
@@ -142,6 +149,27 @@ async function completionComplexEdit(
     }
 
     if (!success) {
+        const componentName = '[roslyn.client.completionComplexEdit]';
+
+        if (editor === undefined) {
+            outputChannel.show();
+            outputChannel.appendLine(`${componentName} Failed to make a complex text edit for completion.`);
+            outputChannel.appendLine(
+                `${componentName} Can't find visible document with uri.fsPath: '${uri.fsPath}' and uri.path: '${uri.path}'`
+            );
+
+            outputChannel.appendLine(`${componentName} URIs of all visible documents:`);
+            for (const visibleEditor of vscode.window.visibleTextEditors) {
+                outputChannel.appendLine(
+                    `${componentName} - uri.fsPath: '${visibleEditor.document.uri.fsPath}' and uri.path: '${visibleEditor.document.uri.path}'`
+                );
+            }
+        } else {
+            outputChannel.appendLine(
+                `${componentName} ${isSnippetString ? 'TextEditor.insertSnippet' : 'workspace.applyEdit'} failed.`
+            );
+        }
+
         throw new Error('Failed to make a complex text edit for completion.');
     }
 }

--- a/src/lsptoolshost/commands.ts
+++ b/src/lsptoolshost/commands.ts
@@ -150,10 +150,11 @@ async function completionComplexEdit(
 
     if (!success) {
         const componentName = '[roslyn.client.completionComplexEdit]';
+        const errorMessage = 'Failed to make a complex text edit for completion.';
+        outputChannel.show();
+        outputChannel.appendLine(`${componentName} ${errorMessage}`);
 
         if (editor === undefined) {
-            outputChannel.show();
-            outputChannel.appendLine(`${componentName} Failed to make a complex text edit for completion.`);
             outputChannel.appendLine(
                 `${componentName} Can't find visible document with uri.fsPath: '${uri.fsPath}' and uri.path: '${uri.path}'`
             );
@@ -170,7 +171,7 @@ async function completionComplexEdit(
             );
         }
 
-        throw new Error('Failed to make a complex text edit for completion.');
+        throw new Error(`${componentName} ${errorMessage}`);
     }
 }
 


### PR DESCRIPTION
... by checking both fsPath and path. Also added logging when there's error.

This is a follow-up on https://github.com/dotnet/vscode-csharp/pull/6315, just in case of unexpected scenarios.

related to:
https://github.com/dotnet/vscode-csharp/issues/6293
https://github.com/dotnet/vscode-csharp/issues/6246
