### PR TITLE
Actually use runtimes equal to 7.0

### DIFF
--- a/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
+++ b/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
@@ -153,7 +153,7 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
             let matchingRuntime: RuntimeInfo | undefined = undefined;
             for (const runtime of coreRuntimeVersions) {
                 // We consider a match if the runtime is greater than or equal to the required version since we roll forward.
-                if (semver.gt(runtime.Version, requiredRuntimeVersion)) {
+                if (semver.gte(runtime.Version, requiredRuntimeVersion)) {
                     matchingRuntime = runtime;
                     break;
                 }


### PR DESCRIPTION
Found in https://github.com/dotnet/vscode-csharp/issues/6599

Before:
```
Failed to find dotnet info from path, falling back to acquire runtime via ms-dotnettools.vscode-dotnet-runtime
No compatible .NET runtime found. Minimum required version is 7.0.
Dotnet path: c:\Users\WDAGUtilityAccount\AppData\Roaming\Code\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\7.0.13~x64\dotnet.exe
```

After:
```
Using dotnet configured on PATH
Dotnet path: C:\Program Files\dotnet\dotnet.exe
```

With dotnet --info:
```
.NET SDK:
 Version:   7.0.100
 Commit:    e12b7af219

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\7.0.100\

Host:
  Version:      7.0.0
  Architecture: x64
  Commit:       d099f075e4

.NET SDKs installed:
  7.0.100 [C:\Program Files\dotnet\sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 7.0.0 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 7.0.0 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 7.0.0 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

Other architectures found:
  None

Environment variables:
  Not set

global.json file:
  Not found

Learn more:
  https://aka.ms/dotnet/info

Download .NET:
  https://aka.ms/dotnet/download
```