### PR TITLE
Ensure artifacts get published in a single folder

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -29,12 +29,11 @@ jobs:
     displayName: 'Build VSIXs'
 
   - task: PublishBuildArtifacts@1
-    # Run the publish step so we have vsix's even if the tests fail.
-    condition: succeededOrFailed()
+    condition: succeeded()
     displayName: 'Publish VSIXs'
     inputs:
       PathtoPublish: '$(Build.SourcesDirectory)/vsix'
-      ArtifactName: 'VSIX_Prerelease_$(System.JobAttempt)'
+      ArtifactName: 'VSIX_Prerelease'
 
   - script: npm run test:artifacts
     displayName: 'Run artifacts tests'
@@ -59,12 +58,11 @@ jobs:
     displayName: 'Build VSIXs'
 
   - task: PublishBuildArtifacts@1
-    # Run the publish step so we have vsix's even if the tests fail.
-    condition: succeededOrFailed()
+    condition: succeeded()
     displayName: 'Publish VSIXs'
     inputs:
       PathtoPublish: '$(Build.SourcesDirectory)/vsix'
-      ArtifactName: 'VSIX_Release_$(System.JobAttempt)'
+      ArtifactName: 'VSIX_Release'
 
   - script: npm run test:artifacts
     displayName: 'Run artifacts tests'


### PR DESCRIPTION
If one of the build platforms (e.g. linux) has multiple attempts, we'd end up uploading some vsixs under attempt 1, and other platforms under attempt 2

Since we no longer run tests in the same run as the build, we can upload artifacts only on successful builds without an attempt number.