### PR TITLE
Debugger: Support Console.ReadLine with 'internalConsole'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Update Razor to 7.0.0-preview.23516.2 (PR: [#6550](https://github.com/dotnet/vscode-csharp/pull/6550))
   * Make sure correct info is passed in code action resolve (PR: [razor#9420](https://github.com/dotnet/razor/pull/9420))
 
-## 2.7.?
+## 2.7.25
 * Update Razor to 7.0.0-preview.23513.5 (PR: [#6551](https://github.com/dotnet/vscode-csharp/pull/6551))
   * Reduce noisy errors when viewing git diff (PR: [razor#9407](https://github.com/dotnet/razor/pull/9407))
 * Update Roslyn to 4.9.0-1.23513.7 (PR: [#6548](https://github.com/dotnet/vscode-csharp/pull/6548))
@@ -20,6 +20,7 @@
 * Fix dotnet path resolution when using snap installed packages (PR: [#6515](https://github.com/dotnet/vscode-csharp/pull/6515))
 * Track debugging sessions until csdevkit is initialized (PR: [#6480](https://github.com/dotnet/vscode-csharp/pull/6480))
 * Update vsdbg and vsdbg-ui to 2.0.4 (PR: [#6517](https://github.com/dotnet/vscode-csharp/pull/6517))
+* Debugger: better handle long strings ([#6496](https://github.com/dotnet/vscode-csharp/issues/6496)). Strings are truncated if they are longer than 1024 UTF-16 characters, but the full value  up to 5,242,880 characters or 10 megabytes, is available using 'Copy Value' in the watch or variables window. Truncated strings will end with '...'.
 * Add setting to control Razor component commit behaviour (PR: [#6506](https://github.com/dotnet/vscode-csharp/pull/6506))
 * Razor textmate colorization fixes (PR: [#6514](https://github.com/dotnet/vscode-csharp/pull/6514))
 
@@ -48,7 +49,6 @@
   * Update Razor project configuration file name (PR: [#70156](https://github.com/dotnet/roslyn/pull/70156))* added support.md file (PR: [#6478](https://github.com/dotnet/vscode-csharp/pull/6478))
 * Debugger: Improve the display of various debug configurations and snippets (PR: [#6456](https://github.com/dotnet/vscode-csharp/pull/6456))
 * Initialize Razor even if Razor doc isn't opened yet (PR: [#6473](https://github.com/dotnet/vscode-csharp/pull/6473))
-* Debugger: better handle long strings ([#6496](https://github.com/dotnet/vscode-csharp/issues/6496)). Strings are truncated if they are longer than 1024 UTF-16 characters, but the full value  up to 5,242,880 characters or 10 megabytes, is available using 'Copy Value' in the watch or variables window. Truncated strings will end with '...'.
 
 ## 2.5.30
 * Add code action fix all support (PR: [#6310](https://github.com/dotnet/vscode-csharp/pull/6310))

--- a/debugger-launchjson.md
+++ b/debugger-launchjson.md
@@ -124,11 +124,19 @@ Environment variables may be passed to your program using this schema:
 
 The `"console"` setting controls what console (terminal) window the target app is launched into. It can be set to any of these values --
 
-`"internalConsole"` (default) : the target process's console output (stdout/stderr) goes to the VS Code Debug Console. This is useful for executables that take their input from the network, files, etc. But this does **NOT** work for applications that want to read from the console (ex: `Console.ReadLine`). 
+`"internalConsole"` (default) : the target process's console input (stdin) and output (stdout/stderr) are routed through the VS Code Debug Console. The advantage of this mode is that it allows you to see messages from both the debugger and the target program in one place, so you will not miss important messages or need to switch back and forth. This is useful for programs with simple console interactions (example: using `Console.WriteLine` and/or `Console.ReadLine`). This should NOT be used when the target program needs full control over the console, such as a program that changes the cursor position, uses `Console.ReadKey` for input, etc. See below for instructions on inputting into the console.
 
-`"integratedTerminal"` : the target process will run inside [VS Code's integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal). Click the 'Terminal' tab in the tab group beneath the editor to interact with your application. Alternatively add `"internalConsoleOptions": "neverOpen"` to make it so that the default foreground tab is the terminal tab.
+`"integratedTerminal"` : the target process will run inside [VS Code's integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal). Click the 'Terminal' tab in the tab group beneath the editor to interact with your application. When using this mode, by default, the Debug Console will not be shown when starting debugging. This can be configured with `internalConsoleOptions`.
 
-`"externalTerminal"`: the target process will run inside its own external terminal.
+`"externalTerminal"`: the target process will run inside its own external terminal. When using this mode, you will need to switch focus between Visual Studio Code and the external terminal window.
+
+### Inputting text into the target process when using `internalConsole`
+
+When using `internalConsole`, you can input text into Visual Studio Code that will be returned from `Console.ReadLine` and similar APIs that read from `stdin`. To do so, while the program is running, type text into the input box at the bottom of the Debug Console. Pressing enter will send the text to the target process. Note that if you enter text in this box while your program is stopped under the debugger, this text will be evaluated as a C# expression, not sent to the target process.
+
+Example:
+
+![Example of inputting text to the Console to be set to the target process's standard input](https://raw.githubusercontent.com/wiki/dotnet/vscode-csharp/images/ConsoleInput.gif)
 
 ## launchSettings.json support
 

--- a/debugger.md
+++ b/debugger.md
@@ -2,7 +2,7 @@
 This page gives you detailed instructions on how to debug code running under .NET Core in VS Code. 
 
 #### Your Feedback​
-File bugs and feature requests [here](https://github.com/OmniSharp/omnisharp-vscode/issues) to help us build great tooling for .NET Core.
+File bugs and feature requests [here](https://github.com/dotnet/vscode-csharp/issues) to help us build great tooling for .NET Core.
 
 ### First Time setup
 ##### 1: Get Visual Studio Code
@@ -43,7 +43,7 @@ VS Code needs to be configured so it understands how to build your project and d
 
 If you open the folder containing your project, the C# extension can automatically generate these files for you if you have a basic project. When you open a project and the C# extension is installed, you should see the following prompt in VS Code:
 
-![Info: Required assets to build and debug are missing from your project. Add them? Yes | Close](https://raw.githubusercontent.com/wiki/OmniSharp/omnisharp-vscode/images/info-bar-add-required-assets.png)
+![Info: Required assets to build and debug are missing from your project. Add them? Yes | Close](https://raw.githubusercontent.com/wiki/dotnet/vscode-csharp/images/info-bar-add-required-assets.png)
 
 Clicking `Yes` on this prompt should add these resources.
 
@@ -51,7 +51,7 @@ Clicking `Yes` on this prompt should add these resources.
 
 If your code has multiple projects or you would rather generate these files by hand, here is how --
 
-**.vscode/tasks.json**: Start with [this example](https://raw.githubusercontent.com/wiki/OmniSharp/omnisharp-vscode/ExampleCode/tasks.json) which configures VS Code to launch `dotnet build`. Update the `cwd` property if your project isn't in the root of the open folder. If you don't want to build from VS Code at all, you can skip this file. If you do this, you will need to comment out the `preLaunchTask` from .vscode/launch.json when you create it.
+**.vscode/tasks.json**: Start with [this example](https://raw.githubusercontent.com/wiki/dotnet/vscode-csharp/ExampleCode/tasks.json) which configures VS Code to launch `dotnet build`. Update the `cwd` property if your project isn't in the root of the open folder. If you don't want to build from VS Code at all, you can skip this file. If you do this, you will need to comment out the `preLaunchTask` from .vscode/launch.json when you create it.
 
 **.vscode/launch.json**: When you want to start debugging, press the debugger play button (or press <kbd>F5</kbd>) as you would normally do. VS Code will provide a list of templates to select from. Pick ".NET Core" from this list and the edit the `program` property to indicate the path to the application dll or .NET Core host executable to launch. For example:
 
@@ -67,7 +67,7 @@ Your project is now all set. Set a breakpoint or two where you want to stop, cli
 If your code was built on a different computer from where you would like to run in there are a few things to keep in mind --
 
 * **Source Maps**: Unless your local source code is at exactly the same path as where the code was originally built you will need to add a [sourceFileMap](https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md#source-file-map) to launch.json.
-* **Portable PDBs**: If the code was built on Windows, it might have been built using Windows PDBs instead of portable PDBs, but the C# extension only supports portable PDBs. See the [portable PDB documentation](https://github.com/OmniSharp/omnisharp-vscode/wiki/Portable-PDBs#how-to-generate-portable-pdbs) for more information.
+* **Portable PDBs**: If the code was built on Windows, it might have been built using Windows PDBs instead of portable PDBs, but the C# extension only supports portable PDBs. See the [portable PDB documentation](https://github.com/dotnet/vscode-csharp/wiki/Portable-PDBs#how-to-generate-portable-pdbs) for more information.
 * **Debug vs. Release**: It is much easier to debug code which has been compiled in the `Debug` configuration. So unless the issue you are looking at only reproduces with optimizations, it is much better to use Debug bits. If you do need to debug optimized code, you will need to disable [justMyCode](https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md#just-my-code) in launch.json.
 
 #### [Configurating launch.json for C# Debugging](debugger-launchjson.md)
@@ -75,19 +75,19 @@ If your code was built on a different computer from where you would like to run 
 #### Attach Support
 The C# debugger supports attaching to processes. To do this, switch to the Debug tab, and open the configuration drop down.
 
-![Debug launch configuration drop down](https://raw.githubusercontent.com/wiki/OmniSharp/omnisharp-vscode/images/debug-launch-configurations.png)
+![Debug launch configuration drop down](https://raw.githubusercontent.com/wiki/dotnet/vscode-csharp/images/debug-launch-configurations.png)
 
 Select the '.NET Core Attach' configuration. Clicking the play button (or pressing <kbd>F5</kbd>) will then try to attach. In launch.json, if `processId` is set to `""` this will provide UI to select which process to attach to.
 
 #### Remote Debugging
 
-The debugger supports remotely launching or attaching to processes. See [Attaching to remote processes](https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes) in the wiki for more information.
+The debugger supports remotely launching or attaching to processes. See [Attaching to remote processes](https://github.com/dotnet/vscode-csharp/wiki/Attaching-to-remote-processes) in the wiki for more information.
 
 #### Exception Settings
 
 The VS Code .NET debugger supports configuration options for if the debugger stops when exceptions are thrown or caught. This is done through two different entries in the BREAKPOINTS section of the Run view:
 
-![Exceptions settings in BREAKPOINTS Run View](https://raw.githubusercontent.com/wiki/OmniSharp/omnisharp-vscode/images/Exception-Settings.png)
+![Exceptions settings in BREAKPOINTS Run View](https://raw.githubusercontent.com/wiki/dotnet/vscode-csharp/images/Exception-Settings.png)
 
 Note that the BREAKPOINTS section will be missing these entries until the first time that the folder has been debugged with the .NET debugger.
 

--- a/package.json
+++ b/package.json
@@ -444,7 +444,7 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-win7-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-win7-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "win32"
@@ -454,12 +454,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui.exe",
-      "integrity": "2CC5A41316626EF61CA29368913DA6BD9A98FEC0677AAF25A3513F76C1BE57DB"
+      "integrity": "35E83F9425333AC617E288A07ECAE21A0125E822AF059135CBBC4C8893A6A562"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / ARM64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-win10-arm64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-win10-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "win32"
@@ -468,12 +468,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui.exe",
-      "integrity": "39845F9C1F69D1A23C36EB3BD54E377CD1298A67E425DCF9906C055BB9388EB5"
+      "integrity": "FF75A11B6F4293981BF9EC74666D0C1D41549EDC89F532982CE5009D0C63BCAC"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-osx-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-osx-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "darwin"
@@ -487,12 +487,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui",
-      "integrity": "D6715726EBF09969A1341B227CC363F7D1B6D3558ADEA67349BB48B4D29502AD"
+      "integrity": "FB219A04886B15AE8896B20ACE8A63725CBC59839CC20DA66E2061C49914918D"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / arm64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-osx-arm64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-osx-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "darwin"
@@ -505,12 +505,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui",
-      "integrity": "370B63DCAB00D12255891EB29BF5FB6CEC84B4457106F67017400CB19328B72D"
+      "integrity": "1BBDCFAF4BA7A1D0A383AF7BCF498BCF535531BC385CED1E5CE1F53F3D44B2E2"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-linux-arm.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-linux-arm.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -523,12 +523,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "FBC80CBA32E51151DEF28754B9E1B5B87A9153BC2DF76F71C95D752E676EA8F8"
+      "integrity": "F166A10B134F31A048039FB13C3EEDB0C7BF60DD9276BC533C41E4A57815CD3E"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-linux-arm64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-linux-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -541,12 +541,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "684271EB3D7715D7B96656D743F7A34F1D16F3E0464B755066305AABB45E7096"
+      "integrity": "4A113139E24CD498CFC4F72167921B1911E03603BB1D74AEBAABE73B2F2E7FBF"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-linux-musl-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-linux-musl-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -559,12 +559,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "B492504AC6A8FAE7D93445D037F608417DD65E14FF080AA9913CC0E8AA4BE6EA"
+      "integrity": "C26312FC5450542231933869A2B20682057785F1BEF38BDC8828CB187829C1F7"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / ARM64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-linux-musl-arm64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-linux-musl-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -577,12 +577,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "46BAE37A95413CEB23E3B9A11B125E73DA4F2BADF75C66A19D3BCB1C389F788C"
+      "integrity": "F49BF6AD38646DA79A4D085BC05D9D948D436871EE57C3036E5BD45688BDF9B2"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-4/coreclr-debug-linux-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-0-5/coreclr-debug-linux-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -595,7 +595,7 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "1A56E250BF066D46B828F00F3AA1D30C48CDB92DF37691C5E34AAD7705D22CEC"
+      "integrity": "B8D8D0C03C1B5F2793826CA283271DC25C64494C62E748AD3B681A8B6AB535F6"
     },
     {
       "id": "Razor",
@@ -1850,6 +1850,11 @@
             "markdownDescription": "%generateOptionsSchema.logging.diagnosticsLog.startDebuggingTracing.markdownDescription%",
             "default": false
           },
+          "csharp.debug.logging.consoleUsageMessage": {
+            "type": "boolean",
+            "description": "%generateOptionsSchema.logging.consoleUsageMessage.description%",
+            "default": true
+          },
           "csharp.debug.suppressJITOptimizations": {
             "type": "boolean",
             "markdownDescription": "%generateOptionsSchema.suppressJITOptimizations.markdownDescription%",
@@ -2434,6 +2439,11 @@
                         "default": false
                       }
                     }
+                  },
+                  "consoleUsageMessage": {
+                    "type": "boolean",
+                    "description": "%generateOptionsSchema.logging.consoleUsageMessage.description%",
+                    "default": true
                   }
                 }
               },
@@ -2934,6 +2944,11 @@
                         "default": false
                       }
                     }
+                  },
+                  "consoleUsageMessage": {
+                    "type": "boolean",
+                    "description": "%generateOptionsSchema.logging.consoleUsageMessage.description%",
+                    "default": true
                   }
                 }
               },
@@ -3710,6 +3725,11 @@
                         "default": false
                       }
                     }
+                  },
+                  "consoleUsageMessage": {
+                    "type": "boolean",
+                    "description": "%generateOptionsSchema.logging.consoleUsageMessage.description%",
+                    "default": true
                   }
                 }
               },
@@ -4210,6 +4230,11 @@
                         "default": false
                       }
                     }
+                  },
+                  "consoleUsageMessage": {
+                    "type": "boolean",
+                    "description": "%generateOptionsSchema.logging.consoleUsageMessage.description%",
+                    "default": true
                   }
                 }
               },

--- a/package.nls.json
+++ b/package.nls.json
@@ -83,7 +83,7 @@
   "debuggers.coreclr.configurationSnippets.label.blazor-hosted": ".NET: Web Assembly - Launch hosted Blazor project",
   "debuggers.coreclr.configurationSnippets.label.blazor-standalone": ".NET: Web Assembly - Launch standalone Blazor project",
   "debuggers.coreclr.configurationSnippets.description.console-local": {
-    "message" : "This snippet is used to launch a new process under the .NET debugger (coreclr), specifying the path to the executable to launch. In most cases, the \".NET: Launch C# project\" snippet is a better choice. This snippet is useful when the project was built outside this VS Code instance or you want to host your .NET Code in a custom executable, such as a specific version of 'dotnet.exe'/'dotnet' or the .NET Code is hosted by a native application. This snippet is for console applications.",
+    "message": "This snippet is used to launch a new process under the .NET debugger (coreclr), specifying the path to the executable to launch. In most cases, the \".NET: Launch C# project\" snippet is a better choice. This snippet is useful when the project was built outside this VS Code instance or you want to host your .NET Code in a custom executable, such as a specific version of 'dotnet.exe'/'dotnet' or the .NET Code is hosted by a native application. This snippet is for console applications.",
     "comment": [
       "'coreclr' is the name of the debugger 'type', and should not be localized",
       "{Locked='(coreclr)'}"
@@ -317,6 +317,7 @@
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
   },
+  "generateOptionsSchema.logging.consoleUsageMessage.description": "Controls if a message is logged when the target process calls a 'Console.Read*' API and stdin is redirected to the console.",
   "generateOptionsSchema.pipeTransport.description": "When present, this tells the debugger to connect to a remote computer using another executable as a pipe that will relay standard input/output between VS Code and the .NET Core debugger backend executable (vsdbg).",
   "generateOptionsSchema.pipeTransport.pipeCwd.description": "The fully qualified path to the working directory for the pipe program.",
   "generateOptionsSchema.pipeTransport.pipeProgram.description": "The fully qualified pipe command to execute.",

--- a/src/tools/OptionsSchema.json
+++ b/src/tools/OptionsSchema.json
@@ -241,6 +241,11 @@
         "diagnosticsLog": {
           "$ref": "#/definitions/DiagnosticsLog",
           "description": "Settings to control which messages are printed to the output window from the debugger's diagnostics log. This log is meant to help troubleshoot problems with the debugger."
+        },
+        "consoleUsageMessage": {
+          "type": "boolean",
+          "description": "Controls if a message is logged when the target process calls a 'Console.Read*' API and stdin is redirected to the console.",
+          "default": true
         }
       }
     },


### PR DESCRIPTION
This PR pulls in a new version of the debugger that supports `Console.ReadLine` and `Console.Read` when using `"console":"internalConsole"` (the default value). This also updates documentation.

This addresses #5704

Two other minor changes I noticed while I was here:
* Updated the changelog to correctly indicate when the 'long string' fix went it
* Updated links in the debugger md files that were still pointing at OmniSharp