### PR TITLE
Add hiddenWhen to debuggers in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "webpack-cli": "4.6.0"
       },
       "engines": {
-        "vscode": "^1.73.0"
+        "vscode": "^1.83.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "webpack-cli": "4.6.0"
       },
       "engines": {
-        "vscode": "^1.83.0"
+        "vscode": "^1.73.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -872,7 +872,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.73.0"
+    "vscode": "^1.83.0"
   },
   "activationEvents": [
     "onDebugInitialConfigurations",
@@ -1937,6 +1937,7 @@
       {
         "type": "coreclr",
         "label": ".NET 5+ and .NET Core",
+        "hiddenWhen": "dotnet.debug.serviceBrokerAvailable",
         "languages": [
           "csharp",
           "razor",
@@ -3091,6 +3092,7 @@
       {
         "type": "clr",
         "when": "workspacePlatform == windows",
+        "hiddenWhen": "dotnet.debug.serviceBrokerAvailable",
         "label": ".NET Framework 4.x",
         "languages": [
           "csharp",
@@ -4138,6 +4140,7 @@
       {
         "type": "blazorwasm",
         "label": "Blazor WebAssembly Debug",
+        "hiddenWhen": "dotnet.debug.serviceBrokerAvailable",
         "initialConfigurations": [
           {
             "type": "blazorwasm",

--- a/package.json
+++ b/package.json
@@ -872,7 +872,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.83.0"
+    "vscode": "^1.73.0"
   },
   "activationEvents": [
     "onDebugInitialConfigurations",


### PR DESCRIPTION
This PR adds the 'hiddenWhen' attribute to debuggers contributed by the C# Extension.

Related: https://github.com/microsoft/vscode/pull/193157

Fixes: 
- https://github.com/microsoft/vscode-dotnettools/issues/14 
- https://github.com/microsoft/vscode-dotnettools/issues/512 
- https://github.com/microsoft/vscode-dotnettools/issues/513


Note: This PR requires the VS Code September 2023 Update