### PR TITLE
Unit test debugging: wait for attach complete

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -54,6 +54,7 @@ import { registerRazorCommands } from './razorCommands';
 import { registerOnAutoInsert } from './onAutoInsert';
 import { commonOptions, languageServerOptions, omnisharpOptions } from '../shared/options';
 import { NamedPipeInformation } from './roslynProtocol';
+import { IDisposable } from '../disposable';
 
 let _channel: vscode.OutputChannel;
 let _traceChannel: vscode.OutputChannel;
@@ -615,6 +616,46 @@ export class RoslynLanguageServer {
         );
     }
 
+    // eslint-disable-next-line @typescript-eslint/promise-function-async
+    private WaitForAttachCompleteAsync(attachRequestId: string): Promise<boolean> {
+        return new Promise<boolean>((resolve) => {
+            let didTerminateRegistation: IDisposable | null = null;
+            let customEventReg: IDisposable | null = null;
+            let isComplete = false;
+
+            const fire = (result: boolean) => {
+                if (isComplete === false) {
+                    isComplete = true;
+                    didTerminateRegistation?.dispose();
+                    customEventReg?.dispose();
+                    resolve(result);
+                }
+            };
+
+            didTerminateRegistation = vscode.debug.onDidTerminateDebugSession((session: vscode.DebugSession) => {
+                if (session.configuration.attachRequestId !== attachRequestId) {
+                    return;
+                }
+
+                fire(false);
+            });
+
+            customEventReg = vscode.debug.onDidReceiveDebugSessionCustomEvent(
+                (event: vscode.DebugSessionCustomEvent) => {
+                    if (event.session.configuration.attachRequestId !== attachRequestId) {
+                        return;
+                    }
+
+                    if (event.event !== 'attachComplete') {
+                        return;
+                    }
+
+                    fire(true);
+                }
+            );
+        });
+    }
+
     private registerDebuggerAttach() {
         this._languageClient.onRequest<RoslynProtocol.DebugAttachParams, RoslynProtocol.DebugAttachResult, void>(
             RoslynProtocol.DebugAttachRequest.type,
@@ -622,16 +663,22 @@ export class RoslynLanguageServer {
                 const debugOptions = commonOptions.unitTestDebuggingOptions;
                 const debugConfiguration: vscode.DebugConfiguration = {
                     ...debugOptions,
-                    name: '.NET Core Attach',
+                    name: '.NET Debug Unit test',
                     type: 'coreclr',
                     request: 'attach',
                     processId: request.processId,
+                    attachRequestId: randomUUID(),
                 };
 
-                const result = await vscode.debug.startDebugging(undefined, debugConfiguration, undefined);
-                return {
-                    didAttach: result,
-                };
+                const waitCompletePromise = this.WaitForAttachCompleteAsync(debugConfiguration.attachRequestId);
+
+                let success = await vscode.debug.startDebugging(undefined, debugConfiguration, undefined);
+                if (!success) {
+                    return { didAttach: false };
+                }
+
+                success = await waitCompletePromise;
+                return { didAttach: success };
             }
         );
     }


### PR DESCRIPTION
This PR adds code to the Roslyn unit test debugging code to wait for attach complete. This addresses #5968.