### PR TITLE
Fix dotnet path resolution when using snap installed packages

### DIFF
--- a/src/shared/utils/dotnetInfo.ts
+++ b/src/shared/utils/dotnetInfo.ts
@@ -5,7 +5,7 @@
 
 import * as semver from 'semver';
 
-type RuntimeVersionMap = { [runtime: string]: semver.SemVer[] };
+type RuntimeVersionMap = { [runtime: string]: RuntimeInfo[] };
 export interface DotnetInfo {
     CliPath?: string;
     FullInfo: string;
@@ -14,4 +14,9 @@ export interface DotnetInfo {
     RuntimeId?: string;
     Architecture?: string;
     Runtimes: RuntimeVersionMap;
+}
+
+export interface RuntimeInfo {
+    Version: semver.SemVer;
+    Path: string;
 }

--- a/src/shared/utils/getDotnetInfo.ts
+++ b/src/shared/utils/getDotnetInfo.ts
@@ -7,7 +7,7 @@ import * as semver from 'semver';
 import { join } from 'path';
 import { execChildProcess } from '../../common';
 import { CoreClrDebugUtil } from '../../coreclrDebug/util';
-import { DotnetInfo } from './dotnetInfo';
+import { DotnetInfo, RuntimeInfo } from './dotnetInfo';
 import { EOL } from 'os';
 
 // This function calls `dotnet --info` and returns the result as a DotnetInfo object.
@@ -69,7 +69,7 @@ async function parseDotnetInfo(dotnetInfo: string, dotnetExecutablePath: string 
             }
         }
 
-        const runtimeVersions: { [runtime: string]: semver.SemVer[] } = {};
+        const runtimeVersions: { [runtime: string]: RuntimeInfo[] } = {};
         const listRuntimes = await execChildProcess('dotnet --list-runtimes', process.cwd(), process.env);
         lines = listRuntimes.split(/\r?\n/);
         for (const line of lines) {
@@ -78,9 +78,17 @@ async function parseDotnetInfo(dotnetInfo: string, dotnetExecutablePath: string 
                 const runtime = match[1];
                 const runtimeVersion = match[2];
                 if (runtime in runtimeVersions) {
-                    runtimeVersions[runtime].push(semver.parse(runtimeVersion)!);
+                    runtimeVersions[runtime].push({
+                        Version: semver.parse(runtimeVersion)!,
+                        Path: match[3],
+                    });
                 } else {
-                    runtimeVersions[runtime] = [semver.parse(runtimeVersion)!];
+                    runtimeVersions[runtime] = [
+                        {
+                            Version: semver.parse(runtimeVersion)!,
+                            Path: match[3],
+                        },
+                    ];
                 }
             }
         }


### PR DESCRIPTION
On systems installing dotnet via snap, the dotnet on the path does not point to the dotnet install location, even via symlinks.  Instead, it is symlinked to the snap executable, e.g. `/usr/bin/snap`.

So calling `which dotnet` and reading symlinks will not give us a valid dotnet installation.

The fix here is to instead parse the output of `dotnet --list-runtimes` which will return the real assembly locations of the dotnet install.  Since the dotnet install has a [known layout](https://github.com/dotnet/designs/blob/main/accepted/2020/install-locations.md#net-core-install-layout), we can easily find the dotnet executable given a runtime install path.

See https://github.com/dotnet/vscode-csharp/issues/6513 for more info.

Resolves https://github.com/dotnet/vscode-csharp/issues/6513

