### PR TITLE
[Razor] Register `razorFormatNewFileHandler`

### DIFF
--- a/src/razor/src/extension.ts
+++ b/src/razor/src/extension.ts
@@ -189,7 +189,7 @@ export async function activate(
                 documentManager,
                 logger
             );
-            const formatNewFileHandler = new RazorFormatNewFileHandler(
+            const razorFormatNewFileHandler = new RazorFormatNewFileHandler(
                 documentSynchronizer,
                 languageServerClient,
                 languageServiceClient,
@@ -240,7 +240,7 @@ export async function activate(
                 razorDiagnosticHandler.register(),
                 codeActionsHandler.register(),
                 razorSimplifyMethodHandler.register(),
-                formatNewFileHandler.register(),
+                razorFormatNewFileHandler.register(),
             ]);
         });
 

--- a/src/razor/src/extension.ts
+++ b/src/razor/src/extension.ts
@@ -44,6 +44,7 @@ import { RazorSignatureHelpProvider } from './signatureHelp/razorSignatureHelpPr
 import { TelemetryReporter } from './telemetryReporter';
 import { RazorDiagnosticHandler } from './diagnostics/razorDiagnosticHandler';
 import { RazorSimplifyMethodHandler } from './simplify/razorSimplifyMethodHandler';
+import { RazorFormatNewFileHandler } from './formatNewFile/razorFormatNewFileHandler';
 
 // We specifically need to take a reference to a particular instance of the vscode namespace,
 // otherwise providers attempt to operate on the null extension.
@@ -188,6 +189,13 @@ export async function activate(
                 documentManager,
                 logger
             );
+            const formatNewFileHandler = new RazorFormatNewFileHandler(
+                documentSynchronizer,
+                languageServerClient,
+                languageServiceClient,
+                documentManager,
+                logger
+            );
 
             localRegistrations.push(
                 languageConfiguration.register(),
@@ -232,6 +240,7 @@ export async function activate(
                 razorDiagnosticHandler.register(),
                 codeActionsHandler.register(),
                 razorSimplifyMethodHandler.register(),
+                formatNewFileHandler.register(),
             ]);
         });
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1891128

https://github.com/dotnet/vscode-csharp/pull/6329 added `razorFormatNewFileHandler` but we needed to register it for the handler to take effect.