### PR TITLE
Update required VSCode version to account for APIs in vscode-extension-telementry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1014,7 +1014,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.73.0"
+    "vscode": "^1.75.0"
   },
   "activationEvents": [
     "onDebugInitialConfigurations",
@@ -1023,18 +1023,7 @@
     "onDebugResolve:clr",
     "onDebugResolve:dotnet",
     "onLanguage:csharp",
-    "onLanguage:aspnetcorerazor",
-    "onCommand:o.restart",
-    "onCommand:o.pickProjectAndStart",
     "onCommand:o.showOutput",
-    "onCommand:dotnet.restore.project",
-    "onCommand:dotnet.restore.all",
-    "onCommand:dotnet.generateAssets",
-    "onCommand:dotnet.openSolution",
-    "onCommand:csharp.downloadDebugger",
-    "onCommand:csharp.listProcess",
-    "onCommand:csharp.listRemoteProcess",
-    "onCommand:csharp.listRemoteDockerProcess",
     "onCommand:omnisharp.registerLanguageMiddleware",
     "workspaceContains:project.json",
     "workspaceContains:**/*.{csproj,sln,slnf,csx,cake}"


### PR DESCRIPTION
Originally discussed in https://github.com/dotnet/vscode-csharp/issues/6707#issuecomment-1839655674