### PR TITLE
Improve reliability of Razor integration test

### DIFF
--- a/test/razorIntegrationTests/formatting.integration.test.ts
+++ b/test/razorIntegrationTests/formatting.integration.test.ts
@@ -32,8 +32,8 @@ jestLib.describe(`Razor Formatting ${testAssetWorkspace.description}`, function 
         const htmlConfig = vscode.workspace.getConfiguration('html');
         await htmlConfig.update('format.enable', true);
 
-        await integrationHelpers.activateCSharpExtension();
         await integrationHelpers.openFileInWorkspaceAsync(path.join('Pages', 'BadlyFormatted.razor'));
+        await integrationHelpers.activateCSharpExtension();
     });
 
     jestLib.afterAll(async () => {
@@ -61,12 +61,20 @@ jestLib.describe(`Razor Formatting ${testAssetWorkspace.description}`, function 
 
         jestLib.expect(edits).toBeDefined();
 
+        console.log(`Got $(edits.length) edits`);
+
         // It's much easier to verify the expected state of the document, than a bunch of edits
         const formatEdit = new vscode.WorkspaceEdit();
         formatEdit.set(activeDocument, edits);
+
+        console.log(`Applying edit $(formatEdit)`);
+
         await vscode.workspace.applyEdit(formatEdit);
 
         const contents = normalizeNewlines(vscode.window.activeTextEditor?.document.getText());
+
+        console.log(`Checking document contents`);
+
         jestLib.expect(contents).toBe(
             normalizeNewlines(`@page "/bad"
 

--- a/test/razorIntegrationTests/formatting.integration.test.ts
+++ b/test/razorIntegrationTests/formatting.integration.test.ts
@@ -61,19 +61,19 @@ jestLib.describe(`Razor Formatting ${testAssetWorkspace.description}`, function 
 
         jestLib.expect(edits).toBeDefined();
 
-        console.log(`Got $(edits.length) edits`);
+        console.log(`Got ${edits.length} edits`);
 
         // It's much easier to verify the expected state of the document, than a bunch of edits
         const formatEdit = new vscode.WorkspaceEdit();
         formatEdit.set(activeDocument, edits);
 
-        console.log(`Applying edit $(formatEdit)`);
+        console.log(`Applying edit ${formatEdit}`);
 
         await vscode.workspace.applyEdit(formatEdit);
 
         const contents = normalizeNewlines(vscode.window.activeTextEditor?.document.getText());
 
-        console.log(`Checking document contents`);
+        console.log(`Checking document contents...`);
 
         jestLib.expect(contents).toBe(
             normalizeNewlines(`@page "/bad"


### PR DESCRIPTION
I tried to do fancy things like wait for the Razor server to be activated etc. but it was painful because on my machine when we start waiting, it has already activated so we missed the event. I was going to go further and add a way to query status, but this seems to work just as well for now, and is much easier. It's also how the inlay hints test works, so maybe there is some tribal knowledge that this is the right way to do things.

10 successful runs. That'll do :)

<img width="648" alt="image" src="https://github.com/dotnet/vscode-csharp/assets/754264/37df3ef1-959b-40c7-81f0-9ec1bd6c4e7b">
