### PR TITLE
Read extension paths option

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -902,7 +902,7 @@ export async function activateRoslynLanguageServer(
     return languageServer;
 
     function scanExtensionPlugins(): string[] {
-        return vscode.extensions.all.flatMap((extension) => {
+        const extensionsFromPackageJson = vscode.extensions.all.flatMap((extension) => {
             let loadPaths = extension.packageJSON.contributes?.['csharpExtensionLoadPaths'];
             if (loadPaths === undefined || loadPaths === null) {
                 _traceChannel.appendLine(`Extension ${extension.id} does not contribute csharpExtensionLoadPaths`);
@@ -920,6 +920,8 @@ export async function activateRoslynLanguageServer(
             _traceChannel.appendLine(`Extension ${extension.id} contributes csharpExtensionLoadPaths: ${loadPaths}`);
             return loadPaths;
         });
+        const extensionsFromOptions = languageServerOptions.extensionsPaths ?? [];
+        return extensionsFromPackageJson.concat(extensionsFromOptions);
     }
 }
 


### PR DESCRIPTION
Went missing in a refactoring at some point - reads the extension path from settings as well as package.json