### PR TITLE
Upgrade Roslyn to .NET8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 ## Latest
+* Update Roslyn to run on .NET 8 (PR: [#6840](https://github.com/dotnet/vscode-csharp/pull/6840))
+
+## 2.17.7
 * Update Roslyn to 4.10.0-2.24102.11 (PR: [#6847](https://github.com/dotnet/vscode-csharp/pull/6847))
   * Fix another issue loading .NET projects when only the 6.0 SDK is installed (PR: [#71881](https://github.com/dotnet/roslyn/pull/71881))
   * Fix request info leak when project loading is cancelled (PR: [#71737](https://github.com/dotnet/roslyn/pull/71737))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ This section shows how to set up local Razor or Roslyn language servers for debu
 1. Clone the [Roslyn repository](https://github.com/dotnet/roslyn). This repository contains the Roslyn server implementation.
 2. Follow the build instructions provided in the repository.
 
-The server DLL is typically at `$roslynRepoRoot/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net7.0/Microsoft.CodeAnalysis.LanguageServer.dll`, but this may vary based on the built configuration.
+The server DLL is typically at `$roslynRepoRoot/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net8.0/Microsoft.CodeAnalysis.LanguageServer.dll`, but this may vary based on the built configuration.
 
 #### Razor
 
@@ -110,7 +110,7 @@ In your workspace `settings.json` file, add the following lines:
 
 ```json
 "dotnet.server.waitForDebugger": true,
-"dotnet.server.path": "<roslynRepoRoot>/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net7.0/Microsoft.CodeAnalysis.LanguageServer.dll"
+"dotnet.server.path": "<roslynRepoRoot>/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net8.0/Microsoft.CodeAnalysis.LanguageServer.dll"
 ```
 
 Replace <roslynRepoRoot> with the actual path to your Roslyn repository.

--- a/azure-pipelines/prereqs.yml
+++ b/azure-pipelines/prereqs.yml
@@ -16,7 +16,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDKs'
   inputs:
-    version: '7.x'
+    version: '8.x'
 
 - script: |
     dotnet tool install --tool-path $(Agent.BuildDirectory) nbgv

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "defaults": {
-    "roslyn": "4.10.0-2.24102.11",
+    "roslyn": "4.10.0-2.24105.1",
     "omniSharp": "1.39.11",
     "razor": "7.0.0-preview.23627.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",

--- a/server/ServerDownload.csproj
+++ b/server/ServerDownload.csproj
@@ -12,7 +12,7 @@
         <!-- It's still PackageReference, so project intermediates are still created. -->
         <MSBuildProjectExtensionsPath>$(RestorePackagesPath)obj/</MSBuildProjectExtensionsPath>
         <!-- This is not super relevant, as long as your SDK version supports it. -->
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <!-- If a package is resolved to a fallback folder, it may not be downloaded.-->
         <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
         <!-- We don't want to build this project, so we do not need the reference assemblies for the framework we chose.-->

--- a/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
+++ b/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
@@ -16,7 +16,7 @@ import { getDotnetInfo } from '../shared/utils/getDotnetInfo';
 import { readFile } from 'fs/promises';
 import { RuntimeInfo } from '../shared/utils/dotnetInfo';
 
-export const DotNetRuntimeVersion = '7.0';
+export const DotNetRuntimeVersion = '8.0';
 
 interface IDotnetAcquireResult {
     dotnetPath: string;
@@ -26,7 +26,6 @@ interface IDotnetAcquireResult {
  * Resolves the dotnet runtime for a server executable from given options and the dotnet runtime VSCode extension.
  */
 export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
-    private readonly minimumDotnetRuntimeVersion = '7.0';
     constructor(
         private platformInfo: PlatformInformation,
         /**
@@ -163,9 +162,9 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
             }
 
             // Verify that the dotnet we found includes a runtime version that is compatible with our requirement.
-            const requiredRuntimeVersion = semver.parse(`${this.minimumDotnetRuntimeVersion}.0`);
+            const requiredRuntimeVersion = semver.parse(`${DotNetRuntimeVersion}.0`);
             if (!requiredRuntimeVersion) {
-                throw new Error(`Unable to parse minimum required version ${this.minimumDotnetRuntimeVersion}`);
+                throw new Error(`Unable to parse minimum required version ${DotNetRuntimeVersion}`);
             }
 
             const coreRuntimeVersions = dotnetInfo.Runtimes['Microsoft.NETCore.App'];
@@ -180,7 +179,7 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
 
             if (!matchingRuntime) {
                 throw new Error(
-                    `No compatible .NET runtime found. Minimum required version is ${this.minimumDotnetRuntimeVersion}.`
+                    `No compatible .NET runtime found. Minimum required version is ${DotNetRuntimeVersion}.`
                 );
             }
 

--- a/tasks/offlinePackagingTasks.ts
+++ b/tasks/offlinePackagingTasks.ts
@@ -47,8 +47,12 @@ export const platformSpecificPackages: VSIXPlatformInfo[] = [
     { vsceTarget: 'win32-arm64', rid: 'win-arm64', platformInfo: new PlatformInformation('win32', 'arm64') },
     { vsceTarget: 'linux-x64', rid: 'linux-x64', platformInfo: new PlatformInformation('linux', 'x86_64') },
     { vsceTarget: 'linux-arm64', rid: 'linux-arm64', platformInfo: new PlatformInformation('linux', 'arm64') },
-    { vsceTarget: 'alpine-x64', rid: 'alpine-x64', platformInfo: new PlatformInformation('linux-musl', 'x86_64') },
-    { vsceTarget: 'alpine-arm64', rid: 'alpine-arm64', platformInfo: new PlatformInformation('linux-musl', 'arm64') },
+    { vsceTarget: 'alpine-x64', rid: 'linux-musl-x64', platformInfo: new PlatformInformation('linux-musl', 'x86_64') },
+    {
+        vsceTarget: 'alpine-arm64',
+        rid: 'linux-musl-arm64',
+        platformInfo: new PlatformInformation('linux-musl', 'arm64'),
+    },
     { vsceTarget: 'darwin-x64', rid: 'osx-x64', platformInfo: new PlatformInformation('darwin', 'x86_64') },
     { vsceTarget: 'darwin-arm64', rid: 'osx-arm64', platformInfo: new PlatformInformation('darwin', 'arm64') },
 ];

--- a/test/integrationTests/testAssets/slnWithCsproj/test/test.csproj
+++ b/test/integrationTests/testAssets/slnWithCsproj/test/test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Uses the .NET8 runtime to run the Roslyn language server.  .NET7 is going out of support on May 14th: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

This means that if .NET8 is not found on the path, we will download a .NET8 runtime to launch the language server.

Draft until a server build with .net8 is available - https://github.com/dotnet/roslyn/pull/71903