### PR TITLE
Add a timeout for downloading razor telemetry

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -36,6 +36,7 @@
   "Cancel": "Cancel",
   "Replace existing build and debug assets?": "Replace existing build and debug assets?",
   "Unable to generate assets to build and debug. {0}.": "Unable to generate assets to build and debug. {0}.",
+  "Downloading Razor Telemetry Package": "Downloading Razor Telemetry Package",
   "Cannot load Razor language server because the directory was not found: '{0}'": "Cannot load Razor language server because the directory was not found: '{0}'",
   "Could not find '{0}' in or above '{1}'.": "Could not find '{0}' in or above '{1}'.",
   "Invalid trace setting for Razor language server. Defaulting to '{0}'": "Invalid trace setting for Razor language server. Defaulting to '{0}'",

--- a/src/packageManager/fileDownloader.ts
+++ b/src/packageManager/fileDownloader.ts
@@ -66,6 +66,7 @@ async function downloadFile(
         agent: getProxyAgent(url, proxy, strictSSL),
         port: url.port,
         rejectUnauthorized: strictSSL,
+        timeout: 5 * 60 * 1000, // timeout is in milliseconds
     };
 
     const buffers: any[] = [];
@@ -127,6 +128,10 @@ async function downloadFile(
                     )
                 );
             });
+        });
+
+        request.on('timeout', () => {
+            request.destroy(new Error(`Timed out trying to download ${urlString}.`));
         });
 
         request.on('error', (err) => {

--- a/src/razor/razorTelemetryDownloader.ts
+++ b/src/razor/razorTelemetryDownloader.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscode from 'vscode';
 import { PlatformInformation } from '../shared/platform';
 import { PackageInstallation, LogPlatformInfo, InstallationSuccess } from '../omnisharp/loggingEvents';
 import { EventStream } from '../eventStream';
@@ -42,17 +43,27 @@ export class RazorTelemetryDownloader {
         if (packagesToInstall.length > 0) {
             this.eventStream.post(new PackageInstallation(`Razor Telemetry Version = ${version}`));
             this.eventStream.post(new LogPlatformInfo(this.platformInfo));
-            if (
-                await downloadAndInstallPackages(
-                    packagesToInstall,
-                    this.networkSettingsProvider,
-                    this.eventStream,
-                    isValidDownload
-                )
-            ) {
-                this.eventStream.post(new InstallationSuccess());
-                return true;
-            }
+            await vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: vscode.l10n.t('Downloading Razor Telemetry Package'),
+                    cancellable: true,
+                },
+                async (_, token) => {
+                    if (
+                        await downloadAndInstallPackages(
+                            packagesToInstall,
+                            this.networkSettingsProvider,
+                            this.eventStream,
+                            isValidDownload,
+                            token
+                        )
+                    ) {
+                        this.eventStream.post(new InstallationSuccess());
+                        return true;
+                    }
+                }
+            );
         }
 
         return false;

--- a/src/razor/src/extension.ts
+++ b/src/razor/src/extension.ts
@@ -6,6 +6,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as vscodeapi from 'vscode';
+import * as util from '../../common';
 import { ExtensionContext } from 'vscode';
 import { BlazorDebugConfigurationProvider } from './blazorDebug/blazorDebugConfigurationProvider';
 import { CodeActionsHandler } from './codeActions/codeActionsHandler';
@@ -99,9 +100,19 @@ export async function activate(
         // Save user's DOTNET_ROOT env-var value so server can recover the user setting when needed
         env.DOTNET_ROOT_USER = process.env.DOTNET_ROOT ?? 'EMPTY';
 
+        let telemetryExtensionDllPath = '';
         // Set up DevKit environment for telemetry
         if (csharpDevkitExtension) {
             await setupDevKitEnvironment(env, csharpDevkitExtension, logger);
+
+            const telemetryExtensionPath = path.join(
+                util.getExtensionPath(),
+                '.razortelemetry',
+                'Microsoft.VisualStudio.DevKit.Razor.dll'
+            );
+            if (await util.fileExists(telemetryExtensionPath)) {
+                telemetryExtensionDllPath = telemetryExtensionPath;
+            }
         }
 
         const languageServerClient = new RazorLanguageServerClient(
@@ -109,7 +120,7 @@ export async function activate(
             languageServerDir,
             razorTelemetryReporter,
             vscodeTelemetryReporter,
-            csharpDevkitExtension !== undefined,
+            telemetryExtensionDllPath,
             env,
             dotnetInfo.path,
             logger

--- a/src/razor/src/razorLanguageServerClient.ts
+++ b/src/razor/src/razorLanguageServerClient.ts
@@ -3,10 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as cp from 'child_process';
 import { EventEmitter } from 'events';
-import * as util from '../../common';
 import * as vscode from 'vscode';
 import { RequestHandler, RequestType } from 'vscode-jsonrpc';
 import { GenericNotificationHandler, InitializeResult, LanguageClientOptions, State } from 'vscode-languageclient';
@@ -40,7 +38,7 @@ export class RazorLanguageServerClient implements vscode.Disposable {
         private readonly languageServerDir: string,
         private readonly razorTelemetryReporter: RazorTelemetryReporter,
         private readonly vscodeTelemetryReporter: TelemetryReporter,
-        private readonly isCSharpDevKitActivated: boolean,
+        private readonly telemetryExtensionDllPath: string,
         private readonly env: NodeJS.ProcessEnv,
         private readonly dotnetExecutablePath: string,
         private readonly logger: RazorLogger
@@ -249,13 +247,10 @@ export class RazorLanguageServerClient implements vscode.Disposable {
             args.push('--UpdateBuffersForClosedDocuments');
             args.push('true');
 
-            if (this.isCSharpDevKitActivated) {
+            if (this.telemetryExtensionDllPath.length > 0) {
                 args.push('--telemetryLevel', this.vscodeTelemetryReporter.telemetryLevel);
                 args.push('--sessionId', getSessionId());
-                args.push(
-                    '--telemetryExtensionPath',
-                    path.join(util.getExtensionPath(), '.razortelemetry', 'Microsoft.VisualStudio.DevKit.Razor.dll')
-                );
+                args.push('--telemetryExtensionPath', this.telemetryExtensionDllPath);
             }
         }
 

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -29,6 +29,7 @@ import { getPackageJSON } from '../tasks/packageJson';
 import { createPackageAsync } from '../tasks/vsceTasks';
 import { isValidDownload } from '../src/packageManager/isValidDownload';
 import path = require('path');
+import { CancellationToken } from 'vscode';
 // There are no typings for this library.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const argv = require('yargs').argv;
@@ -153,7 +154,8 @@ async function installDebugger(packageJSON: any, platformInfo: PlatformInformati
 async function installPackageJsonDependency(
     dependencyName: string,
     packageJSON: any,
-    platformInfo: PlatformInformation
+    platformInfo: PlatformInformation,
+    token?: CancellationToken
 ) {
     const eventStream = new EventStream();
     const logger = new Logger((message) => process.stdout.write(message));
@@ -168,7 +170,7 @@ async function installPackageJsonDependency(
         codeExtensionPath
     );
     const provider = () => new NetworkSettings('', true);
-    if (!(await downloadAndInstallPackages(packagesToInstall, provider, eventStream, isValidDownload))) {
+    if (!(await downloadAndInstallPackages(packagesToInstall, provider, eventStream, isValidDownload, token))) {
         throw Error('Failed to download package.');
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-csharp/issues/6547

The issue these users are having is to do with their proxy settings in VS Code, and is happening inside where we already have error handling for the download, so it seems like node is just stuck downloading. The only recourse I could work out was a timeout, so at least we're not blocking users _forever_.