### PR TITLE
Update debugger options for v2.0.3 of the debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1656,11 +1656,6 @@
             "markdownDescription": "%generateOptionsSchema.logging.programOutput.markdownDescription%",
             "default": true
           },
-          "csharp.debug.logging.engineLogging": {
-            "type": "boolean",
-            "markdownDescription": "%generateOptionsSchema.logging.engineLogging.markdownDescription%",
-            "default": false
-          },
           "csharp.debug.logging.browserStdOut": {
             "type": "boolean",
             "markdownDescription": "%generateOptionsSchema.logging.browserStdOut.markdownDescription%",
@@ -1680,6 +1675,63 @@
             "type": "boolean",
             "markdownDescription": "%generateOptionsSchema.logging.processExit.markdownDescription%",
             "default": true
+          },
+          "csharp.debug.logging.engineLogging": {
+            "type": "boolean",
+            "deprecationMessage": "%generateOptionsSchema.logging.engineLogging.deprecationMessage%",
+            "default": false
+          },
+          "csharp.debug.logging.diagnosticsLog.protocolMessages": {
+            "type": "boolean",
+            "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.protocolMessages.markdownDescription%",
+            "default": false
+          },
+          "csharp.debug.logging.diagnosticsLog.dispatcherMessages": {
+            "type": "string",
+            "enum": [
+              "none",
+              "error",
+              "important",
+              "normal"
+            ],
+            "enumDescriptions": [
+              "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.none.enumDescription%",
+              "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.error.enumDescription%",
+              "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.important.enumDescription%",
+              "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.normal.enumDescription%"
+            ],
+            "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.markdownDescription%",
+            "default": "none"
+          },
+          "csharp.debug.logging.diagnosticsLog.debugEngineAPITracing": {
+            "type": "string",
+            "enum": [
+              "none",
+              "error",
+              "all"
+            ],
+            "enumDescriptions": [
+              "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.none.enumDescription%",
+              "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.error.enumDescription%",
+              "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.all.enumDescription%"
+            ],
+            "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.markdownDescription%",
+            "default": "none"
+          },
+          "csharp.debug.logging.diagnosticsLog.debugRuntimeEventTracing": {
+            "type": "boolean",
+            "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugRuntimeEventTracing.markdownDescription%",
+            "default": false
+          },
+          "csharp.debug.logging.diagnosticsLog.expressionEvaluationTracing": {
+            "type": "boolean",
+            "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.expressionEvaluationTracing.markdownDescription%",
+            "default": false
+          },
+          "csharp.debug.logging.diagnosticsLog.startDebuggingTracing": {
+            "type": "boolean",
+            "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.startDebuggingTracing.markdownDescription%",
+            "default": false
           },
           "csharp.debug.suppressJITOptimizations": {
             "type": "boolean",
@@ -2181,11 +2233,6 @@
                     "markdownDescription": "%generateOptionsSchema.logging.programOutput.markdownDescription%",
                     "default": true
                   },
-                  "engineLogging": {
-                    "type": "boolean",
-                    "markdownDescription": "%generateOptionsSchema.logging.engineLogging.markdownDescription%",
-                    "default": false
-                  },
                   "browserStdOut": {
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.browserStdOut.markdownDescription%",
@@ -2205,6 +2252,71 @@
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.processExit.markdownDescription%",
                     "default": true
+                  },
+                  "engineLogging": {
+                    "type": "boolean",
+                    "deprecationMessage": "%generateOptionsSchema.logging.engineLogging.deprecationMessage%",
+                    "default": false
+                  },
+                  "diagnosticsLog": {
+                    "description": "%generateOptionsSchema.logging.diagnosticsLog.description%",
+                    "type": "object",
+                    "required": [],
+                    "default": {},
+                    "properties": {
+                      "protocolMessages": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.protocolMessages.markdownDescription%",
+                        "default": false
+                      },
+                      "dispatcherMessages": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "error",
+                          "important",
+                          "normal"
+                        ],
+                        "enumDescriptions": [
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.none.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.error.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.important.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.normal.enumDescription%"
+                        ],
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.markdownDescription%",
+                        "default": "none"
+                      },
+                      "debugEngineAPITracing": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "error",
+                          "all"
+                        ],
+                        "enumDescriptions": [
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.none.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.error.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.all.enumDescription%"
+                        ],
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.markdownDescription%",
+                        "default": "none"
+                      },
+                      "debugRuntimeEventTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugRuntimeEventTracing.markdownDescription%",
+                        "default": false
+                      },
+                      "expressionEvaluationTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.expressionEvaluationTracing.markdownDescription%",
+                        "default": false
+                      },
+                      "startDebuggingTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.startDebuggingTracing.markdownDescription%",
+                        "default": false
+                      }
+                    }
                   }
                 }
               },
@@ -2621,11 +2733,6 @@
                     "markdownDescription": "%generateOptionsSchema.logging.programOutput.markdownDescription%",
                     "default": true
                   },
-                  "engineLogging": {
-                    "type": "boolean",
-                    "markdownDescription": "%generateOptionsSchema.logging.engineLogging.markdownDescription%",
-                    "default": false
-                  },
                   "browserStdOut": {
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.browserStdOut.markdownDescription%",
@@ -2645,6 +2752,71 @@
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.processExit.markdownDescription%",
                     "default": true
+                  },
+                  "engineLogging": {
+                    "type": "boolean",
+                    "deprecationMessage": "%generateOptionsSchema.logging.engineLogging.deprecationMessage%",
+                    "default": false
+                  },
+                  "diagnosticsLog": {
+                    "description": "%generateOptionsSchema.logging.diagnosticsLog.description%",
+                    "type": "object",
+                    "required": [],
+                    "default": {},
+                    "properties": {
+                      "protocolMessages": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.protocolMessages.markdownDescription%",
+                        "default": false
+                      },
+                      "dispatcherMessages": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "error",
+                          "important",
+                          "normal"
+                        ],
+                        "enumDescriptions": [
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.none.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.error.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.important.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.normal.enumDescription%"
+                        ],
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.markdownDescription%",
+                        "default": "none"
+                      },
+                      "debugEngineAPITracing": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "error",
+                          "all"
+                        ],
+                        "enumDescriptions": [
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.none.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.error.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.all.enumDescription%"
+                        ],
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.markdownDescription%",
+                        "default": "none"
+                      },
+                      "debugRuntimeEventTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugRuntimeEventTracing.markdownDescription%",
+                        "default": false
+                      },
+                      "expressionEvaluationTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.expressionEvaluationTracing.markdownDescription%",
+                        "default": false
+                      },
+                      "startDebuggingTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.startDebuggingTracing.markdownDescription%",
+                        "default": false
+                      }
+                    }
                   }
                 }
               },
@@ -3337,11 +3509,6 @@
                     "markdownDescription": "%generateOptionsSchema.logging.programOutput.markdownDescription%",
                     "default": true
                   },
-                  "engineLogging": {
-                    "type": "boolean",
-                    "markdownDescription": "%generateOptionsSchema.logging.engineLogging.markdownDescription%",
-                    "default": false
-                  },
                   "browserStdOut": {
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.browserStdOut.markdownDescription%",
@@ -3361,6 +3528,71 @@
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.processExit.markdownDescription%",
                     "default": true
+                  },
+                  "engineLogging": {
+                    "type": "boolean",
+                    "deprecationMessage": "%generateOptionsSchema.logging.engineLogging.deprecationMessage%",
+                    "default": false
+                  },
+                  "diagnosticsLog": {
+                    "description": "%generateOptionsSchema.logging.diagnosticsLog.description%",
+                    "type": "object",
+                    "required": [],
+                    "default": {},
+                    "properties": {
+                      "protocolMessages": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.protocolMessages.markdownDescription%",
+                        "default": false
+                      },
+                      "dispatcherMessages": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "error",
+                          "important",
+                          "normal"
+                        ],
+                        "enumDescriptions": [
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.none.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.error.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.important.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.normal.enumDescription%"
+                        ],
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.markdownDescription%",
+                        "default": "none"
+                      },
+                      "debugEngineAPITracing": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "error",
+                          "all"
+                        ],
+                        "enumDescriptions": [
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.none.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.error.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.all.enumDescription%"
+                        ],
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.markdownDescription%",
+                        "default": "none"
+                      },
+                      "debugRuntimeEventTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugRuntimeEventTracing.markdownDescription%",
+                        "default": false
+                      },
+                      "expressionEvaluationTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.expressionEvaluationTracing.markdownDescription%",
+                        "default": false
+                      },
+                      "startDebuggingTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.startDebuggingTracing.markdownDescription%",
+                        "default": false
+                      }
+                    }
                   }
                 }
               },
@@ -3777,11 +4009,6 @@
                     "markdownDescription": "%generateOptionsSchema.logging.programOutput.markdownDescription%",
                     "default": true
                   },
-                  "engineLogging": {
-                    "type": "boolean",
-                    "markdownDescription": "%generateOptionsSchema.logging.engineLogging.markdownDescription%",
-                    "default": false
-                  },
                   "browserStdOut": {
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.browserStdOut.markdownDescription%",
@@ -3801,6 +4028,71 @@
                     "type": "boolean",
                     "markdownDescription": "%generateOptionsSchema.logging.processExit.markdownDescription%",
                     "default": true
+                  },
+                  "engineLogging": {
+                    "type": "boolean",
+                    "deprecationMessage": "%generateOptionsSchema.logging.engineLogging.deprecationMessage%",
+                    "default": false
+                  },
+                  "diagnosticsLog": {
+                    "description": "%generateOptionsSchema.logging.diagnosticsLog.description%",
+                    "type": "object",
+                    "required": [],
+                    "default": {},
+                    "properties": {
+                      "protocolMessages": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.protocolMessages.markdownDescription%",
+                        "default": false
+                      },
+                      "dispatcherMessages": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "error",
+                          "important",
+                          "normal"
+                        ],
+                        "enumDescriptions": [
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.none.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.error.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.important.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.normal.enumDescription%"
+                        ],
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.markdownDescription%",
+                        "default": "none"
+                      },
+                      "debugEngineAPITracing": {
+                        "type": "string",
+                        "enum": [
+                          "none",
+                          "error",
+                          "all"
+                        ],
+                        "enumDescriptions": [
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.none.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.error.enumDescription%",
+                          "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.all.enumDescription%"
+                        ],
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.markdownDescription%",
+                        "default": "none"
+                      },
+                      "debugRuntimeEventTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.debugRuntimeEventTracing.markdownDescription%",
+                        "default": false
+                      },
+                      "expressionEvaluationTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.expressionEvaluationTracing.markdownDescription%",
+                        "default": false
+                      },
+                      "startDebuggingTracing": {
+                        "type": "boolean",
+                        "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.startDebuggingTracing.markdownDescription%",
+                        "default": false
+                      }
+                    }
                   }
                 }
               },

--- a/package.nls.json
+++ b/package.nls.json
@@ -178,12 +178,6 @@
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
-  "generateOptionsSchema.logging.engineLogging.markdownDescription": {
-    "message": "Flag to determine whether diagnostic engine logs should be logged to the output window. This option defaults to `false`.",
-    "comment": [
-      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
-    ]
-  },
   "generateOptionsSchema.logging.browserStdOut.markdownDescription": {
     "message": "Flag to determine if stdout text from the launching the web browser should be logged to the output window. This option defaults to `true`.",
     "comment": [
@@ -191,7 +185,7 @@
     ]
   },
   "generateOptionsSchema.logging.elapsedTiming.markdownDescription": {
-    "message": "If true, engine logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took. This option defaults to `false`.",
+    "message": "If true, protocol message logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took. This option defaults to `false`.",
     "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
@@ -204,6 +198,51 @@
   },
   "generateOptionsSchema.logging.processExit.markdownDescription": {
     "message": "Controls if a message is logged when the target process exits, or debugging is stopped. This option defaults to `true`.",
+    "comment": [
+      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+    ]
+  },
+  "generateOptionsSchema.logging.engineLogging.deprecationMessage": "The setting 'logging.engineLogging' has been deprecated in favor of 'logging.diagnosticsLog.protocolMessages'.",
+  "generateOptionsSchema.logging.diagnosticsLog.description": "Settings to control which messages are printed to the output window from the debugger's diagnostics log. This log is meant to help troubleshoot problems with the debugger.",
+  "generateOptionsSchema.logging.diagnosticsLog.protocolMessages.markdownDescription": {
+    "message": "Flag to determine whether DAP protocol messages exchanged between the C# debugger and the UI should be logged to the output window. This option defaults to `false`.",
+    "comment": [
+      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+    ]
+  },
+  "generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.markdownDescription": {
+    "message": "Controls which messages are printed to the output window from the debugger's dispatcher. If not specified, this will default to `none` unless one of the verbose log settings are enabled (`debugEngineAPITracing`, `debugRuntimeEventTracing`, `expressionEvaluationTracing` or `startDebuggingTracing`), in which case the default changes to `normal`.",
+    "comment": [
+      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+    ]
+  },
+  "generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.none.enumDescription": "Do not print additional diagnostic messages.",
+  "generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.error.enumDescription": "Print error-level diagnostic messages.",
+  "generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.important.enumDescription": "Print important diagnostic messages.",
+  "generateOptionsSchema.logging.diagnosticsLog.dispatcherMessages.normal.enumDescription": "Print all non-verbose diagnostic messages.",
+  "generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.markdownDescription": {
+    "message": "Controls if API calls to Microsoft.VisualStudio.Debugger.Engine/vsdebugeng.h should be printed to the output window. This option defaults to `none`.",
+    "comment": [
+      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+    ]
+  },
+  "generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.none.enumDescription": "Disable tracing API calls",
+  "generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.error.enumDescription": "Print failures from debugger API calls.",
+  "generateOptionsSchema.logging.diagnosticsLog.debugEngineAPITracing.all.enumDescription": "Print all debugger API calls. This is very verbose.",
+  "generateOptionsSchema.logging.diagnosticsLog.debugRuntimeEventTracing.markdownDescription": {
+    "message": "Flag to determine whether verbose tracing for events raised by the underlying runtime should be enabled. This option defaults to `false`.",
+    "comment": [
+      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+    ]
+  },
+  "generateOptionsSchema.logging.diagnosticsLog.expressionEvaluationTracing.markdownDescription": {
+    "message": "Flag to determine whether verbose tracing for expression evaluation should be enabled. This option defaults to `false`.",
+    "comment": [
+      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+    ]
+  },
+  "generateOptionsSchema.logging.diagnosticsLog.startDebuggingTracing.markdownDescription": {
+    "message": "Flag to determine whether verbose tracing for start debugging should be enabled. This option defaults to `false`.",
     "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -141,6 +141,57 @@
         }
       }
     },
+    "DiagnosticsLog": {
+      "type": "object",
+      "required": [],
+      "default": {},
+      "description": "Settings to control which messages are printed to the output window from the debugger's diagnostics log. This log is meant to help troubleshoot problems with the debugger.",
+      "properties": {
+        "protocolMessages": {
+          "type": "boolean",
+          "markdownDescription": "Flag to determine whether DAP protocol messages exchanged between the C# debugger and the UI should be logged to the output window. This option defaults to `false`.",
+          "default": false
+        },
+        "dispatcherMessages": {
+          "type": "string",
+          "enum": [ "none", "error", "important", "normal" ],
+          "enumDescriptions": [
+            "Do not print additional diagnostic messages.",
+            "Print error-level diagnostic messages.",
+            "Print important diagnostic messages.",
+            "Print all non-verbose diagnostic messages."
+          ],
+          "markdownDescription": "Controls which messages are printed to the output window from the debugger's dispatcher. If not specified, this will default to `none` unless one of the verbose log settings are enabled (`debugEngineAPITracing`, `debugRuntimeEventTracing`, `expressionEvaluationTracing` or `startDebuggingTracing`), in which case the default changes to `normal`.",
+          "default": "none"
+        },
+        "debugEngineAPITracing": {
+          "type": "string",
+          "enum": [ "none", "error", "all" ],
+          "enumDescriptions": [
+            "Disable tracing API calls",
+            "Print failures from debugger API calls.",
+            "Print all debugger API calls. This is very verbose."
+          ],
+          "markdownDescription": "Controls if API calls to Microsoft.VisualStudio.Debugger.Engine/vsdebugeng.h should be printed to the output window. This option defaults to `none`.",
+          "default": "none"
+        },
+        "debugRuntimeEventTracing": {
+          "type": "boolean",
+          "markdownDescription": "Flag to determine whether verbose tracing for events raised by the underlying runtime should be enabled. This option defaults to `false`.",
+          "default": false
+        },
+        "expressionEvaluationTracing": {
+          "type": "boolean",
+          "markdownDescription": "Flag to determine whether verbose tracing for expression evaluation should be enabled. This option defaults to `false`.",
+          "default": false
+        },
+        "startDebuggingTracing": {
+          "type": "boolean",
+          "markdownDescription": "Flag to determine whether verbose tracing for start debugging should be enabled. This option defaults to `false`.",
+          "default": false
+        }
+      }
+    },
     "Logging": {
       "type": "object",
       "required": [],
@@ -162,11 +213,6 @@
           "markdownDescription": "Flag to determine whether program output should be logged to the output window when not using an external console. This option defaults to `true`.",
           "default": true
         },
-        "engineLogging": {
-          "type": "boolean",
-          "markdownDescription": "Flag to determine whether diagnostic engine logs should be logged to the output window. This option defaults to `false`.",
-          "default": false
-        },
         "browserStdOut": {
           "type": "boolean",
           "markdownDescription": "Flag to determine if stdout text from the launching the web browser should be logged to the output window. This option defaults to `true`.",
@@ -174,7 +220,7 @@
         },
         "elapsedTiming": {
           "type": "boolean",
-          "markdownDescription": "If true, engine logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took. This option defaults to `false`.",
+          "markdownDescription": "If true, protocol message logging will include `adapterElapsedTime` and `engineElapsedTime` properties to indicate the amount of time, in microseconds, that a request took. This option defaults to `false`.",
           "default": false
         },
         "threadExit": {
@@ -186,6 +232,15 @@
           "type": "boolean",
           "markdownDescription": "Controls if a message is logged when the target process exits, or debugging is stopped. This option defaults to `true`.",
           "default": true
+        },
+        "engineLogging": {
+          "type": "boolean",
+          "deprecationMessage": "The setting 'logging.engineLogging' has been deprecated in favor of 'logging.diagnosticsLog.protocolMessages'.",
+          "default": false
+        },
+        "diagnosticsLog": {
+          "$ref": "#/definitions/DiagnosticsLog",
+          "description": "Settings to control which messages are printed to the output window from the debugger's diagnostics log. This log is meant to help troubleshoot problems with the debugger."
         }
       }
     },


### PR DESCRIPTION
Debugger version 2.0.3 improved support for logging. This PR updates the launch options schema to match what is now supported.