### PR TITLE
Pass ForceNoAlign to ensure msbuild output is parseable by the vscode problem matcher

### DIFF
--- a/omnisharptest/omnisharpFeatureTests/assets.test.ts
+++ b/omnisharptest/omnisharpFeatureTests/assets.test.ts
@@ -78,7 +78,7 @@ suite('Asset generation: csproj', () => {
         // We do not check the watch task since this parameter can break hot reload scenarios.
         tasksJson.tasks
             .filter((task) => task.label !== 'watch')
-            .forEach((task) => task.args!.should.contain('/consoleloggerparameters:NoSummary'));
+            .forEach((task) => task.args!.should.contain('/consoleloggerparameters:NoSummary;ForceNoAlign'));
     });
 
     test("Generated 'watch' task does not have the property GenerateFullPaths set to true ", () => {
@@ -111,7 +111,7 @@ suite('Asset generation: csproj', () => {
 
         const watchTask = tasksJson.tasks!.find((task) => task.label === 'watch');
         isNotNull(watchTask?.args);
-        watchTask.args.should.not.contain('/consoleloggerparameters:NoSummary');
+        watchTask.args.should.not.contain('/consoleloggerparameters:NoSummary;ForceNoAlign');
     });
 
     test('Create tasks.json for nested project opened in workspace', () => {

--- a/src/shared/assets.ts
+++ b/src/shared/assets.ts
@@ -293,7 +293,7 @@ export class AssetGenerator {
         }
 
         commandArgs.push('/property:GenerateFullPaths=true');
-        commandArgs.push('/consoleloggerparameters:NoSummary');
+        commandArgs.push('/consoleloggerparameters:NoSummary;ForceNoAlign');
     }
 
     private getBuildProjectPath(): string | null {


### PR DESCRIPTION
When the terminal size is adjusted, msbuild can alter the output making it unparseable by the vscode problem matcher.  This flag makes msbuild not attempt to align the output based on the terminal size.
See https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022

This flag is also used by devkit for a similar reason, see https://devdiv.visualstudio.com/DevDiv/_git/vs-green?path=/tools/msbuild/Directory.Build.rsp&version=GBmain&line=16&lineEnd=17&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents (internal)

Resolves https://github.com/dotnet/vscode-csharp/issues/6309

Fixed:
![image](https://github.com/dotnet/vscode-csharp/assets/5749229/ac3cb347-c93e-45a2-ab49-55f39e44d196)

Before:
![image](https://github.com/dotnet/vscode-csharp/assets/5749229/09098f27-38f9-4da1-965c-72ef881173f6)
