### PR TITLE
Fix Razor completion bugs

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -110,6 +110,7 @@
   "Unexpected error when attaching to C# preview window.": "Unexpected error when attaching to C# preview window.",
   "Razor C# copied to clipboard": "Razor C# copied to clipboard",
   "Copy C#": "Copy C#",
+  "{0} Keyword": "{0} Keyword",
   "Unexpected completion trigger kind: {0}": "Unexpected completion trigger kind: {0}",
   "1 reference": "1 reference",
   "{0} references": "{0} references",

--- a/src/razor/src/completion/provisionalCompletionOrchestrator.ts
+++ b/src/razor/src/completion/provisionalCompletionOrchestrator.ts
@@ -134,7 +134,8 @@ export class ProvisionalCompletionOrchestrator {
             htmlPosition,
             provisionalPosition,
             completionContext,
-            projection.languageKind
+            projection.languageKind,
+            newDocument
         );
 
         // We track when we add provisional dots to avoid doing unnecessary work on commonly invoked events.


### PR DESCRIPTION
These fixes are both pretty hacky, but I believe we lack reasonable alternatives at the moment.

1) Fixes bug where all completion item icons are incorrect (notice `ushort` appears with the snippet icon instead of the keyword icon):
![image](https://github.com/dotnet/vscode-csharp/assets/16968319/9d6e3ee8-458a-489f-939c-59c7a6021e28)

This is because we're deserializing the LSP completion item type returned by Roslyn into a VS Code completion item type. Notice that the `CompletionItemKinds` on both types are off by one:
![image](https://github.com/dotnet/vscode-csharp/assets/16968319/f1bfb6f2-36bb-4d13-88b6-cb3eb660bfc4)

2) Fixes https://github.com/dotnet/vscode-csharp/issues/6199

We technically have the same bug in VS, but since we have snippets available there (snippets are currently unavailable for Razor in VS Code), we still get `using` in the completion list (screenshot below is the current experience in VS):
![image](https://github.com/dotnet/vscode-csharp/assets/16968319/66f65d97-253f-4bd8-963a-b483a1e7b8b6)

However, both VS and VS Code are missing `using` the _keyword_ in the list. The reason we're not getting the keyword is because we're trying to get completions at `__o = [||]`, which is not a valid location for a using statement.

End result after both of these fixes (1 & 2):
![image](https://github.com/dotnet/vscode-csharp/assets/16968319/27e932df-e32d-46ed-ad8a-3bf768cff081)

