### PR TITLE
Fix Remote Process Listing from Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # This is a generated file from vscode-l10n tool, and it always uses 'lf' and line ending. Set it to 'lf' so we don't get warning every time when localization file get changed.
 l10n/bundle.l10n.json text eol=lf
+
+# This is a Unix shell script, so it always use the 'lf' line ends
+scripts/remoteProcessPickerScript text eol=lf


### PR DESCRIPTION
The change to produce the Windows .vsix files on a Windows machine exposed the fact that we didn't have a .gitattributes entry in this repo to force the process listing script to use LF line endings, thus breaking remote process listing from Windows.

This fixes #6729
