### PR TITLE
Allow Razor to format new documents via Roslyn

### DIFF
--- a/src/lsptoolshost/razorCommands.ts
+++ b/src/lsptoolshost/razorCommands.ts
@@ -26,6 +26,7 @@ import {
 } from 'vscode-languageclient/node';
 import SerializableSimplifyMethodParams from '../razor/src/simplify/serializableSimplifyMethodParams';
 import { TextEdit } from 'vscode-html-languageservice';
+import { SerializableFormatNewFileParams } from '../razor/src/formatNewFile/serializableFormatNewFileParams';
 
 // These are commands that are invoked by the Razor extension, and are used to send LSP requests to the Roslyn LSP server
 export const roslynDidChangeCommand = 'roslyn.changeRazorCSharp';
@@ -36,6 +37,7 @@ export const resolveCodeActionCommand = 'roslyn.resolveCodeAction';
 export const provideCompletionsCommand = 'roslyn.provideCompletions';
 export const resolveCompletionsCommand = 'roslyn.resolveCompletion';
 export const roslynSimplifyMethodCommand = 'roslyn.simplifyMethod';
+export const roslynFormatNewFileCommand = 'roslyn.formatNewFile';
 export const razorInitializeCommand = 'razor.initialize';
 
 export function registerRazorCommands(context: vscode.ExtensionContext, languageServer: RoslynLanguageServer) {
@@ -67,6 +69,19 @@ export function registerRazorCommands(context: vscode.ExtensionContext, language
                     'roslyn/simplifyMethod'
                 );
                 return await languageServer.sendRequest(simplifyMethodRequestType, request, CancellationToken.None);
+            }
+        )
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            roslynFormatNewFileCommand,
+            async (request: SerializableFormatNewFileParams) => {
+                const formatNewFileRequestType = new RequestType<
+                    SerializableFormatNewFileParams,
+                    string | undefined,
+                    any
+                >('roslyn/formatNewFile');
+                return await languageServer.sendRequest(formatNewFileRequestType, request, CancellationToken.None);
             }
         )
     );

--- a/src/razor/src/formatNewFile/razorFormatNewFileHandler.ts
+++ b/src/razor/src/formatNewFile/razorFormatNewFileHandler.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { RequestType } from 'vscode-languageclient';
+import { RazorLanguageServerClient } from '../razorLanguageServerClient';
+import { RazorDocumentManager } from '../document/razorDocumentManager';
+import { RazorLanguageServiceClient } from '../razorLanguageServiceClient';
+import { RazorLanguageFeatureBase } from '../razorLanguageFeatureBase';
+import { RazorDocumentSynchronizer } from '../document/razorDocumentSynchronizer';
+import { RazorLogger } from '../razorLogger';
+import { SerializableFormatNewFileParams } from './serializableFormatNewFileParams';
+import { roslynFormatNewFileCommand } from '../../../lsptoolshost/razorCommands';
+
+export class RazorFormatNewFileHandler extends RazorLanguageFeatureBase {
+    private static readonly razorFormatNewFileCommand = 'razor/formatNewFile';
+    private formatNewFileRequestType: RequestType<SerializableFormatNewFileParams, string | undefined, any> =
+        new RequestType(RazorFormatNewFileHandler.razorFormatNewFileCommand);
+
+    constructor(
+        documentSynchronizer: RazorDocumentSynchronizer,
+        protected readonly serverClient: RazorLanguageServerClient,
+        protected readonly serviceClient: RazorLanguageServiceClient,
+        protected readonly documentManager: RazorDocumentManager,
+        protected readonly logger: RazorLogger
+    ) {
+        super(documentSynchronizer, documentManager, serviceClient, logger);
+    }
+
+    public async register() {
+        await this.serverClient.onRequestWithParams<SerializableFormatNewFileParams, string | undefined, any>(
+            this.formatNewFileRequestType,
+            async (request: SerializableFormatNewFileParams, token: vscode.CancellationToken) =>
+                this.getFormatNewFile(request, token)
+        );
+    }
+
+    private async getFormatNewFile(
+        request: SerializableFormatNewFileParams,
+        _: vscode.CancellationToken
+    ): Promise<string | undefined> {
+        if (!this.documentManager.roslynActivated) {
+            return undefined;
+        }
+
+        const response: string | undefined = await vscode.commands.executeCommand(roslynFormatNewFileCommand, request);
+
+        return response;
+    }
+}

--- a/src/razor/src/formatNewFile/serializableFormatNewFileParams.ts
+++ b/src/razor/src/formatNewFile/serializableFormatNewFileParams.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SerializableTextDocumentIdentifier } from '../rpc/serializableTextDocumentIdentifier';
+
+export interface SerializableFormatNewFileParams {
+    project: SerializableTextDocumentIdentifier;
+    document: SerializableTextDocumentIdentifier;
+    contents: string;
+}


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/4330

Plumbing!

Connects https://github.com/dotnet/razor/pull/9263 to https://github.com/dotnet/roslyn/pull/69878 in VS Code

Currently untested due to unrelated changes running a locally build Roslyn server, which hopefully will be solved soon.