### PR TITLE
Fix a typo in package.nls.json

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -52,13 +52,13 @@
   "debuggers.dotnet.launch.launchConfigurationId.description": "The launch configuration id to use. Empty string will use the current active configuration.",
   "viewsWelcome.debug.contents": {
     "message": "[Generate C# Assets for Build and Debug](command:dotnet.generateAssets)\n\nTo learn more about launch.json, see [Configuring launch.json for C# debugging](https://aka.ms/VSCode-CS-LaunchJson).",
-    "comments": [
+    "comment": [
       "Do not translate 'command:dotnet.generateAssets' and 'https://aka.ms/VSCode-CS-LaunchJson'"
     ]
   },
   "generateOptionsSchema.program.markdownDescription": {
     "message": "Path to the application dll or .NET Core host executable to launch.\nThis property normally takes the form: `${workspaceFolder}/bin/Debug/(target-framework)/(project-name.dll)`\n\nExample: `${workspaceFolder}/bin/Debug/netcoreapp1.1/MyProject.dll`\n\nWhere:\n`(target-framework)` is the framework that the debugged project is being built for. This is normally found in the project file as the `TargetFramework` property.\n\n`(project-name.dll)` is the name of debugged project's build output dll. This is normally the same as the project file name but with a '.dll' extension.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
@@ -67,26 +67,26 @@
   "generateOptionsSchema.args.1.description": "Stringified version of command line arguments passed to the program.",
   "generateOptionsSchema.stopAtEntry.markdownDescription": {
     "message": "If true, the debugger should stop at the entry point of the target. This option defaults to `false`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.launchBrowser.description": "Describes options to launch a web browser as part of launch",
   "generateOptionsSchema.launchBrowser.enabled.description": {
     "message": "Whether web browser launch is enabled. This option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.launchBrowser.args.description": {
     "message": "The arguments to pass to the command to open the browser. This is used only if the platform-specific element (`osx`, `linux` or `windows`) doesn't specify a value for `args`. Use ${auto-detect-url} to automatically use the address the server is listening to.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.launchBrowser.osx.description": {
     "message": "OSX-specific web launch configuration options. By default, this will start the browser using `open`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
@@ -94,7 +94,7 @@
   "generateOptionsSchema.launchBrowser.osx.args.description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
   "generateOptionsSchema.launchBrowser.linux.description": {
     "message": "Linux-specific web launch configuration options. By default, this will start the browser using `xdg-open`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
@@ -102,7 +102,7 @@
   "generateOptionsSchema.launchBrowser.linux.args.description": "The arguments to pass to the command to open the browser. Use ${auto-detect-url} to automatically use the address the server is listening to.",
   "generateOptionsSchema.launchBrowser.windows.description": {
     "message": "Windows-specific web launch configuration options. By default, this will start the browser using `cmd /c start`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
@@ -111,14 +111,14 @@
   "generateOptionsSchema.env.description": "Environment variables passed to the program.",
   "generateOptionsSchema.envFile.markdownDescription": {
     "message": "Environment variables passed to the program by a file. E.g. `${workspaceFolder}/.env`",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.console.markdownDescription": "When launching console projects, indicates which console the target program should be launched into.",
   "generateOptionsSchema.console.settingsDescription": {
     "message": "**Note:** _This option is only used for the `dotnet` debug configuration type_.\n\nWhen launching console projects, indicates which console the target program should be launched into.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
@@ -127,82 +127,82 @@
   "generateOptionsSchema.console.externalTerminal.enumDescription": "External terminal that can be configured via user settings.",
   "generateOptionsSchema.externalConsole.markdownDescription": {
     "message": "Attribute `externalConsole` is deprecated, use `console` instead. This option defaults to `false`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.launchSettingsFilePath.markdownDescription": {
     "message": "The path to a launchSettings.json file. If this isn't set, the debugger will search in `{cwd}/Properties/launchSettings.json`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.launchSettingsProfile.description": "If specified, indicates the name of the profile in launchSettings.json to use. This is ignored if launchSettings.json is not found. launchSettings.json will be read from the path specified should be the 'launchSettingsFilePath' property, or {cwd}/Properties/launchSettings.json if that isn't set. If this is set to null or an empty string then launchSettings.json is ignored. If this value is not specified the first 'Project' profile will be used.",
   "generateOptionsSchema.sourceFileMap.markdownDescription": {
     "message": "Maps build-time paths to local source locations. All instances of build-time path will be replaced with the local source path.\n\nExample:\n\n`{\"<build-path>\":\"<local-source-path>\"}`",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.justMyCode.markdownDescription": "When enabled (the default), the debugger only displays and steps into user code (\"My Code\"), ignoring system code and other code that is optimized or that does not have debugging symbols. [More information](https://aka.ms/VSCode-CS-LaunchJson#just-my-code)",
   "generateOptionsSchema.requireExactSource.markdownDescription": {
     "message": "Flag to require current source code to match the pdb. This option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.enableStepFiltering.markdownDescription": {
     "message": "Flag to enable stepping over Properties and Operators. This option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.logging.description": "Flags to determine what types of messages should be logged to the output window.",
   "generateOptionsSchema.logging.exceptions.markdownDescription": {
     "message": "Flag to determine whether exception messages should be logged to the output window. This option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.logging.moduleLoad.markdownDescription": {
     "message": "Flag to determine whether module load events should be logged to the output window. This option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.logging.programOutput.markdownDescription": {
     "message": "Flag to determine whether program output should be logged to the output window when not using an external console. This option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.logging.engineLogging.markdownDescription": {
     "message": "Flag to determine whether diagnostic engine logs should be logged to the output window. This option defaults to `false`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.logging.browserStdOut.markdownDescription": {
     "message": "Flag to determine if stdout text from the launching the web browser should be logged to the output window. This option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.logging.elapsedTiming.markdownDescription": {
     "message": "If true, engine logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took. This option defaults to `false`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.logging.threadExit.markdownDescription": {
     "message": "Controls if a message is logged when a thread in the target process exits. This option defaults to `false`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.logging.processExit.markdownDescription": {
     "message": "Controls if a message is logged when the target process exits, or debugging is stopped. This option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
@@ -239,21 +239,21 @@
   "generateOptionsSchema.symbolOptions.description": "Options to control how symbols (.pdb files) are found and loaded.",
   "generateOptionsSchema.symbolOptions.searchPaths.description": {
     "message": "Array of symbol server URLs (example: http\u200b://MyExampleSymbolServer) or directories (example: /build/symbols) to search for .pdb files. These directories will be searched in addition to the default locations -- next to the module and the path where the pdb was originally dropped to.",
-    "comments": [
+    "comment": [
       "We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. Please do not translate or localized the URL.",
       "{Locked='(example: http\u200b://MyExampleSymbolServer)'}"
     ]
   },
   "generateOptionsSchema.symbolOptions.searchMicrosoftSymbolServer.description": {
     "message": "If 'true' the Microsoft Symbol server (https\u200b://msdl.microsoft.com\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
-    "comments": [
+    "comment": [
       "We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. Please do not translate or localized the URL.",
       "{Locked='(https\u200b://msdl.microsoft.com\u200b/download/symbols)'}"
     ]
   },
   "generateOptionsSchema.symbolOptions.searchNuGetOrgSymbolServer.description": {
     "message": "If 'true' the NuGet.org symbol server (https\u200b://symbols.nuget.org\u200b/download/symbols) is added to the symbols search path. If unspecified, this option defaults to 'false'.",
-    "comments": [
+    "comment": [
       "We use '\u200b' (unicode zero-length space character) to break VS Code's URL detection regex for URLs that are examples. Please do not translate or localized the URL.",
       "{Locked='(https\u200b://symbols.nuget.org\u200b/download/symbols)'}"
     ]
@@ -269,7 +269,7 @@
   "generateOptionsSchema.sourceLinkOptions.markdownDescription": "Options to control how Source Link connects to web servers. [More information](https://aka.ms/VSCode-CS-LaunchJson#source-link-options)",
   "generateOptionsSchema.sourceLinkOptions.additionalItems.enabled.markdownDescription": {
     "message": "Is Source Link enabled for this URL? If unspecified, this option defaults to `true`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
@@ -277,31 +277,31 @@
   "generateOptionsSchema.targetOutputLogPath.description": "When set, text that the target application writes to stdout and stderr (ex: Console.WriteLine) will be saved to the specified file. This option is ignored if console is set to something other than internalConsole. E.g. '${workspaceFolder}/out.txt'",
   "generateOptionsSchema.targetArchitecture.markdownDescription": {
     "message": "[Only supported in local macOS debugging]\n\nThe architecture of the debuggee. This will automatically be detected unless this parameter is set. Allowed values are `x86_64` or `arm64`.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.checkForDevCert.description": {
     "message": "If you are launching a web project on Windows or macOS and this is enabled, the debugger will check if the computer has a self-signed HTTPS certificate used to develop web servers running on https endpoints. If unspecified, defaults to true when `serverReadyAction` is set. This option does nothing on Linux, VS Code remote, and VS Code Web UI scenarios. If the HTTPS certificate is not found or isn't trusted, the user will be prompted to install/trust it.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.processName.markdownDescription": {
     "message": "The process name to attach to. If this is used, `processId` should not be used.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.processId.0.markdownDescription": {
     "message": "The process id to attach to. Use \"\" to get a list of running processes to attach to. If `processId` used, `processName` should not be used.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
   "generateOptionsSchema.processId.1.markdownDescription": {
     "message": "The process id to attach to. Use \"\" to get a list of running processes to attach to. If `processId` used, `processName` should not be used.",
-    "comments": [
+    "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   }

--- a/src/tools/generateOptionsSchema.ts
+++ b/src/tools/generateOptionsSchema.ts
@@ -176,7 +176,7 @@ function generateLocForProperty(key: string, prop: any, keyToLocString: any): vo
             if (comments.length > 0) {
                 keyToLocString[descriptionKey] = {
                     message: prop.description,
-                    comments: comments,
+                    comment: comments,
                 };
             } else {
                 keyToLocString[descriptionKey] = prop.description;
@@ -192,7 +192,7 @@ function generateLocForProperty(key: string, prop: any, keyToLocString: any): vo
             if (comments.length > 0) {
                 keyToLocString[markdownDescriptionKey] = {
                     message: prop.markdownDescription,
-                    comments: comments,
+                    comment: comments,
                 };
             } else {
                 keyToLocString[markdownDescriptionKey] = prop.markdownDescription;
@@ -208,7 +208,7 @@ function generateLocForProperty(key: string, prop: any, keyToLocString: any): vo
             if (comments.length > 0) {
                 keyToLocString[settingsDescriptionKey] = {
                     message: prop.settingsDescription,
-                    comments: comments,
+                    comment: comments,
                 };
             } else {
                 keyToLocString[settingsDescriptionKey] = prop.settingsDescription;
@@ -224,7 +224,7 @@ function generateLocForProperty(key: string, prop: any, keyToLocString: any): vo
             if (comments.length > 0) {
                 keyToLocString[descriptionKey] = {
                     message: prop.deprecationMessage,
-                    comments: comments,
+                    comment: comments,
                 };
             } else {
                 keyToLocString[descriptionKey] = prop.deprecationMessage;


### PR DESCRIPTION
We still get many loc PRs like https://github.com/dotnet/vscode-csharp/pull/6383
After changing `comments` to `comment` I see the `lock` block is added to the generated xlf files.
![image](https://github.com/dotnet/vscode-csharp/assets/24360909/d71f6ac2-f264-4002-b037-b0c053a0182f)
So it should address the issue on our side.