### PR TITLE
Fix isSubfolderOf to correctly determine if a folder is a subfolder

### DIFF
--- a/omnisharptest/omnisharpJestTests/common.test.ts
+++ b/omnisharptest/omnisharpJestTests/common.test.ts
@@ -3,82 +3,79 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { describe, test, expect } from '@jest/globals';
 import * as path from 'path';
 
 import { isSubfolderOf, safeLength, sum } from '../../src/common';
 
-import { should, expect } from 'chai';
-
-suite('Common', () => {
-    suiteSetup(() => should());
-
-    suite('safeLength', () => {
+describe('Common', () => {
+    describe('safeLength', () => {
         test('return 0 for empty array', () => {
             const array: any[] = [];
             const result = safeLength(array);
-            result.should.equal(0);
+            expect(result).toBe(0);
         });
 
         test('returns 5 for array of 5 elements', () => {
             const array = [1, 2, 3, 4, 5];
             const result = safeLength(array);
-            result.should.equal(5);
+            expect(result).toBe(5);
         });
 
         test('returns 0 for undefined', () => {
             const array = undefined;
             const result = safeLength(array);
-            result.should.equal(0);
+            expect(result).toBe(0);
         });
     });
 
-    suite('sum', () => {
+    describe('sum', () => {
         test('produce total from numbers', () => {
             const array = [1, 2, 3, 4, 5];
             const result = sum(array, (i) => i);
-            result.should.equal(15);
+            expect(result).toBe(15);
         });
 
         test('produce total from lengths of arrays', () => {
             const array = [[1, 2], [3], [], [4, 5, 6]];
             const result = sum(array, (i) => i.length);
-            result.should.equal(6);
+            expect(result).toBe(6);
         });
 
         test('produce total of true values from array of booleans', () => {
             const array = [true, false, false, true, true, true, false, true];
             const result = sum(array, (b) => (b ? 1 : 0));
-            result.should.equal(5);
+            expect(result).toBe(5);
         });
     });
 
-    suite('isSubfolderOf', () => {
+    describe('isSubfolderOf', () => {
         test('same paths', () => {
             const subfolder: string = ['C:', 'temp', 'VS', 'dotnetProject'].join(path.sep);
             const folder: string = ['C:', 'temp', 'VS', 'dotnetProject'].join(path.sep);
 
-            expect(isSubfolderOf(subfolder, folder)).to.be.true;
+            expect(isSubfolderOf(subfolder, folder)).toBe(true);
         });
 
         test('correct subfolder', () => {
-            const subfolder: string = ['C:', 'temp', 'VS'].join(path.sep);
-            const folder: string = ['C:', 'temp', 'VS', 'dotnetProject'].join(path.sep);
+            const folder: string = ['C:', 'temp', 'VS'].join(path.sep);
+            const subfolder: string = ['C:', 'temp', 'VS', 'dotnetProject'].join(path.sep);
 
-            expect(isSubfolderOf(subfolder, folder)).to.be.true;
+            expect(isSubfolderOf(subfolder, folder)).toBe(true);
         });
 
-        test('longer subfolder', () => {
-            const subfolder: string = ['C:', 'temp', 'VS', 'a', 'b', 'c'].join(path.sep);
-            const folder: string = ['C:', 'temp', 'VS'].join(path.sep);
+        test('longer folder', () => {
+            const folder: string = ['C:', 'temp', 'VS', 'a', 'b', 'c'].join(path.sep);
+            const subfolder: string = ['C:', 'temp', 'VS'].join(path.sep);
 
-            expect(isSubfolderOf(subfolder, folder)).to.be.false;
+            expect(isSubfolderOf(subfolder, folder)).toBe(false);
         });
 
         test('Different drive', () => {
             const subfolder: string = ['C:', 'temp', 'VS'].join(path.sep);
             const folder: string = ['E:', 'temp', 'VS'].join(path.sep);
 
-            expect(isSubfolderOf(subfolder, folder)).to.be.false;
+            expect(isSubfolderOf(subfolder, folder)).toBe(false);
         });
     });
 });

--- a/src/common.ts
+++ b/src/common.ts
@@ -186,21 +186,21 @@ export function convertNativePathToPosix(pathString: string): string {
 }
 
 /**
- * This function checks to see if a subfolder is part of folder.
+ * This function checks to see if a subfolder is part of a parent folder.
  *
- * Assumes subfolder and folder are absolute paths and have consistent casing.
+ * Assumes subfolder and parent folder are absolute paths and have consistent casing.
  *
- * @param subfolder subfolder to check if it is part of the folder parameter
- * @param folder folder to check aganist
+ * @param subfolder subfolder to check if it is part of the parent folder parameter
+ * @param parentFolder folder to check aganist
  */
-export function isSubfolderOf(subfolder: string, folder: string): boolean {
+export function isSubfolderOf(subfolder: string, parentFolder: string): boolean {
     const subfolderArray: string[] = subfolder.split(path.sep);
-    const folderArray: string[] = folder.split(path.sep);
+    const parentFolderArray: string[] = parentFolder.split(path.sep);
 
     // Check to see that every sub directory in subfolder exists in folder.
     return (
-        subfolderArray.length <= folderArray.length &&
-        subfolderArray.every((subpath, index) => folderArray[index] === subpath)
+        parentFolderArray.length <= subfolder.length &&
+        parentFolderArray.every((subpath, index) => subfolderArray[index] === subpath)
     );
 }
 

--- a/src/omnisharpWorkspaceDebugInformationProvider.ts
+++ b/src/omnisharpWorkspaceDebugInformationProvider.ts
@@ -44,11 +44,12 @@ export class OmnisharpWorkspaceDebugInformationProvider implements IWorkspaceDeb
          * Note: serverUtils.requestWorkspaceInformation only retrieves one folder for multi-root workspaces. Therefore, generator will be incorrect for all folders
          * except the first in a workspace. Currently, this only works if the requested folder is the same as the server's solution path or folder.
          */
-        return projects?.filter((p) => {
+        const projectsInWorkspace = projects?.filter((p) => {
             // Get absolute paths of current folder and server folder.
             const workspaceFolder = path.resolve(workspacePath.fsPath);
             const projectFolder = path.dirname(p.projectPath);
             return isSubfolderOf(projectFolder, workspaceFolder);
         });
+        return projectsInWorkspace;
     }
 }


### PR DESCRIPTION
Was testing project loading in O# and discovered this issue.  Not sure how long it has been broken.   Shoud only affect O#.