### PR TITLE
[Razor] Textmate colorization fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4869,6 +4869,10 @@
         "description": "A token that represents an attribute quote in a Markup attribute."
       },
       {
+        "id": "markupAttributeValue",
+        "description": "The value of a Markup attribute."
+      },
+      {
         "id": "markupComment",
         "description": "The contents of a Markup comment."
       },
@@ -5174,7 +5178,10 @@
             "entity.other.attribute-name.html"
           ],
           "markupAttributeQuote": [
-            "punctuation.definition.string.html"
+            "punctuation.definition.tag.html"
+          ],
+          "markupAttributeValue": [
+            "punctuation.definition.entity.html"
           ],
           "markupComment": [
             "comment.block.html"
@@ -5543,9 +5550,7 @@
         "scopeName": "text.aspnetcorerazor",
         "path": "./src/razor/syntaxes/aspnetcorerazor.tmLanguage.json",
         "unbalancedBracketScopes": [
-          "keyword.operator.arrow.cs",
-          "keyword.operator.bitwise.shift.cs",
-          "keyword.operator.relational.cs"
+          "text.aspnetcorerazor"
         ]
       }
     ],


### PR DESCRIPTION
This is less of a fix and more of a hack. I spent a significant amount of time the past few days trying to fix this the proper way - i.e., making major changes to Razor's Textmate grammar - but it was incredibly frustrating and there were edge cases that kept popping up. This solution fixes the problem without a huge investment but makes some compromises.

Problem:
- The Razor Textmate grammar is very basic and marks a non-trivial amount of proper Razor syntax as invalid.
- VS Code (via language-configuration.json) marks unbalanced brackets in red. Even setting a semantic token type won't override the red color.
- One solution would be to change the grammar to account for certain cases, e.g. recognizing `=>` and `"` as possible valid syntax in component attributes. But because of how buggy our Razor Textmate grammar already is, this turned out to be a much more difficult task than expected, hence the simplified solution in this PR.
 

Solution:
- Get rid of unbalanced bracket coloring altogether in Razor files. They have a high change of not being accurate since our Textmate grammar isn't great. IMO we could/should eventually use some form of diagnostic to recognize unbalanced brackets instead.
- There is still some red colorization even after these PR changes, which should be resolved after https://github.com/dotnet/razor/issues/9371 is fixed.

Before example:
![image](https://github.com/dotnet/vscode-csharp/assets/16968319/2984ce16-9c88-45be-8644-9880c7806c6f)

After example:
![image](https://github.com/dotnet/vscode-csharp/assets/16968319/422337e5-f05e-42eb-8592-d6854c32a5f4)
