### PR TITLE
[Razor] Support platform agnostic language server & telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -733,6 +733,22 @@
       "integrity": "AB4D44465EA5135912737F8D943DB8DB7ADF1CC213F433188401FEE36B78A319"
     },
     {
+      "id": "Razor",
+      "description": "Razor Language Server (Platform Agnostic)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/f8b5b74b-3df3-47cc-83b1-cd1d93d1771d/e456a753103b84b87bf5f000499ce3d7/razorlanguageserver-platformagnostic-7.0.0-preview.23513.5.zip",
+      "installPath": ".razor",
+      "platforms": [
+        "neutral"
+      ],
+      "architectures": [
+        "neutral"
+      ],
+      "binaries": [
+        "./rzls"
+      ],
+      "integrity": "0CDC371C58614CBD5BAE83A0AEDF9896115A637E3AF007B7E399F5414CA66451"
+    },
+    {
       "id": "RazorOmnisharp",
       "description": "Razor Language Server for OmniSharp (Windows / x64)",
       "url": "https://download.visualstudio.microsoft.com/download/pr/aee63398-023f-48db-bba2-30162c68f0c4/8d42e62ea4051381c219b3e31bc4eced/razorlanguageserver-win-x64-7.0.0-preview.23363.1.zip",
@@ -974,6 +990,19 @@
         "arm64"
       ],
       "integrity": "65B17BBB7BA66987F74ED0B9261FC495BBB40C8C1C4FC4F8981BA5824B300A00"
+    },
+    {
+      "id": "RazorTelemetry",
+      "description": "Razor Language Server Telemetry (Platform Agnostic)",
+      "url": "https://download.visualstudio.microsoft.com/download/pr/f8b5b74b-3df3-47cc-83b1-cd1d93d1771d/1affdce6b3431a5ed16d545a325a8474/devkittelemetry-platformagnostic-7.0.0-preview.23513.5.zip",
+      "installPath": ".razortelemetry",
+      "platforms": [
+        "netural"
+      ],
+      "architectures": [
+        "neutral"
+      ],
+      "integrity": "5410885094C69A494D847755CC974F41850AC21C613D140B4A775DE7E531880E"
     }
   ],
   "engines": {

--- a/src/razor/razorTelemetryDownloader.ts
+++ b/src/razor/razorTelemetryDownloader.ts
@@ -24,11 +24,20 @@ export class RazorTelemetryDownloader {
     public async DownloadAndInstallRazorTelemetry(version: string): Promise<boolean> {
         const runtimeDependencies = getRuntimeDependenciesPackages(this.packageJSON);
         const razorPackages = runtimeDependencies.filter((inputPackage) => inputPackage.id === 'RazorTelemetry');
-        const packagesToInstall = await getAbsolutePathPackagesToInstall(
+        let packagesToInstall = await getAbsolutePathPackagesToInstall(
             razorPackages,
             this.platformInfo,
             this.extensionPath
         );
+
+        if (packagesToInstall.length == 0) {
+            const platformNeutral = new PlatformInformation('netural', 'neutral');
+            packagesToInstall = await getAbsolutePathPackagesToInstall(
+                razorPackages,
+                platformNeutral,
+                this.extensionPath
+            );
+        }
 
         if (packagesToInstall.length > 0) {
             this.eventStream.post(new PackageInstallation(`Razor Telemetry Version = ${version}`));

--- a/src/razor/razorTelemetryDownloader.ts
+++ b/src/razor/razorTelemetryDownloader.ts
@@ -31,7 +31,7 @@ export class RazorTelemetryDownloader {
         );
 
         if (packagesToInstall.length == 0) {
-            const platformNeutral = new PlatformInformation('netural', 'neutral');
+            const platformNeutral = new PlatformInformation('neutral', 'neutral');
             packagesToInstall = await getAbsolutePathPackagesToInstall(
                 razorPackages,
                 platformNeutral,

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -140,7 +140,7 @@ async function acquireRoslyn(
 async function installRazor(packageJSON: any, platformInfo: PlatformInformation) {
     if (!(await installPackageJsonDependency('Razor', packageJSON, platformInfo))) {
         // Try downloading platform neutral package instead
-        const platformNeutral = new PlatformInformation('netural', 'neutral');
+        const platformNeutral = new PlatformInformation('neutral', 'neutral');
         if (!(await installPackageJsonDependency('Razor', packageJSON, platformNeutral))) {
             throw Error('Failed to download package.');
         }

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -138,26 +138,23 @@ async function acquireRoslyn(
 }
 
 async function installRazor(packageJSON: any, platformInfo: PlatformInformation) {
-    if (!(await installPackageJsonDependency('Razor', packageJSON, platformInfo))) {
-        // Try downloading platform neutral package instead
+    if (platformInfo === undefined) {
         const platformNeutral = new PlatformInformation('neutral', 'neutral');
-        if (!(await installPackageJsonDependency('Razor', packageJSON, platformNeutral))) {
-            throw Error('Failed to download package.');
-        }
+        return await installPackageJsonDependency('Razor', packageJSON, platformNeutral);
     }
+
+    return await installPackageJsonDependency('Razor', packageJSON, platformInfo);
 }
 
 async function installDebugger(packageJSON: any, platformInfo: PlatformInformation) {
-    if (!(await installPackageJsonDependency('Debugger', packageJSON, platformInfo))) {
-        throw Error('Failed to download package.');
-    }
+    return await installPackageJsonDependency('Debugger', packageJSON, platformInfo);
 }
 
 async function installPackageJsonDependency(
     dependencyName: string,
     packageJSON: any,
     platformInfo: PlatformInformation
-): Promise<boolean> {
+) {
     const eventStream = new EventStream();
     const logger = new Logger((message) => process.stdout.write(message));
     const stdoutObserver = new CsharpLoggerObserver(logger);
@@ -172,10 +169,8 @@ async function installPackageJsonDependency(
     );
     const provider = () => new NetworkSettings('', true);
     if (!(await downloadAndInstallPackages(packagesToInstall, provider, eventStream, isValidDownload))) {
-        return false;
+        throw Error('Failed to download package.');
     }
-
-    return true;
 }
 
 async function acquireNugetPackage(packageName: string, packageVersion: string, interactive: boolean): Promise<string> {


### PR DESCRIPTION
Supports platform agnostic language server + telemetry for Razor in the case that the user isn't using an officially supported platform and architecture.