### PR TITLE
Fix command enablement by using specific activation contexts for O#, Roslyn standalone, and Roslyn devkit

### DIFF
--- a/omnisharptest/omnisharpIntegrationTests/omnisharpCommands.integration.test.ts
+++ b/omnisharptest/omnisharpIntegrationTests/omnisharpCommands.integration.test.ts
@@ -7,6 +7,7 @@ import { expect, test, beforeAll, afterAll, describe } from '@jest/globals';
 import * as vscode from 'vscode';
 import { activateCSharpExtension } from './integrationHelpers';
 import testAssetWorkspace from './testAssets/activeTestAssetWorkspace';
+import { CommonCommands, OmniSharpCommands, RoslynCommands } from '../../test/integrationTests/expectedCommands';
 
 describe(`Command Enablement: ${testAssetWorkspace.description}`, function () {
     beforeAll(async function () {
@@ -19,31 +20,20 @@ describe(`Command Enablement: ${testAssetWorkspace.description}`, function () {
         await testAssetWorkspace.cleanupWorkspace();
     });
 
-    test('Only expected commands are available', async function () {
+    test('Omnisharp commands are available', async function () {
         const commands = await vscode.commands.getCommands(true);
 
-        // Ensure the O# commands are available.
-        expect(commands).toContain('o.restart');
-        expect(commands).toContain('o.pickProjectAndStart');
-        expect(commands).toContain('o.fixAll.solution');
-        expect(commands).toContain('o.fixAll.project');
-        expect(commands).toContain('o.fixAll.document');
-        expect(commands).toContain('o.reanalyze.allProjects');
-        expect(commands).toContain('o.reanalyze.currentProject');
-        expect(commands).toContain('dotnet.generateAssets');
-        expect(commands).toContain('dotnet.restore.project');
-        expect(commands).toContain('dotnet.restore.all');
-        expect(commands).toContain('dotnet.test.runTestsInContext');
-        expect(commands).toContain('dotnet.test.debugTestsInContext');
-        expect(commands).toContain('csharp.listProcess');
-        expect(commands).toContain('csharp.listRemoteProcess');
-        expect(commands).toContain('csharp.listRemoteDockerProcess');
-        expect(commands).toContain('csharp.attachToProcess');
-        expect(commands).toContain('csharp.reportIssue');
-        expect(commands).toContain('csharp.showDecompilationTerms');
+        // Ensure O# commands are available.
+        OmniSharpCommands.forEach((command) => {
+            expect(commands).toContain(command);
+        });
+        CommonCommands.forEach((command) => {
+            expect(commands).toContain(command);
+        });
 
-        // Ensure the non-O# commands are not available.
-        expect(commands).not.toContain('dotnet.openSolution');
-        expect(commands).not.toContain('dotnet.restartServer');
+        // Ensure Roslyn standalone commands are not available.
+        RoslynCommands.forEach((command) => {
+            expect(commands).not.toContain(command);
+        });
     });
 });

--- a/omnisharptest/omnisharpIntegrationTests/omnisharpCommands.integration.test.ts
+++ b/omnisharptest/omnisharpIntegrationTests/omnisharpCommands.integration.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, test, beforeAll, afterAll, describe } from '@jest/globals';
+import * as vscode from 'vscode';
+import { activateCSharpExtension } from './integrationHelpers';
+import testAssetWorkspace from './testAssets/activeTestAssetWorkspace';
+
+describe(`Command Enablement: ${testAssetWorkspace.description}`, function () {
+    beforeAll(async function () {
+        const activation = await activateCSharpExtension();
+        await testAssetWorkspace.restore();
+        await testAssetWorkspace.waitForIdle(activation.eventStream);
+    });
+
+    afterAll(async () => {
+        await testAssetWorkspace.cleanupWorkspace();
+    });
+
+    test('Only expected commands are available', async function () {
+        const commands = await vscode.commands.getCommands(true);
+
+        // Ensure the O# commands are available.
+        expect(commands).toContain('o.restart');
+        expect(commands).toContain('o.pickProjectAndStart');
+        expect(commands).toContain('o.fixAll.solution');
+        expect(commands).toContain('o.fixAll.project');
+        expect(commands).toContain('o.fixAll.document');
+        expect(commands).toContain('o.reanalyze.allProjects');
+        expect(commands).toContain('o.reanalyze.currentProject');
+        expect(commands).toContain('dotnet.generateAssets');
+        expect(commands).toContain('dotnet.restore.project');
+        expect(commands).toContain('dotnet.restore.all');
+        expect(commands).toContain('dotnet.test.runTestsInContext');
+        expect(commands).toContain('dotnet.test.debugTestsInContext');
+        expect(commands).toContain('csharp.listProcess');
+        expect(commands).toContain('csharp.listRemoteProcess');
+        expect(commands).toContain('csharp.listRemoteDockerProcess');
+        expect(commands).toContain('csharp.attachToProcess');
+        expect(commands).toContain('csharp.reportIssue');
+        expect(commands).toContain('csharp.showDecompilationTerms');
+
+        // Ensure the non-O# commands are not available.
+        expect(commands).not.toContain('dotnet.openSolution');
+        expect(commands).not.toContain('dotnet.restartServer');
+    });
+});

--- a/package.json
+++ b/package.json
@@ -2008,49 +2008,49 @@
         "command": "o.restart",
         "title": "%command.o.restart%",
         "category": "OmniSharp",
-        "enablement": "config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "o.pickProjectAndStart",
         "title": "%command.o.pickProjectAndStart%",
         "category": "OmniSharp",
-        "enablement": "config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "dotnet.openSolution",
         "title": "%command.dotnet.openSolution%",
         "category": ".NET",
-        "enablement": "!config.dotnet.server.useOmnisharp && dotnet.server.activatedStandalone"
+        "enablement": "dotnet.server.activationContext == 'Roslyn'"
       },
       {
         "command": "o.fixAll.solution",
         "title": "%command.o.fixAll.solution%",
         "category": "OmniSharp",
-        "enablement": "config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "o.fixAll.project",
         "title": "%command.o.fixAll.project%",
         "category": "OmniSharp",
-        "enablement": "config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "o.fixAll.document",
         "title": "%command.o.fixAll.document%",
         "category": "OmniSharp",
-        "enablement": "config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "o.reanalyze.allProjects",
         "title": "%command.o.reanalyze.allProjects%",
         "category": "OmniSharp",
-        "enablement": "config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "o.reanalyze.currentProject",
         "title": "%command.o.reanalyze.currentProject%",
         "category": "OmniSharp",
-        "enablement": "config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "dotnet.generateAssets",
@@ -2061,18 +2061,13 @@
         "command": "dotnet.restore.project",
         "title": "%command.dotnet.restore.project%",
         "category": ".NET",
-        "enablement": "dotnet.server.activatedStandalone"
+        "enablement": "dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "dotnet.restore.all",
         "title": "%command.dotnet.restore.all%",
         "category": ".NET",
-        "enablement": "dotnet.server.activatedStandalone"
-      },
-      {
-        "command": "csharp.downloadDebugger",
-        "title": "%command.csharp.downloadDebugger%",
-        "category": "Debug"
+        "enablement": "dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "csharp.listProcess",
@@ -2103,7 +2098,7 @@
         "command": "csharp.showDecompilationTerms",
         "title": "%command.csharp.showDecompilationTerms%",
         "category": "CSharp",
-        "enablement": "config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "extension.showRazorCSharpWindow",
@@ -2124,19 +2119,19 @@
         "command": "dotnet.test.runTestsInContext",
         "title": "%command.dotnet.test.runTestsInContext%",
         "category": ".NET",
-        "enablement": "dotnet.server.activatedStandalone"
+        "enablement": "dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "dotnet.test.debugTestsInContext",
         "title": "%command.dotnet.test.debugTestsInContext%",
         "category": ".NET",
-        "enablement": "dotnet.server.activatedStandalone"
+        "enablement": "dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'"
       },
       {
         "command": "dotnet.restartServer",
         "title": "%command.dotnet.restartServer%",
         "category": ".NET",
-        "enablement": "!config.dotnet.server.useOmnisharp"
+        "enablement": "dotnet.server.activationContext != 'OmniSharp'"
       }
     ],
     "keybindings": [
@@ -5638,15 +5633,15 @@
       "commandPalette": [
         {
           "command": "dotnet.test.runTestsInContext",
-          "when": "editorLangId == csharp && dotnet.server.activatedStandalone"
+          "when": "editorLangId == csharp && dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'"
         },
         {
           "command": "dotnet.test.debugTestsInContext",
-          "when": "editorLangId == csharp && dotnet.server.activatedStandalone"
+          "when": "editorLangId == csharp && dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'"
         },
         {
           "command": "o.restart",
-          "when": "config.dotnet.server.useOmnisharp"
+          "when": "dotnet.server.activationContext == 'OmniSharp'"
         },
         {
           "command": "csharp.listProcess",
@@ -5678,12 +5673,12 @@
       "editor/context": [
         {
           "command": "dotnet.test.runTestsInContext",
-          "when": "editorLangId == csharp && dotnet.server.activatedStandalone",
+          "when": "editorLangId == csharp && dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'",
           "group": "2_dotnet@1"
         },
         {
           "command": "dotnet.test.debugTestsInContext",
-          "when": "editorLangId == csharp && dotnet.server.activatedStandalone",
+          "when": "editorLangId == csharp && dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'",
           "group": "2_dotnet@2"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -5673,12 +5673,12 @@
       "editor/context": [
         {
           "command": "dotnet.test.runTestsInContext",
-          "when": "editorLangId == csharp && dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'",
+          "when": "editorLangId == csharp && (dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp')",
           "group": "2_dotnet@1"
         },
         {
           "command": "dotnet.test.debugTestsInContext",
-          "when": "editorLangId == csharp && dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp'",
+          "when": "editorLangId == csharp && (dotnet.server.activationContext == 'Roslyn' || dotnet.server.activationContext == 'OmniSharp')",
           "group": "2_dotnet@2"
         }
       ]

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -518,7 +518,7 @@ export class RoslynLanguageServer {
                 _channel.appendLine('Activating C# + C# Dev Kit...');
             }
 
-            // Set command enablement to use DevKit commands.
+            // Set command enablement as soon as we know devkit is available.
             vscode.commands.executeCommand('setContext', 'dotnet.server.activationContext', 'RoslynDevKit');
 
             const csharpDevKitArgs = this.getCSharpDevKitExportArgs();

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -518,6 +518,9 @@ export class RoslynLanguageServer {
                 _channel.appendLine('Activating C# + C# Dev Kit...');
             }
 
+            // Set command enablement to use DevKit commands.
+            vscode.commands.executeCommand('setContext', 'dotnet.server.activationContext', 'RoslynDevKit');
+
             const csharpDevKitArgs = this.getCSharpDevKitExportArgs();
             args = args.concat(csharpDevKitArgs);
 
@@ -525,7 +528,9 @@ export class RoslynLanguageServer {
         } else {
             // C# Dev Kit is not installed - continue C#-only activation.
             _channel.appendLine('Activating C# standalone...');
-            vscode.commands.executeCommand('setContext', 'dotnet.server.activatedStandalone', true);
+
+            // Set command enablement to use roslyn standalone commands.
+            vscode.commands.executeCommand('setContext', 'dotnet.server.activationContext', 'Roslyn');
             _wasActivatedWithCSharpDevkit = false;
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -184,6 +184,9 @@ export async function activate(
             roslynLanguageServerEvents
         );
     } else {
+        // Set command enablement to use O# commands.
+        vscode.commands.executeCommand('setContext', 'dotnet.server.activationContext', 'OmniSharp');
+
         const dotnetChannelObserver = new DotNetChannelObserver(dotnetChannel);
         const dotnetLoggerObserver = new DotnetLoggerObserver(dotnetChannel);
         eventStream.subscribe(dotnetChannelObserver.post);

--- a/test/integrationTests/commandEnablement.integration.test.ts
+++ b/test/integrationTests/commandEnablement.integration.test.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, test, beforeAll, afterAll, describe } from '@jest/globals';
+import * as vscode from 'vscode';
+import { activateCSharpExtension } from './integrationHelpers';
+import testAssetWorkspace from './testAssets/testAssetWorkspace';
+
+describe(`Command Enablement: ${testAssetWorkspace.description}`, function () {
+    beforeAll(async function () {
+        await activateCSharpExtension();
+    });
+
+    afterAll(async () => {
+        await testAssetWorkspace.cleanupWorkspace();
+    });
+
+    test('Only expected commands are available', async function () {
+        const commands = await vscode.commands.getCommands(true);
+
+        // Ensure the standalone Roslyn commands are available.
+        expect(commands).toContain('dotnet.openSolution');
+        expect(commands).toContain('dotnet.restartServer');
+        expect(commands).toContain('dotnet.generateAssets');
+        expect(commands).toContain('dotnet.restore.project');
+        expect(commands).toContain('dotnet.restore.all');
+        expect(commands).toContain('dotnet.test.runTestsInContext');
+        expect(commands).toContain('dotnet.test.debugTestsInContext');
+        expect(commands).toContain('csharp.listProcess');
+        expect(commands).toContain('csharp.listRemoteProcess');
+        expect(commands).toContain('csharp.listRemoteDockerProcess');
+        expect(commands).toContain('csharp.attachToProcess');
+        expect(commands).toContain('csharp.reportIssue');
+
+        // Ensure the O#-only commands are not available.
+        expect(commands).not.toContain('o.restart');
+        expect(commands).not.toContain('o.pickProjectAndStart');
+        expect(commands).not.toContain('o.fixAll.solution');
+        expect(commands).not.toContain('o.fixAll.project');
+        expect(commands).not.toContain('o.fixAll.document');
+        expect(commands).not.toContain('o.reanalyze.allProjects');
+        expect(commands).not.toContain('o.reanalyze.currentProject');
+    });
+});

--- a/test/integrationTests/commandEnablement.integration.test.ts
+++ b/test/integrationTests/commandEnablement.integration.test.ts
@@ -7,6 +7,7 @@ import { expect, test, beforeAll, afterAll, describe } from '@jest/globals';
 import * as vscode from 'vscode';
 import { activateCSharpExtension } from './integrationHelpers';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
+import { CommonCommands, OmniSharpCommands, RoslynCommands } from './expectedCommands';
 
 describe(`Command Enablement: ${testAssetWorkspace.description}`, function () {
     beforeAll(async function () {
@@ -17,30 +18,20 @@ describe(`Command Enablement: ${testAssetWorkspace.description}`, function () {
         await testAssetWorkspace.cleanupWorkspace();
     });
 
-    test('Only expected commands are available', async function () {
+    test('Roslyn commands are available', async function () {
         const commands = await vscode.commands.getCommands(true);
 
         // Ensure the standalone Roslyn commands are available.
-        expect(commands).toContain('dotnet.openSolution');
-        expect(commands).toContain('dotnet.restartServer');
-        expect(commands).toContain('dotnet.generateAssets');
-        expect(commands).toContain('dotnet.restore.project');
-        expect(commands).toContain('dotnet.restore.all');
-        expect(commands).toContain('dotnet.test.runTestsInContext');
-        expect(commands).toContain('dotnet.test.debugTestsInContext');
-        expect(commands).toContain('csharp.listProcess');
-        expect(commands).toContain('csharp.listRemoteProcess');
-        expect(commands).toContain('csharp.listRemoteDockerProcess');
-        expect(commands).toContain('csharp.attachToProcess');
-        expect(commands).toContain('csharp.reportIssue');
+        RoslynCommands.forEach((command) => {
+            expect(commands).toContain(command);
+        });
+        CommonCommands.forEach((command) => {
+            expect(commands).toContain(command);
+        });
 
-        // Ensure the O#-only commands are not available.
-        expect(commands).not.toContain('o.restart');
-        expect(commands).not.toContain('o.pickProjectAndStart');
-        expect(commands).not.toContain('o.fixAll.solution');
-        expect(commands).not.toContain('o.fixAll.project');
-        expect(commands).not.toContain('o.fixAll.document');
-        expect(commands).not.toContain('o.reanalyze.allProjects');
-        expect(commands).not.toContain('o.reanalyze.currentProject');
+        // Ensure O# commands are not available.
+        OmniSharpCommands.forEach((command) => {
+            expect(commands).not.toContain(command);
+        });
     });
 });

--- a/test/integrationTests/expectedCommands.ts
+++ b/test/integrationTests/expectedCommands.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const OmniSharpCommands = [
+    'o.restart',
+    'o.pickProjectAndStart',
+    'o.fixAll.solution',
+    'o.fixAll.project',
+    'o.fixAll.document',
+    'o.reanalyze.allProjects',
+    'o.reanalyze.currentProject',
+];
+
+export const RoslynCommands = ['dotnet.openSolution', 'dotnet.restartServer'];
+
+export const CommonCommands = [
+    'dotnet.generateAssets',
+    'dotnet.restore.project',
+    'dotnet.restore.all',
+    'dotnet.test.runTestsInContext',
+    'dotnet.test.debugTestsInContext',
+    'csharp.listProcess',
+    'csharp.listRemoteProcess',
+    'csharp.listRemoteDockerProcess',
+    'csharp.attachToProcess',
+    'csharp.reportIssue',
+];


### PR DESCRIPTION
There were various bugs in the old enablement clauses.  For example
1.  Devkit overrides the useOmnisharp configuration setting.  If useOmnisharp was true and devkit was installed, O# commands were displayed (but would not work since devkit activated, not O#).
2.  Some of the restore commands were only enabled when using Roslyn standalone, but not using O#.

This PR modifies the enablement clauses to look at an activation context.  We explicitly set the activation context after we've run all the other logic to determine which server to actually launch.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1891108 (and other non-filed bugs)