### PR TITLE
Change Dynamic Configuration Name from C# to .NET

### DIFF
--- a/package.json
+++ b/package.json
@@ -4336,7 +4336,7 @@
       },
       {
         "type": "dotnet",
-        "label": "C#",
+        "label": ".NET",
         "languages": [
           "csharp",
           "razor",


### PR DESCRIPTION
This PR changes the name from 'C#' to '.NET' for the dynamic configuration provider.

TODO:
- [ ] Update VS Code docs to show .NET instead of C#


Fixes:
https://github.com/microsoft/vscode-dotnettools/issues/512