### PR TITLE
Adding aiKey to monovsdbg

### DIFF
--- a/package.json
+++ b/package.json
@@ -4878,7 +4878,8 @@
         "hiddenWhen": "true",
         "languages": [
           "csharp"
-        ]
+        ],
+        "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255"
       }
     ],
     "semanticTokenTypes": [


### PR DESCRIPTION
As explained by Gregg we need aiKey for telemetry.