### PR TITLE
Add 'when' to 'clr' debugger for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3085,7 +3085,8 @@
       },
       {
         "type": "clr",
-        "label": ".NET Framework 4.x (Windows only)",
+        "when": "workspacePlatform == windows",
+        "label": ".NET Framework 4.x",
         "languages": [
           "csharp",
           "razor",


### PR DESCRIPTION
This PR adds a when clause to detect if the platform is a windows machine. This change will only show the 'clr' debugger if it is a windows machine.

Fixes: #6312