### PR TITLE
Fire telemetry if Razor buffers get out of sync, and recover from same

### DIFF
--- a/src/razor/src/csharp/csharpProjectedDocument.ts
+++ b/src/razor/src/csharp/csharpProjectedDocument.ts
@@ -29,6 +29,14 @@ export class CSharpProjectedDocument implements IProjectedDocument {
         return this.projectedDocumentVersion;
     }
 
+    public get length(): number {
+        return this.content.length;
+    }
+
+    public clear() {
+        this.setContent('');
+    }
+
     public update(edits: ServerTextChange[], hostDocumentVersion: number) {
         this.removeProvisionalDot();
 

--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -245,7 +245,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
             const csharpProjectedDocument = projectedDocument as CSharpProjectedDocument;
 
             // If the language server is telling us that the previous document was empty, then we should clear
-            // ours out. Hopefully outs would have been empty too, but there are cases where things get out of
+            // ours out. Hopefully ours would have been empty too, but there are cases where things get out of
             // sync
             if (updateBufferRequest.previousWasEmpty && projectedDocument.length !== 0) {
                 this.telemetryReporter.reportBuffersOutOfSync();
@@ -288,7 +288,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
             const htmlProjectedDocument = projectedDocument as HtmlProjectedDocument;
 
             // If the language server is telling us that the previous document was empty, then we should clear
-            // ours out. Hopefully outs would have been empty too, but there are cases where things get out of
+            // ours out. Hopefully ours would have been empty too, but there are cases where things get out of
             // sync
             if (updateBufferRequest.previousWasEmpty && projectedDocument.length !== 0) {
                 this.telemetryReporter.reportBuffersOutOfSync();

--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -9,6 +9,7 @@ import { HtmlProjectedDocument } from '../html/htmlProjectedDocument';
 import { RazorLanguage } from '../razorLanguage';
 import { RazorLanguageServerClient } from '../razorLanguageServerClient';
 import { RazorLogger } from '../razorLogger';
+import { TelemetryReporter } from '../telemetryReporter';
 import { UpdateBufferRequest } from '../rpc/updateBufferRequest';
 import { getUriPath } from '../uriPaths';
 import { IRazorDocument } from './IRazorDocument';
@@ -28,7 +29,11 @@ export class RazorDocumentManager implements IRazorDocumentManager {
 
     public razorDocumentGenerationInitialized = false;
 
-    constructor(private readonly serverClient: RazorLanguageServerClient, private readonly logger: RazorLogger) {}
+    constructor(
+        private readonly serverClient: RazorLanguageServerClient,
+        private readonly logger: RazorLogger,
+        private readonly telemetryReporter: TelemetryReporter
+    ) {}
 
     public get onChange() {
         return this.onChangeEmitter.event;
@@ -227,6 +232,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         const projectedDocument = document.csharpDocument;
 
         if (
+            updateBufferRequest.previousWasEmpty ||
             !projectedDocument.hostDocumentSyncVersion ||
             projectedDocument.hostDocumentSyncVersion <= updateBufferRequest.hostDocumentVersion
         ) {
@@ -237,6 +243,15 @@ export class RazorDocumentManager implements IRazorDocumentManager {
             await vscode.workspace.openTextDocument(document.csharpDocument.uri);
 
             const csharpProjectedDocument = projectedDocument as CSharpProjectedDocument;
+
+            // If the language server is telling us that the previous document was empty, then we should clear
+            // ours out. Hopefully outs would have been empty too, but there are cases where things get out of
+            // sync
+            if (updateBufferRequest.previousWasEmpty && projectedDocument.length !== 0) {
+                this.telemetryReporter.reportBuffersOutOfSync();
+                csharpProjectedDocument.clear();
+            }
+
             csharpProjectedDocument.update(updateBufferRequest.changes, updateBufferRequest.hostDocumentVersion);
 
             this.notifyDocumentChange(document, RazorDocumentChangeKind.csharpChanged);
@@ -260,6 +275,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         const projectedDocument = document.htmlDocument;
 
         if (
+            updateBufferRequest.previousWasEmpty ||
             !projectedDocument.hostDocumentSyncVersion ||
             projectedDocument.hostDocumentSyncVersion <= updateBufferRequest.hostDocumentVersion
         ) {
@@ -270,6 +286,15 @@ export class RazorDocumentManager implements IRazorDocumentManager {
             await vscode.workspace.openTextDocument(document.htmlDocument.uri);
 
             const htmlProjectedDocument = projectedDocument as HtmlProjectedDocument;
+
+            // If the language server is telling us that the previous document was empty, then we should clear
+            // ours out. Hopefully outs would have been empty too, but there are cases where things get out of
+            // sync
+            if (updateBufferRequest.previousWasEmpty && projectedDocument.length !== 0) {
+                this.telemetryReporter.reportBuffersOutOfSync();
+                htmlProjectedDocument.clear();
+            }
+
             htmlProjectedDocument.update(updateBufferRequest.changes, updateBufferRequest.hostDocumentVersion);
 
             this.notifyDocumentChange(document, RazorDocumentChangeKind.htmlChanged);

--- a/src/razor/src/extension.ts
+++ b/src/razor/src/extension.ts
@@ -117,7 +117,7 @@ export async function activate(
 
         const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
 
-        const documentManager = new RazorDocumentManager(languageServerClient, logger);
+        const documentManager = new RazorDocumentManager(languageServerClient, logger, razorTelemetryReporter);
         const documentSynchronizer = new RazorDocumentSynchronizer(documentManager, logger);
         reportTelemetryForDocuments(documentManager, razorTelemetryReporter);
         const languageConfiguration = new RazorLanguageConfiguration();

--- a/src/razor/src/html/htmlProjectedDocument.ts
+++ b/src/razor/src/html/htmlProjectedDocument.ts
@@ -26,6 +26,14 @@ export class HtmlProjectedDocument implements IProjectedDocument {
         return this.projectedDocumentVersion;
     }
 
+    public get length(): number {
+        return this.content.length;
+    }
+
+    public clear() {
+        this.setContent('');
+    }
+
     public update(edits: ServerTextChange[], hostDocumentVersion: number) {
         this.hostDocumentVersion = hostDocumentVersion;
 

--- a/src/razor/src/projection/IProjectedDocument.ts
+++ b/src/razor/src/projection/IProjectedDocument.ts
@@ -10,5 +10,6 @@ export interface IProjectedDocument {
     readonly uri: vscode.Uri;
     readonly hostDocumentSyncVersion: number | null;
     readonly projectedDocumentSyncVersion: number;
+    readonly length: number;
     getContent(): string;
 }

--- a/src/razor/src/rpc/updateBufferRequest.ts
+++ b/src/razor/src/rpc/updateBufferRequest.ts
@@ -9,6 +9,7 @@ export class UpdateBufferRequest {
     constructor(
         public readonly hostDocumentVersion: number,
         public readonly hostDocumentFilePath: string,
-        public readonly changes: ServerTextChange[]
+        public readonly changes: ServerTextChange[],
+        public readonly previousWasEmpty: boolean
     ) {}
 }

--- a/src/razor/src/telemetryReporter.ts
+++ b/src/razor/src/telemetryReporter.ts
@@ -10,6 +10,7 @@ export class TelemetryReporter {
     private readonly razorExtensionActivated = createTelemetryEvent('VSCode.Razor.RazorExtensionActivated');
     private readonly debugLanguageServerEvent = createTelemetryEvent('VSCode.Razor.DebugLanguageServer');
     private readonly workspaceContainsRazorEvent = createTelemetryEvent('VSCode.Razor.WorkspaceContainsRazor');
+    private readonly buffersOutOfSyncEvent = createTelemetryEvent('VSCode.Razor.BuffersOutOfSync');
     private reportedWorkspaceContainsRazor = false;
 
     constructor(private readonly eventStream: HostEventStream) {
@@ -22,6 +23,10 @@ export class TelemetryReporter {
             trace: Trace[trace],
         });
         this.eventStream.post(traceLevelEvent);
+    }
+
+    public reportBuffersOutOfSync() {
+        this.eventStream.post(this.buffersOutOfSyncEvent);
     }
 
     public reportErrorOnServerStart(error: unknown) {


### PR DESCRIPTION
This is the VS Code equivalent of https://github.com/dotnet/razor/pull/9202

Fixes https://github.com/dotnet/vscode-csharp/issues/6488

I'm not sure why this is so easily reproducable for the user reporting the error, but its extremely intermittent for me. I basically hit it twice today, and never again, but I did at least see that we had duplicate HTML content in our generated file when I hit it, so can be sure this is the issue we are running into.

Perhaps a new timing issue with our initialization, now that its not deferred until file open, but with part of Roslyn and the extension still expecting it to be. Hopefully https://github.com/dotnet/razor/issues/9344 will fix those issues.