### PR TITLE
Integration Test - TagHelper Quick Info (Hover)

### DIFF
--- a/test/razorIntegrationTests/formatting.integration.test.ts
+++ b/test/razorIntegrationTests/formatting.integration.test.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as jestLib from '@jest/globals';
+import { describe, beforeAll, afterAll, test, expect } from '@jest/globals';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
 import * as integrationHelpers from '../integrationTests/integrationHelpers';
 
@@ -21,8 +21,8 @@ function normalizeNewlines(original: string | undefined): string | undefined {
     return original;
 }
 
-jestLib.describe(`Razor Formatting ${testAssetWorkspace.description}`, function () {
-    jestLib.beforeAll(async function () {
+describe(`Razor Formatting ${testAssetWorkspace.description}`, function () {
+    beforeAll(async function () {
         if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
             return;
         }
@@ -36,11 +36,11 @@ jestLib.describe(`Razor Formatting ${testAssetWorkspace.description}`, function 
         await integrationHelpers.activateCSharpExtension();
     });
 
-    jestLib.afterAll(async () => {
+    afterAll(async () => {
         await testAssetWorkspace.cleanupWorkspace();
     });
 
-    jestLib.test('Document formatted correctly', async () => {
+    test('Document formatted correctly', async () => {
         if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
             return;
         }
@@ -59,7 +59,7 @@ jestLib.describe(`Razor Formatting ${testAssetWorkspace.description}`, function 
             }
         );
 
-        jestLib.expect(edits).toBeDefined();
+        expect(edits).toBeDefined();
 
         console.log(`Got ${edits.length} edits`);
 
@@ -75,7 +75,7 @@ jestLib.describe(`Razor Formatting ${testAssetWorkspace.description}`, function 
 
         console.log(`Checking document contents...`);
 
-        jestLib.expect(contents).toBe(
+        expect(contents).toBe(
             normalizeNewlines(`@page "/bad"
 
 @code {

--- a/test/razorIntegrationTests/hover.integration.test.ts
+++ b/test/razorIntegrationTests/hover.integration.test.ts
@@ -37,7 +37,7 @@ jestLib.describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
             'vscode.executeHoverProvider',
             activeDocument,
             {
-                line: 8,
+                line: 7,
                 character: 2,
             }
         );
@@ -46,6 +46,8 @@ jestLib.describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
 
         jestLib.expect(hover.length).toBe(1);
         const first = hover[0];
-        jestLib.expect(first.contents).toContain('input');
+        const answer =
+            'The input element represents a typed data field, usually with a form control to allow the user to edit the data.';
+        jestLib.expect((<{ language: string; value: string }>first.contents[0]).value).toContain(answer);
     });
 });

--- a/test/razorIntegrationTests/hover.integration.test.ts
+++ b/test/razorIntegrationTests/hover.integration.test.ts
@@ -5,12 +5,12 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as jestLib from '@jest/globals';
+import { describe, beforeAll, afterAll, test, expect } from '@jest/globals';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
 import * as integrationHelpers from '../integrationTests/integrationHelpers';
 
-jestLib.describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
-    jestLib.beforeAll(async function () {
+describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
+    beforeAll(async function () {
         if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
             return;
         }
@@ -19,11 +19,11 @@ jestLib.describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
         await integrationHelpers.activateCSharpExtension();
     });
 
-    jestLib.afterAll(async () => {
+    afterAll(async () => {
         await testAssetWorkspace.cleanupWorkspace();
     });
 
-    jestLib.test('Tag Helper Hover', async () => {
+    test('Tag Helper Hover', async () => {
         if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
             return;
         }
@@ -42,12 +42,12 @@ jestLib.describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
             }
         );
 
-        jestLib.expect(hover).toBeDefined();
+        expect(hover).toBeDefined();
 
-        jestLib.expect(hover.length).toBe(1);
+        expect(hover.length).toBe(1);
         const first = hover[0];
         const answer =
             'The input element represents a typed data field, usually with a form control to allow the user to edit the data.';
-        jestLib.expect((<{ language: string; value: string }>first.contents[0]).value).toContain(answer);
+        expect((<{ language: string; value: string }>first.contents[0]).value).toContain(answer);
     });
 });

--- a/test/razorIntegrationTests/hover.integration.tests.ts
+++ b/test/razorIntegrationTests/hover.integration.tests.ts
@@ -37,8 +37,8 @@ jestLib.describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
             'vscode.executeHoverProvider',
             activeDocument,
             {
-                line: 7,
-                character: 16,
+                line: 8,
+                character: 2,
             }
         );
 
@@ -46,6 +46,6 @@ jestLib.describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
 
         jestLib.expect(hover.length).toBe(1);
         const first = hover[0];
-        jestLib.expect(first.contents).toContain('The h1 element represents a section heading.');
+        jestLib.expect(first.contents).toContain('input');
     });
 });

--- a/test/razorIntegrationTests/hover.integration.tests.ts
+++ b/test/razorIntegrationTests/hover.integration.tests.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as jestLib from '@jest/globals';
+import testAssetWorkspace from './testAssets/testAssetWorkspace';
+import * as integrationHelpers from '../integrationTests/integrationHelpers';
+
+jestLib.describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
+    jestLib.beforeAll(async function () {
+        if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
+            return;
+        }
+
+        await integrationHelpers.openFileInWorkspaceAsync(path.join('Pages', 'Index.cshtml'));
+        await integrationHelpers.activateCSharpExtension();
+    });
+
+    jestLib.afterAll(async () => {
+        await testAssetWorkspace.cleanupWorkspace();
+    });
+
+    jestLib.test('Tag Helper Hover', async () => {
+        if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
+            return;
+        }
+
+        const activeDocument = vscode.window.activeTextEditor?.document.uri;
+        if (!activeDocument) {
+            throw new Error('No active document');
+        }
+
+        const hover = <vscode.Hover[]>await vscode.commands.executeCommand(
+            'vscode.executeHoverProvider',
+            activeDocument,
+            {
+                line: 7,
+                character: 16,
+            }
+        );
+
+        jestLib.expect(hover).toBeDefined();
+
+        jestLib.expect(hover.length).toBe(1);
+        const first = hover[0];
+        jestLib.expect(first.contents).toContain('The h1 element represents a section heading.');
+    });
+});

--- a/test/razorIntegrationTests/testAssets/BasicRazorApp2_1/Pages/Index.cshtml
+++ b/test/razorIntegrationTests/testAssets/BasicRazorApp2_1/Pages/Index.cshtml
@@ -5,3 +5,4 @@
 }
 
 <h1>@(message)</h1>
+<input asp-for="Model.PropertyName" />


### PR DESCRIPTION
This PR adds an integration test for `TagHelper Quick Info` (hovering over a TagHelper).

Issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1861423/