### PR TITLE
Hide debug console when using `"console": "integratedTerminal"`

### DIFF
--- a/src/shared/configurationProvider.ts
+++ b/src/shared/configurationProvider.ts
@@ -76,7 +76,12 @@ export class BaseVsDbgConfigurationProvider implements vscode.DebugConfiguration
                 debugConfiguration.cwd = folder?.uri.fsPath; // Workspace folder
             }
 
-            debugConfiguration.internalConsoleOptions ??= 'openOnSessionStart';
+            if (!debugConfiguration.internalConsoleOptions) {
+                // If the target app is NOT using integratedTerminal, use 'openOnSessionStart' so that the debug console can be seen
+                // If the target app is using integratedTerminal, use 'neverOpen' so that the integrated terminal doesn't get hidden
+                debugConfiguration.internalConsoleOptions =
+                    debugConfiguration.console === 'integratedTerminal' ? 'neverOpen' : 'openOnSessionStart';
+            }
 
             // read from envFile and set config.env
             if (debugConfiguration.envFile !== undefined && debugConfiguration.envFile.length > 0) {


### PR DESCRIPTION
Previously the C# extension would always set `internalConsoleOptions` (which controls if VS Code shows the debug console) to `openOnSessionStart`. The PR changes things so that we will use `neverOpen` if we are going to use the integrated terminal.

This resolves #6516