### PR TITLE
Replace jestlib import with regular import

### DIFF
--- a/omnisharptest/omnisharpUnitTests/optionChangeObserver.test.ts
+++ b/omnisharptest/omnisharpUnitTests/optionChangeObserver.test.ts
@@ -7,11 +7,11 @@ import { timeout } from 'rxjs/operators';
 import { from as observableFrom, Subject, BehaviorSubject } from 'rxjs';
 import { registerOmnisharpOptionChanges } from '../../src/omnisharp/omnisharpOptionChanges';
 
-import * as jestLib from '@jest/globals';
+import { describe, beforeEach, test, expect } from '@jest/globals';
 import * as vscode from 'vscode';
 import { getVSCodeWithConfig, updateConfig } from '../../test/unitTests/fakes';
 
-jestLib.describe('OmniSharpConfigChangeObserver', () => {
+describe('OmniSharpConfigChangeObserver', () => {
     let doClickOk: () => void;
     let doClickCancel: () => void;
     let signalCommandDone: () => void;
@@ -20,7 +20,7 @@ jestLib.describe('OmniSharpConfigChangeObserver', () => {
     let invokedCommand: string | undefined;
     let optionObservable: Subject<void>;
 
-    jestLib.beforeEach(() => {
+    beforeEach(() => {
         resetMocks();
         optionObservable = new BehaviorSubject<void>(undefined);
         infoMessage = undefined;
@@ -40,80 +40,64 @@ jestLib.describe('OmniSharpConfigChangeObserver', () => {
         { config: 'omnisharp', section: 'useModernNet', value: false },
         { config: 'omnisharp', section: 'loggingLevel', value: 'verbose' },
     ].forEach((elem) => {
-        jestLib.describe(`When the ${elem.config} ${elem.section} changes`, () => {
-            jestLib.beforeEach(() => {
-                jestLib.expect(infoMessage).toBe(undefined);
-                jestLib.expect(invokedCommand).toBe(undefined);
+        describe(`When the ${elem.config} ${elem.section} changes`, () => {
+            beforeEach(() => {
+                expect(infoMessage).toBe(undefined);
+                expect(invokedCommand).toBe(undefined);
                 updateConfig(vscode, elem.config, elem.section, elem.value);
                 optionObservable.next();
             });
 
-            jestLib.test(`The information message is shown`, async () => {
-                jestLib
-                    .expect(infoMessage)
-                    .toEqual(
-                        'C# configuration has changed. Would you like to relaunch the Language Server with your changes?'
-                    );
+            test(`The information message is shown`, async () => {
+                expect(infoMessage).toEqual(
+                    'C# configuration has changed. Would you like to relaunch the Language Server with your changes?'
+                );
             });
 
-            jestLib.test(
-                'Given an information message if the user clicks cancel, the command is not executed',
-                async () => {
-                    doClickCancel();
-                    const from = observableFrom(commandDone!).pipe(timeout(1));
-                    const fromPromise = from.toPromise();
-                    await jestLib.expect(fromPromise).rejects.toThrow();
-                    jestLib.expect(invokedCommand).toBe(undefined);
-                }
-            );
+            test('Given an information message if the user clicks cancel, the command is not executed', async () => {
+                doClickCancel();
+                const from = observableFrom(commandDone!).pipe(timeout(1));
+                const fromPromise = from.toPromise();
+                await expect(fromPromise).rejects.toThrow();
+                expect(invokedCommand).toBe(undefined);
+            });
 
-            jestLib.test(
-                'Given an information message if the user clicks Reload, the command is executed',
-                async () => {
-                    doClickOk();
-                    await commandDone;
-                    jestLib.expect(invokedCommand).toEqual('o.restart');
-                }
-            );
+            test('Given an information message if the user clicks Reload, the command is executed', async () => {
+                doClickOk();
+                await commandDone;
+                expect(invokedCommand).toEqual('o.restart');
+            });
         });
     });
 
     [{ config: 'dotnet', section: 'server.useOmnisharp', value: true }].forEach((elem) => {
-        jestLib.describe(`When the ${elem.config} ${elem.section} changes`, () => {
-            jestLib.beforeEach(() => {
-                jestLib.expect(infoMessage).toBe(undefined);
-                jestLib.expect(invokedCommand).toBe(undefined);
+        describe(`When the ${elem.config} ${elem.section} changes`, () => {
+            beforeEach(() => {
+                expect(infoMessage).toBe(undefined);
+                expect(invokedCommand).toBe(undefined);
                 updateConfig(vscode, elem.config, elem.section, elem.value);
                 optionObservable.next();
             });
 
-            jestLib.test(`The information message is shown`, async () => {
-                jestLib
-                    .expect(infoMessage)
-                    .toEqual(
-                        'dotnet.server.useOmnisharp option has changed. Please reload the window to apply the change'
-                    );
+            test(`The information message is shown`, async () => {
+                expect(infoMessage).toEqual(
+                    'dotnet.server.useOmnisharp option has changed. Please reload the window to apply the change'
+                );
             });
 
-            jestLib.test(
-                'Given an information message if the user clicks cancel, the command is not executed',
-                async () => {
-                    doClickCancel();
-                    const from = observableFrom(commandDone!).pipe(timeout(1));
-                    const fromPromise = from.toPromise();
-                    await jestLib.expect(fromPromise).rejects.toThrow();
-                    jestLib.expect(invokedCommand).toBe(undefined);
-                }
-            );
+            test('Given an information message if the user clicks cancel, the command is not executed', async () => {
+                doClickCancel();
+                const from = observableFrom(commandDone!).pipe(timeout(1));
+                const fromPromise = from.toPromise();
+                await expect(fromPromise).rejects.toThrow();
+                expect(invokedCommand).toBe(undefined);
+            });
 
-            jestLib.test(
-                'Given an information message if the user clicks Reload, the command is executed',
-                async () => {
-                    doClickOk();
-                    await commandDone;
-                    jestLib.expect(invokedCommand).toEqual('workbench.action.reloadWindow');
-                }
-            );
+            test('Given an information message if the user clicks Reload, the command is executed', async () => {
+                doClickOk();
+                await commandDone;
+                expect(invokedCommand).toEqual('workbench.action.reloadWindow');
+            });
         });
     });
 
@@ -127,12 +111,12 @@ jestLib.describe('OmniSharpConfigChangeObserver', () => {
         { config: 'omnisharp', section: 'projectLoadTimeout', value: 1000 },
         { config: 'omnisharp', section: 'autoStart', value: false },
     ].forEach((elem) => {
-        jestLib.test(`Information Message is not shown on change in ${elem.config}.${elem.section}`, () => {
-            jestLib.expect(infoMessage).toBe(undefined);
-            jestLib.expect(invokedCommand).toBe(undefined);
+        test(`Information Message is not shown on change in ${elem.config}.${elem.section}`, () => {
+            expect(infoMessage).toBe(undefined);
+            expect(invokedCommand).toBe(undefined);
             updateConfig(vscode, elem.config, elem.section, elem.value);
             optionObservable.next();
-            jestLib.expect(infoMessage).toBe(undefined);
+            expect(infoMessage).toBe(undefined);
         });
     });
 

--- a/test/integrationTests/lspInlayHints.integration.test.ts
+++ b/test/integrationTests/lspInlayHints.integration.test.ts
@@ -5,13 +5,13 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as jestLib from '@jest/globals';
+import { describe, beforeAll, afterAll, test, expect } from '@jest/globals';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
 import * as integrationHelpers from './integrationHelpers';
 import { InlayHint, InlayHintKind, Position } from 'vscode-languageserver-protocol';
 
-jestLib.describe(`[${testAssetWorkspace.description}] Test LSP Inlay Hints `, function () {
-    jestLib.beforeAll(async function () {
+describe(`[${testAssetWorkspace.description}] Test LSP Inlay Hints `, function () {
+    beforeAll(async function () {
         const editorConfig = vscode.workspace.getConfiguration('editor');
         await editorConfig.update('inlayHints.enabled', true);
         const dotnetConfig = vscode.workspace.getConfiguration('dotnet');
@@ -34,11 +34,11 @@ jestLib.describe(`[${testAssetWorkspace.description}] Test LSP Inlay Hints `, fu
         await integrationHelpers.activateCSharpExtension();
     });
 
-    jestLib.afterAll(async () => {
+    afterAll(async () => {
         await testAssetWorkspace.cleanupWorkspace();
     });
 
-    jestLib.test('Hints retrieved for region', async () => {
+    test('Hints retrieved for region', async () => {
         const range = new vscode.Range(new vscode.Position(4, 8), new vscode.Position(15, 85));
         const activeDocument = vscode.window.activeTextEditor?.document.uri;
         if (!activeDocument) {
@@ -50,7 +50,7 @@ jestLib.describe(`[${testAssetWorkspace.description}] Test LSP Inlay Hints `, fu
             range
         );
 
-        jestLib.expect(hints).toHaveLength(6);
+        expect(hints).toHaveLength(6);
 
         assertInlayHintEqual(hints[0], InlayHint.create(Position.create(6, 12), 'InlayHints', InlayHintKind.Type));
         assertInlayHintEqual(hints[1], InlayHint.create(Position.create(7, 27), 'InlayHints', InlayHintKind.Type));
@@ -61,10 +61,10 @@ jestLib.describe(`[${testAssetWorkspace.description}] Test LSP Inlay Hints `, fu
 
         function assertInlayHintEqual(actual: vscode.InlayHint, expected: InlayHint) {
             const actualLabel = actual.label as string;
-            jestLib.expect(actualLabel).toBe(expected.label);
-            jestLib.expect(actual.position.line).toBe(expected.position.line);
-            jestLib.expect(actual.position.character).toBe(expected.position.character);
-            jestLib.expect(actual.kind).toBe(expected.kind);
+            expect(actualLabel).toBe(expected.label);
+            expect(actual.position.line).toBe(expected.position.line);
+            expect(actual.position.character).toBe(expected.position.character);
+            expect(actual.kind).toBe(expected.kind);
         }
     });
 });

--- a/test/integrationTests/unitTests.integration.test.ts
+++ b/test/integrationTests/unitTests.integration.test.ts
@@ -5,17 +5,17 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as jestLib from '@jest/globals';
+import { describe, beforeAll, beforeEach, afterAll, test, expect } from '@jest/globals';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
 import { activateCSharpExtension, openFileInWorkspaceAsync } from './integrationHelpers';
 import { TestProgress } from '../../src/lsptoolshost/roslynProtocol';
 
-jestLib.describe(`[${testAssetWorkspace.description}] Test Unit Testing`, function () {
-    jestLib.beforeAll(async function () {
+describe(`[${testAssetWorkspace.description}] Test Unit Testing`, function () {
+    beforeAll(async function () {
         await activateCSharpExtension();
     });
 
-    jestLib.beforeEach(async function () {
+    beforeEach(async function () {
         vscode.workspace
             .getConfiguration()
             .update('dotnet.unitTests.runSettingsPath', undefined, vscode.ConfigurationTarget.Workspace);
@@ -23,69 +23,69 @@ jestLib.describe(`[${testAssetWorkspace.description}] Test Unit Testing`, functi
         await openFileInWorkspaceAsync(fileName);
     });
 
-    jestLib.afterAll(async () => {
+    afterAll(async () => {
         await testAssetWorkspace.cleanupWorkspace();
     });
 
-    jestLib.test('Unit test code lens items are displayed', async () => {
+    test('Unit test code lens items are displayed', async () => {
         const codeLenses = await getCodeLensesAsync();
-        jestLib.expect(codeLenses).toHaveLength(9);
+        expect(codeLenses).toHaveLength(9);
 
         const classRange = new vscode.Range(new vscode.Position(5, 17), new vscode.Position(5, 26));
 
         // Class level debug all tests
-        jestLib.expect(codeLenses[1].command?.command).toBe('dotnet.test.run');
-        jestLib.expect(codeLenses[1].command?.title).toBe('Debug All Tests');
-        jestLib.expect(codeLenses[1].command?.arguments![0].attachDebugger).toBe(true);
-        jestLib.expect(codeLenses[1].range).toStrictEqual(classRange);
+        expect(codeLenses[1].command?.command).toBe('dotnet.test.run');
+        expect(codeLenses[1].command?.title).toBe('Debug All Tests');
+        expect(codeLenses[1].command?.arguments![0].attachDebugger).toBe(true);
+        expect(codeLenses[1].range).toStrictEqual(classRange);
 
         // Class level run all tests
-        jestLib.expect(codeLenses[2].command?.command).toBe('dotnet.test.run');
-        jestLib.expect(codeLenses[2].command?.title).toBe('Run All Tests');
-        jestLib.expect(codeLenses[2].command?.arguments![0].attachDebugger).toBe(false);
-        jestLib.expect(codeLenses[2].range).toStrictEqual(classRange);
+        expect(codeLenses[2].command?.command).toBe('dotnet.test.run');
+        expect(codeLenses[2].command?.title).toBe('Run All Tests');
+        expect(codeLenses[2].command?.arguments![0].attachDebugger).toBe(false);
+        expect(codeLenses[2].range).toStrictEqual(classRange);
 
         let methodRange = new vscode.Range(new vscode.Position(8, 20), new vscode.Position(8, 25));
         // Method level run and debug test
-        jestLib.expect(codeLenses[4].command?.command).toBe('dotnet.test.run');
-        jestLib.expect(codeLenses[4].command?.title).toBe('Debug Test');
-        jestLib.expect(codeLenses[4].command?.arguments![0].attachDebugger).toBe(true);
-        jestLib.expect(codeLenses[4].range).toStrictEqual(methodRange);
-        jestLib.expect(codeLenses[5].command?.command).toBe('dotnet.test.run');
-        jestLib.expect(codeLenses[5].command?.title).toBe('Run Test');
-        jestLib.expect(codeLenses[5].command?.arguments![0].attachDebugger).toBe(false);
-        jestLib.expect(codeLenses[5].range).toStrictEqual(methodRange);
+        expect(codeLenses[4].command?.command).toBe('dotnet.test.run');
+        expect(codeLenses[4].command?.title).toBe('Debug Test');
+        expect(codeLenses[4].command?.arguments![0].attachDebugger).toBe(true);
+        expect(codeLenses[4].range).toStrictEqual(methodRange);
+        expect(codeLenses[5].command?.command).toBe('dotnet.test.run');
+        expect(codeLenses[5].command?.title).toBe('Run Test');
+        expect(codeLenses[5].command?.arguments![0].attachDebugger).toBe(false);
+        expect(codeLenses[5].range).toStrictEqual(methodRange);
 
         methodRange = new vscode.Range(new vscode.Position(15, 20), new vscode.Position(15, 25));
-        jestLib.expect(codeLenses[7].command?.command).toBe('dotnet.test.run');
-        jestLib.expect(codeLenses[7].command?.title).toBe('Debug Test');
-        jestLib.expect(codeLenses[7].command?.arguments![0].attachDebugger).toBe(true);
-        jestLib.expect(codeLenses[7].range).toStrictEqual(methodRange);
-        jestLib.expect(codeLenses[8].command?.command).toBe('dotnet.test.run');
-        jestLib.expect(codeLenses[8].command?.title).toBe('Run Test');
-        jestLib.expect(codeLenses[8].command?.arguments![0].attachDebugger).toBe(false);
-        jestLib.expect(codeLenses[8].range).toStrictEqual(methodRange);
+        expect(codeLenses[7].command?.command).toBe('dotnet.test.run');
+        expect(codeLenses[7].command?.title).toBe('Debug Test');
+        expect(codeLenses[7].command?.arguments![0].attachDebugger).toBe(true);
+        expect(codeLenses[7].range).toStrictEqual(methodRange);
+        expect(codeLenses[8].command?.command).toBe('dotnet.test.run');
+        expect(codeLenses[8].command?.title).toBe('Run Test');
+        expect(codeLenses[8].command?.arguments![0].attachDebugger).toBe(false);
+        expect(codeLenses[8].range).toStrictEqual(methodRange);
     });
 
-    jestLib.test('Code lens command executes tests', async () => {
+    test('Code lens command executes tests', async () => {
         const codeLenses = await getCodeLensesAsync();
-        jestLib.expect(codeLenses).toHaveLength(9);
+        expect(codeLenses).toHaveLength(9);
 
         const runAllTestsCommand = codeLenses[2].command!;
-        jestLib.expect(runAllTestsCommand.title).toBe('Run All Tests');
+        expect(runAllTestsCommand.title).toBe('Run All Tests');
 
         const testResults = await vscode.commands.executeCommand<TestProgress | undefined>(
             runAllTestsCommand.command,
             runAllTestsCommand.arguments![0]
         );
-        jestLib.expect(testResults).toBeDefined();
-        jestLib.expect(testResults?.totalTests).toEqual(2);
-        jestLib.expect(testResults?.testsPassed).toEqual(2);
-        jestLib.expect(testResults?.testsFailed).toEqual(0);
-        jestLib.expect(testResults?.testsSkipped).toEqual(0);
+        expect(testResults).toBeDefined();
+        expect(testResults?.totalTests).toEqual(2);
+        expect(testResults?.testsPassed).toEqual(2);
+        expect(testResults?.testsFailed).toEqual(0);
+        expect(testResults?.testsSkipped).toEqual(0);
     });
 
-    jestLib.test('dotnet.test.runTestsInContext executes tests', async () => {
+    test('dotnet.test.runTestsInContext executes tests', async () => {
         const activeEditor = vscode.window.activeTextEditor;
         if (!activeEditor) {
             throw new Error('No active editor');
@@ -97,31 +97,31 @@ jestLib.describe(`[${testAssetWorkspace.description}] Test Unit Testing`, functi
             'dotnet.test.runTestsInContext',
             activeEditor
         );
-        jestLib.expect(testResults).toBeDefined();
-        jestLib.expect(testResults?.totalTests).toEqual(1);
-        jestLib.expect(testResults?.testsPassed).toEqual(1);
-        jestLib.expect(testResults?.testsFailed).toEqual(0);
-        jestLib.expect(testResults?.testsSkipped).toEqual(0);
+        expect(testResults).toBeDefined();
+        expect(testResults?.totalTests).toEqual(1);
+        expect(testResults?.testsPassed).toEqual(1);
+        expect(testResults?.testsFailed).toEqual(0);
+        expect(testResults?.testsSkipped).toEqual(0);
     });
 
-    jestLib.test('Run tests uses .runsettings', async () => {
+    test('Run tests uses .runsettings', async () => {
         await vscode.workspace.getConfiguration().update('dotnet.unitTests.runSettingsPath', '.runsettings');
 
         const codeLenses = await getCodeLensesAsync();
-        jestLib.expect(codeLenses).toHaveLength(9);
+        expect(codeLenses).toHaveLength(9);
 
         const runAllTestsCommand = codeLenses[2].command!;
-        jestLib.expect(runAllTestsCommand.title).toBe('Run All Tests');
+        expect(runAllTestsCommand.title).toBe('Run All Tests');
 
         const testResults = await vscode.commands.executeCommand<TestProgress | undefined>(
             runAllTestsCommand.command,
             runAllTestsCommand.arguments![0]
         );
-        jestLib.expect(testResults).toBeDefined();
-        jestLib.expect(testResults?.totalTests).toEqual(1);
-        jestLib.expect(testResults?.testsPassed).toEqual(1);
-        jestLib.expect(testResults?.testsFailed).toEqual(0);
-        jestLib.expect(testResults?.testsSkipped).toEqual(0);
+        expect(testResults).toBeDefined();
+        expect(testResults?.totalTests).toEqual(1);
+        expect(testResults?.testsPassed).toEqual(1);
+        expect(testResults?.testsFailed).toEqual(0);
+        expect(testResults?.testsSkipped).toEqual(0);
     });
 });
 

--- a/test/unitTests/configurationMiddleware.test.ts
+++ b/test/unitTests/configurationMiddleware.test.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync } from 'fs';
 import { convertServerOptionNameToClientConfigurationName } from '../../src/lsptoolshost/optionNameConverter';
-import * as jestLib from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 
 const editorBehaviorSection = 1;
 const testData = [
@@ -263,25 +263,22 @@ const testData = [
     },
 ];
 
-jestLib.describe('Server option name to vscode configuration name test', () => {
+describe('Server option name to vscode configuration name test', () => {
     const packageJson = JSON.parse(readFileSync('package.json').toString());
     const configurations = <any[]>packageJson['contributes']['configuration'];
     const numConfigurations = 5;
-    jestLib.test('Max server sections are expected', () => {
-        jestLib.expect(configurations.length).toBe(numConfigurations);
+    test('Max server sections are expected', () => {
+        expect(configurations.length).toBe(numConfigurations);
     });
 
     testData.forEach((data) => {
-        jestLib.test(
-            `Server option name ${data.serverOption} should be converted to ${data.vsCodeConfiguration}`,
-            () => {
-                const actualName = convertServerOptionNameToClientConfigurationName(data.serverOption);
-                jestLib.expect(actualName).toBe(data.vsCodeConfiguration);
-                if (data.declareInPackageJson) {
-                    const section = Object.keys(configurations[data.section!]['properties']);
-                    jestLib.expect(section).toContain(data.vsCodeConfiguration);
-                }
+        test(`Server option name ${data.serverOption} should be converted to ${data.vsCodeConfiguration}`, () => {
+            const actualName = convertServerOptionNameToClientConfigurationName(data.serverOption);
+            expect(actualName).toBe(data.vsCodeConfiguration);
+            if (data.declareInPackageJson) {
+                const section = Object.keys(configurations[data.section!]['properties']);
+                expect(section).toContain(data.vsCodeConfiguration);
             }
-        );
+        });
     });
 });

--- a/test/unitTests/json.test.ts
+++ b/test/unitTests/json.test.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { tolerantParse } from '../../src/json';
-import * as jestLib from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 
-jestLib.describe('JSON', () => {
-    jestLib.test('no comments', () => {
+describe('JSON', () => {
+    test('no comments', () => {
         const text = `{
     "hello": "world"
 }`;
@@ -15,10 +15,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(text);
+        expect(result).toEqual(text);
     });
 
-    jestLib.test('no comments (minified)', () => {
+    test('no comments (minified)', () => {
         const text = `{"hello":"world","from":"json"}`;
 
         const expected = `{
@@ -29,10 +29,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('single-line comment before JSON', () => {
+    test('single-line comment before JSON', () => {
         const text = `// comment
 {
     "hello": "world\\"" // comment
@@ -45,10 +45,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('single-line comment on separate line', () => {
+    test('single-line comment on separate line', () => {
         const text = `{
     // comment
     "hello": "world"
@@ -61,10 +61,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('single-line comment at end of line', () => {
+    test('single-line comment at end of line', () => {
         const text = `{
     "hello": "world" // comment
 }`;
@@ -76,10 +76,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('single-line comment at end of text', () => {
+    test('single-line comment at end of text', () => {
         const text = `{
     "hello": "world"
 } // comment`;
@@ -91,10 +91,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('ignore single-line comment inside string', () => {
+    test('ignore single-line comment inside string', () => {
         const text = `{
     "hello": "world // comment"
 }`;
@@ -102,10 +102,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(text);
+        expect(result).toEqual(text);
     });
 
-    jestLib.test('single-line comment after string with escaped double quote', () => {
+    test('single-line comment after string with escaped double quote', () => {
         const text = `{
     "hello": "world\\"" // comment
 }`;
@@ -117,10 +117,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('multi-line comment at start of text', () => {
+    test('multi-line comment at start of text', () => {
         const text = `/**/{
     "hello": "world"
 }`;
@@ -132,10 +132,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('comment out key/value pair', () => {
+    test('comment out key/value pair', () => {
         const text = `{
     /*"hello": "world"*/
     "from": "json"
@@ -148,10 +148,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('multi-line comment at end of text', () => {
+    test('multi-line comment at end of text', () => {
         const text = `{
     "hello": "world"
 }/**/`;
@@ -163,10 +163,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('ignore multi-line comment inside string', () => {
+    test('ignore multi-line comment inside string', () => {
         const text = `{
     "hello": "wo/**/rld"
 }`;
@@ -178,10 +178,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('ignore BOM', () => {
+    test('ignore BOM', () => {
         const text = `\uFEFF{
     "hello": "world"
 }`;
@@ -193,10 +193,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('ignore trailing comma in object member list', () => {
+    test('ignore trailing comma in object member list', () => {
         const text = `{
     "obj": {
         "hello": "world",
@@ -214,10 +214,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('ignore trailing comma in array element list', () => {
+    test('ignore trailing comma in array element list', () => {
         const text = `{
     "array": [
         "element1",
@@ -235,10 +235,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('ignore trailing comma in object member list with leading and trailing whitespace', () => {
+    test('ignore trailing comma in object member list with leading and trailing whitespace', () => {
         const text = `{
     "obj": { "a" : 1 , }
 }`;
@@ -252,10 +252,10 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 
-    jestLib.test('single-line comments in multiple locations', () => {
+    test('single-line comments in multiple locations', () => {
         const text = `
 // This comment should be allowed.
 {
@@ -287,6 +287,6 @@ jestLib.describe('JSON', () => {
         const json = tolerantParse(text);
         const result = JSON.stringify(json, null, 4);
 
-        jestLib.expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
     });
 });

--- a/test/unitTests/languageServerConfigChangeObserver.test.ts
+++ b/test/unitTests/languageServerConfigChangeObserver.test.ts
@@ -7,11 +7,11 @@ import { timeout } from 'rxjs/operators';
 import { from as observableFrom, Subject, BehaviorSubject } from 'rxjs';
 import { registerLanguageServerOptionChanges } from '../../src/lsptoolshost/optionChanges';
 
-import * as jestLib from '@jest/globals';
+import { describe, beforeEach, test, expect } from '@jest/globals';
 import * as vscode from 'vscode';
 import { getVSCodeWithConfig, updateConfig } from './fakes';
 
-jestLib.describe('Option changes observer', () => {
+describe('Option changes observer', () => {
     let doClickOk: () => void;
     let doClickCancel: () => void;
     let signalCommandDone: () => void;
@@ -20,7 +20,7 @@ jestLib.describe('Option changes observer', () => {
     let invokedCommand: string | undefined;
     let optionObservable: Subject<void>;
 
-    jestLib.beforeEach(() => {
+    beforeEach(() => {
         resetMocks();
         optionObservable = new BehaviorSubject<void>(undefined);
         infoMessage = undefined;
@@ -38,80 +38,64 @@ jestLib.describe('Option changes observer', () => {
         { config: 'dotnet', section: 'server.trace', value: 'trace' },
         { config: 'dotnet', section: 'preferCSharpExtension', value: true },
     ].forEach((elem) => {
-        jestLib.describe(`When the ${elem.config}.${elem.section} changes`, () => {
-            jestLib.beforeEach(() => {
-                jestLib.expect(infoMessage).toBe(undefined);
-                jestLib.expect(invokedCommand).toBe(undefined);
+        describe(`When the ${elem.config}.${elem.section} changes`, () => {
+            beforeEach(() => {
+                expect(infoMessage).toBe(undefined);
+                expect(invokedCommand).toBe(undefined);
                 updateConfig(vscode, elem.config, elem.section, elem.value);
                 optionObservable.next();
             });
 
-            jestLib.test(`The information message is shown`, async () => {
-                jestLib
-                    .expect(infoMessage)
-                    .toEqual(
-                        'C# configuration has changed. Would you like to reload the window to apply your changes?'
-                    );
+            test(`The information message is shown`, async () => {
+                expect(infoMessage).toEqual(
+                    'C# configuration has changed. Would you like to reload the window to apply your changes?'
+                );
             });
 
-            jestLib.test(
-                'Given an information message if the user clicks cancel, the command is not executed',
-                async () => {
-                    doClickCancel();
-                    const from = observableFrom(commandDone!).pipe(timeout(1));
-                    const fromPromise = from.toPromise();
-                    await jestLib.expect(fromPromise).rejects.toThrow();
-                    jestLib.expect(invokedCommand).toBe(undefined);
-                }
-            );
+            test('Given an information message if the user clicks cancel, the command is not executed', async () => {
+                doClickCancel();
+                const from = observableFrom(commandDone!).pipe(timeout(1));
+                const fromPromise = from.toPromise();
+                await expect(fromPromise).rejects.toThrow();
+                expect(invokedCommand).toBe(undefined);
+            });
 
-            jestLib.test(
-                'Given an information message if the user clicks Reload, the command is executed',
-                async () => {
-                    doClickOk();
-                    await commandDone;
-                    jestLib.expect(invokedCommand).toEqual('workbench.action.reloadWindow');
-                }
-            );
+            test('Given an information message if the user clicks Reload, the command is executed', async () => {
+                doClickOk();
+                await commandDone;
+                expect(invokedCommand).toEqual('workbench.action.reloadWindow');
+            });
         });
     });
 
     [{ config: 'dotnet', section: 'server.useOmnisharp', value: true }].forEach((elem) => {
-        jestLib.describe(`When the ${elem.config}.${elem.section} changes`, () => {
-            jestLib.beforeEach(() => {
-                jestLib.expect(infoMessage).toBe(undefined);
-                jestLib.expect(invokedCommand).toBe(undefined);
+        describe(`When the ${elem.config}.${elem.section} changes`, () => {
+            beforeEach(() => {
+                expect(infoMessage).toBe(undefined);
+                expect(invokedCommand).toBe(undefined);
                 updateConfig(vscode, elem.config, elem.section, elem.value);
                 optionObservable.next();
             });
 
-            jestLib.test(`The information message is shown`, async () => {
-                jestLib
-                    .expect(infoMessage)
-                    .toEqual(
-                        'dotnet.server.useOmnisharp option has changed. Please reload the window to apply the change'
-                    );
+            test(`The information message is shown`, async () => {
+                expect(infoMessage).toEqual(
+                    'dotnet.server.useOmnisharp option has changed. Please reload the window to apply the change'
+                );
             });
 
-            jestLib.test(
-                'Given an information message if the user clicks cancel, the command is not executed',
-                async () => {
-                    doClickCancel();
-                    const from = observableFrom(commandDone!).pipe(timeout(1));
-                    const fromPromise = from.toPromise();
-                    await jestLib.expect(fromPromise).rejects.toThrow();
-                    jestLib.expect(invokedCommand).toBe(undefined);
-                }
-            );
+            test('Given an information message if the user clicks cancel, the command is not executed', async () => {
+                doClickCancel();
+                const from = observableFrom(commandDone!).pipe(timeout(1));
+                const fromPromise = from.toPromise();
+                await expect(fromPromise).rejects.toThrow();
+                expect(invokedCommand).toBe(undefined);
+            });
 
-            jestLib.test(
-                'Given an information message if the user clicks Reload, the command is executed',
-                async () => {
-                    doClickOk();
-                    await commandDone;
-                    jestLib.expect(invokedCommand).toEqual('workbench.action.reloadWindow');
-                }
-            );
+            test('Given an information message if the user clicks Reload, the command is executed', async () => {
+                doClickOk();
+                await commandDone;
+                expect(invokedCommand).toEqual('workbench.action.reloadWindow');
+            });
         });
     });
 
@@ -119,16 +103,13 @@ jestLib.describe('Option changes observer', () => {
         { config: 'dotnet', section: 'server.documentSelector', value: ['csharp'] },
         { config: 'dotnet', section: 'server.trace', value: 'Information' },
     ].forEach((elem) => {
-        jestLib.test(
-            `Information Message is not shown if no change in value for ${elem.config}.${elem.section}`,
-            () => {
-                jestLib.expect(infoMessage).toBe(undefined);
-                jestLib.expect(invokedCommand).toBe(undefined);
-                updateConfig(vscode, elem.config, elem.section, elem.value);
-                optionObservable.next();
-                jestLib.expect(infoMessage).toBe(undefined);
-            }
-        );
+        test(`Information Message is not shown if no change in value for ${elem.config}.${elem.section}`, () => {
+            expect(infoMessage).toBe(undefined);
+            expect(invokedCommand).toBe(undefined);
+            updateConfig(vscode, elem.config, elem.section, elem.value);
+            optionObservable.next();
+            expect(infoMessage).toBe(undefined);
+        });
     });
 
     [
@@ -137,12 +118,12 @@ jestLib.describe('Option changes observer', () => {
         { config: 'files', section: 'exclude', value: false },
         { config: 'search', section: 'exclude', value: 1000 },
     ].forEach((elem) => {
-        jestLib.test(`Information Message is not shown on change in ${elem.config}.${elem.section}`, () => {
-            jestLib.expect(infoMessage).toBe(undefined);
-            jestLib.expect(invokedCommand).toBe(undefined);
+        test(`Information Message is not shown on change in ${elem.config}.${elem.section}`, () => {
+            expect(infoMessage).toBe(undefined);
+            expect(invokedCommand).toBe(undefined);
             updateConfig(vscode, elem.config, elem.section, elem.value);
             optionObservable.next();
-            jestLib.expect(infoMessage).toBe(undefined);
+            expect(infoMessage).toBe(undefined);
         });
     });
 

--- a/test/unitTests/migrateOptions.test.ts
+++ b/test/unitTests/migrateOptions.test.ts
@@ -5,9 +5,9 @@
 
 import { readFileSync } from 'fs';
 import { migrateOptions } from '../../src/shared/migrateOptions';
-import * as jestLib from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 
-jestLib.describe('Migrate configuration should in package.json', () => {
+describe('Migrate configuration should in package.json', () => {
     const packageJson = JSON.parse(readFileSync('package.json').toString());
     const configuration = packageJson.contributes.configuration;
     // Read the "Project", "Text Editor", "Debugger", "LSP Server" sections of the package.json
@@ -19,8 +19,8 @@ jestLib.describe('Migrate configuration should in package.json', () => {
     ];
 
     migrateOptions.forEach((data) => {
-        jestLib.test(`Should have ${data.roslynOption} in package.json`, () => {
-            jestLib.expect(configurations).toContain(data.roslynOption);
+        test(`Should have ${data.roslynOption} in package.json`, () => {
+            expect(configurations).toContain(data.roslynOption);
         });
     });
 });

--- a/test/unitTests/packageNlsJson.test.ts
+++ b/test/unitTests/packageNlsJson.test.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { readFileSync } from 'fs';
-import * as jestLib from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
 
-jestLib.describe('package.nls.json validation tests', () => {
+describe('package.nls.json validation tests', () => {
     const langCodes = ['cs', 'de', 'es', 'fr', 'it', 'ja', 'ko', 'pl', 'pt-br', 'ru', 'tr', 'zh-cn', 'zh-tw'];
     const keysWithURLExamples = [
         'generateOptionsSchema.symbolOptions.searchPaths.description',
@@ -15,12 +15,12 @@ jestLib.describe('package.nls.json validation tests', () => {
     ];
 
     langCodes.forEach((lang) => {
-        jestLib.test(`Verify \\u200b exists in example URLs in package.nls.${lang}.json`, () => {
+        test(`Verify \\u200b exists in example URLs in package.nls.${lang}.json`, () => {
             const filename = `package.nls.${lang}.json`;
             const packageNLSJson = JSON.parse(readFileSync(filename).toString());
             for (const key of keysWithURLExamples) {
                 try {
-                    jestLib.expect(packageNLSJson[key]).toContain('\u200b');
+                    expect(packageNLSJson[key]).toContain('\u200b');
                 } catch (e) {
                     throw "Missing \\u200b in example urls, please run 'gulp fixLocURLs' and check in those changes.";
                 }


### PR DESCRIPTION
Now that mocha is gone we no longer need to explicitly reference jestlib.  Can just be a normal import.  This PR removes the rest of the places where we were using the explicit jestlib reference.