### PR TITLE
Remove check for projectPath for resolveDebugConfiguration

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -3,6 +3,7 @@
   "Cannot create .NET debug configurations. The server is still initializing or has exited unexpectedly.": "Cannot create .NET debug configurations. The server is still initializing or has exited unexpectedly.",
   "Cannot create .NET debug configurations. The active C# project is not within folder '{0}'.": "Cannot create .NET debug configurations. The active C# project is not within folder '{0}'.",
   "Does not contain .NET Core projects.": "Does not contain .NET Core projects.",
+  "No launchable target found.": "No launchable target found.",
   "No launchable target found for '{0}'": "No launchable target found for '{0}'",
   "Cannot resolve .NET debug configurations. The server is still initializing or has exited unexpectedly.": "Cannot resolve .NET debug configurations. The server is still initializing or has exited unexpectedly.",
   "Unable to determine a configuration for '{0}'. Please generate C# debug assets instead.": "Unable to determine a configuration for '{0}'. Please generate C# debug assets instead.",

--- a/src/lsptoolshost/services/IDotnetDebugConfigurationService.ts
+++ b/src/lsptoolshost/services/IDotnetDebugConfigurationService.ts
@@ -23,7 +23,7 @@ export interface IDotnetDebugConfigurationServiceResult {
 
 export interface IDotnetDebugConfigurationService {
     resolveDebugConfigurationWithLaunchConfigurationService(
-        projectPath: string,
+        projectPath: string | undefined,
         debugConfiguration: vscode.DebugConfiguration,
         token?: vscode.CancellationToken
     ): Promise<IDotnetDebugConfigurationServiceResult>;


### PR DESCRIPTION
This PR allows `projectPath` to be `null` for `resolveDebugConfigurationWithLaunchConfigurationService` as that service can now handle it being `null`.