### PR TITLE
Log the extension log directory in integration tests

### DIFF
--- a/test/integrationTests/integrationHelpers.ts
+++ b/test/integrationTests/integrationHelpers.ts
@@ -39,6 +39,7 @@ export async function activateCSharpExtension(): Promise<void> {
     await csharpExtension.activate();
     await csharpExtension.exports.initializationFinished();
     console.log('ms-dotnettools.csharp activated');
+    console.log(`Extension Log Directory: ${csharpExtension.exports.logDirectory}`);
 
     if (shouldRestart) {
         // Register to wait for initialization events and restart the server.


### PR DESCRIPTION
This will allow us to map to the correct set of artifacts in a failed CI run