### PR TITLE
fix(vscode): Add dotnet executable path in list runtimes command

### DIFF
--- a/src/shared/utils/getDotnetInfo.ts
+++ b/src/shared/utils/getDotnetInfo.ts
@@ -70,7 +70,8 @@ async function parseDotnetInfo(dotnetInfo: string, dotnetExecutablePath: string 
         }
 
         const runtimeVersions: { [runtime: string]: RuntimeInfo[] } = {};
-        const listRuntimes = await execChildProcess('dotnet --list-runtimes', process.cwd(), process.env);
+        const command = dotnetExecutablePath ? `"${dotnetExecutablePath}"` : 'dotnet';
+        const listRuntimes = await execChildProcess(`${command} --list-runtimes`, process.cwd(), process.env);
         lines = listRuntimes.split(/\r?\n/);
         for (const line of lines) {
             let match: RegExpMatchArray | null;


### PR DESCRIPTION
### Main Code Changes
- Add `dotnetExecutablePath` to the list runtimes command the same way it does to info command