### PR TITLE
Use a case-insensitive find for files on Mac and Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Direct debugger setting documentation to code.visualstudio.com (PR: [#6659](https://github.com/dotnet/vscode-csharp/pull/6659))
 * Add a timeout for downloading razor telemetry (PR: [#6622](https://github.com/dotnet/vscode-csharp/pull/6622))
 * Rearrange settings sections into actual categories (PR: [#6652](https://github.com/dotnet/vscode-csharp/pull/6652))
+* Use case-insensitive path lookups for Razor files on Windows and Mac (PR: [#6683](https://github.com/dotnet/vscode-csharp/pull/6683))
 
 ## 2.10.28
 * Fix C# Debugger telemetry (PR: [#6627](https://github.com/dotnet/vscode-csharp/pull/6627))

--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -18,6 +18,7 @@ import { IRazorDocumentManager } from './IRazorDocumentManager';
 import { RazorDocumentChangeKind } from './razorDocumentChangeKind';
 import { createDocument } from './razorDocumentFactory';
 import { razorInitializeCommand } from '../../../lsptoolshost/razorCommands';
+import { PlatformInformation } from '../../../shared/platform';
 
 export class RazorDocumentManager implements IRazorDocumentManager {
     public roslynActivated = false;
@@ -32,7 +33,8 @@ export class RazorDocumentManager implements IRazorDocumentManager {
     constructor(
         private readonly serverClient: RazorLanguageServerClient,
         private readonly logger: RazorLogger,
-        private readonly telemetryReporter: TelemetryReporter
+        private readonly telemetryReporter: TelemetryReporter,
+        private readonly platformInfo: PlatformInformation
     ) {}
 
     public get onChange() {
@@ -146,7 +148,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
 
     private _getDocument(uri: vscode.Uri) {
         const path = getUriPath(uri);
-        let document = this.razorDocuments[path];
+        let document = this.findDocument(path);
 
         // This might happen in the case that a file is opened outside the workspace
         if (!document) {
@@ -198,7 +200,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
 
     private addDocument(uri: vscode.Uri) {
         const path = getUriPath(uri);
-        let document = this.razorDocuments[path];
+        let document = this.findDocument(path);
         if (document) {
             this.logger.logMessage(`Skipping document creation for '${path}' because it already exists.`);
             return document;
@@ -217,6 +219,26 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         delete this.razorDocuments[document.path];
 
         this.notifyDocumentChange(document, RazorDocumentChangeKind.removed);
+    }
+
+    private findDocument(path: string) {
+        // This method ultimately gets called from VS Code, using file system paths, or from DevKit, which
+        // can use paths as specified in the sln file. When these don't agree, on case-insensitive operating
+        // systems, we have to be careful to match things up correctly.
+
+        if (this.platformInfo.isLinux()) {
+            return this.razorDocuments[path];
+        }
+
+        const lowerCasePath = path.toLowerCase();
+        const key = Object.keys(this.razorDocuments).find(
+            (documentPath) => documentPath.toLowerCase() === lowerCasePath
+        );
+        if (key) {
+            return this.razorDocuments[key];
+        }
+
+        return undefined;
     }
 
     private async updateCSharpBuffer(updateBufferRequest: UpdateBufferRequest) {

--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -230,15 +230,9 @@ export class RazorDocumentManager implements IRazorDocumentManager {
             return this.razorDocuments[path];
         }
 
-        const lowerCasePath = path.toLowerCase();
-        const key = Object.keys(this.razorDocuments).find(
-            (documentPath) => documentPath.toLowerCase() === lowerCasePath
+        return Object.values(this.razorDocuments).find(
+            (document) => document.path.localeCompare(path, undefined, { sensitivity: 'base' }) === 0
         );
-        if (key) {
-            return this.razorDocuments[key];
-        }
-
-        return undefined;
     }
 
     private async updateCSharpBuffer(updateBufferRequest: UpdateBufferRequest) {

--- a/src/razor/src/extension.ts
+++ b/src/razor/src/extension.ts
@@ -128,7 +128,12 @@ export async function activate(
 
         const languageServiceClient = new RazorLanguageServiceClient(languageServerClient);
 
-        const documentManager = new RazorDocumentManager(languageServerClient, logger, razorTelemetryReporter);
+        const documentManager = new RazorDocumentManager(
+            languageServerClient,
+            logger,
+            razorTelemetryReporter,
+            platformInfo
+        );
         const documentSynchronizer = new RazorDocumentSynchronizer(documentManager, logger);
         reportTelemetryForDocuments(documentManager, razorTelemetryReporter);
         const languageConfiguration = new RazorLanguageConfiguration();

--- a/test/razorIntegrationTests/formatting.integration.test.ts
+++ b/test/razorIntegrationTests/formatting.integration.test.ts
@@ -9,18 +9,6 @@ import { describe, beforeAll, afterAll, test, expect } from '@jest/globals';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
 import * as integrationHelpers from '../integrationTests/integrationHelpers';
 
-function normalizeNewlines(original: string | undefined): string | undefined {
-    if (!original) {
-        return original;
-    }
-
-    while (original.indexOf('\r\n') != -1) {
-        original = original.replace('\r\n', '\n');
-    }
-
-    return original;
-}
-
 describe(`Razor Formatting ${testAssetWorkspace.description}`, function () {
     beforeAll(async function () {
         if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
@@ -59,34 +47,35 @@ describe(`Razor Formatting ${testAssetWorkspace.description}`, function () {
             }
         );
 
-        expect(edits).toBeDefined();
+        expect(edits).toHaveLength(13);
 
-        console.log(`Got ${edits.length} edits`);
+        assertEditEqual(edits[0], 3, 0, 3, 0, '    ');
+        assertEditEqual(edits[1], 3, 7, 3, 17, '');
+        assertEditEqual(edits[2], 3, 18, 3, 31, '');
+        assertEditEqual(edits[3], 3, 37, 3, 38, '');
+        assertEditEqual(edits[4], 3, 39, 3, 57, '');
+        assertEditEqual(edits[5], 3, 59, 3, 69, '');
+        assertEditEqual(edits[6], 3, 70, 3, 86, '');
+        assertEditEqual(edits[7], 3, 87, 3, 99, '');
+        assertEditEqual(edits[8], 3, 100, 3, 108, '');
+        assertEditEqual(edits[9], 5, 0, 5, 0, '    ');
+        assertEditEqual(edits[10], 6, 0, 6, 0, '    ');
+        assertEditEqual(edits[11], 7, 0, 7, 0, '        ');
+        assertEditEqual(edits[12], 8, 0, 8, 0, '    ');
 
-        // It's much easier to verify the expected state of the document, than a bunch of edits
-        const formatEdit = new vscode.WorkspaceEdit();
-        formatEdit.set(activeDocument, edits);
-
-        console.log(`Applying edit ${formatEdit}`);
-
-        await vscode.workspace.applyEdit(formatEdit);
-
-        const contents = normalizeNewlines(vscode.window.activeTextEditor?.document.getText());
-
-        console.log(`Checking document contents...`);
-
-        expect(contents).toBe(
-            normalizeNewlines(`@page "/bad"
-
-@code {
-    private string _x = "";
-
-    private void M()
-    {
-        // hi there
-    }
-}
-`)
-        );
+        function assertEditEqual(
+            actual: vscode.TextEdit,
+            startLine: number,
+            startChar: number,
+            endLine: number,
+            endChar: number,
+            text: string
+        ) {
+            expect(actual.newText).toBe(text);
+            expect(actual.range.start.line).toBe(startLine);
+            expect(actual.range.start.character).toBe(startChar);
+            expect(actual.range.end.line).toBe(endLine);
+            expect(actual.range.end.character).toBe(endChar);
+        }
     });
 });


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-csharp/issues/6644

The server side already does [the same thing](https://github.com/dotnet/razor/blob/main/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparer.cs#L17-L19) but we have a whole document manager here in TypeScript land, and I guess sometimes CPS uses the path in the sln file as a source of truth.

UPDATE: The razor formatting test failed in a weird spot, so I also changed how it asserts to hopefully make it more reliable.