### PR TITLE
Allow rzls to launch using standard dotnet (Redo)

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -48,7 +48,7 @@
   "Cannot load Razor language server because the directory was not found: '{0}'": "Cannot load Razor language server because the directory was not found: '{0}'",
   "Could not find '{0}' in or above '{1}'.": "Could not find '{0}' in or above '{1}'.",
   "Invalid razor.server.trace setting. Defaulting to '{0}'": "Invalid razor.server.trace setting. Defaulting to '{0}'",
-  "Could not find Razor Language Server executable within directory '{0}'": "Could not find Razor Language Server executable within directory '{0}'",
+  "Could not find Razor Language Server executable '{0}' within directory": "Could not find Razor Language Server executable '{0}' within directory",
   "Server failed to start after retrying 5 times.": "Server failed to start after retrying 5 times.",
   "Razor Language Server failed to start unexpectedly, please check the 'Razor Log' and report an issue.": "Razor Language Server failed to start unexpectedly, please check the 'Razor Log' and report an issue.",
   "Tried to send requests while server is not started.": "Tried to send requests while server is not started.",

--- a/src/razor/src/extension.ts
+++ b/src/razor/src/extension.ts
@@ -90,20 +90,11 @@ export async function activate(
         );
 
         const dotnetInfo = await hostExecutableResolver.getHostExecutableInfo();
-        const dotnetRuntimePath = path.dirname(dotnetInfo.path);
-
-        // Take care to always run .NET processes on the runtime that we intend.
-        // The dotnet.exe we point to should not go looking for other runtimes.
-        const env: NodeJS.ProcessEnv = { ...process.env };
-        env.DOTNET_ROOT = dotnetRuntimePath;
-        env.DOTNET_MULTILEVEL_LOOKUP = '0';
-        // Save user's DOTNET_ROOT env-var value so server can recover the user setting when needed
-        env.DOTNET_ROOT_USER = process.env.DOTNET_ROOT ?? 'EMPTY';
 
         let telemetryExtensionDllPath = '';
         // Set up DevKit environment for telemetry
         if (csharpDevkitExtension) {
-            await setupDevKitEnvironment(env, csharpDevkitExtension, logger);
+            await setupDevKitEnvironment(dotnetInfo.env, csharpDevkitExtension, logger);
 
             const telemetryExtensionPath = path.join(
                 util.getExtensionPath(),
@@ -121,7 +112,7 @@ export async function activate(
             razorTelemetryReporter,
             vscodeTelemetryReporter,
             telemetryExtensionDllPath,
-            env,
+            dotnetInfo.env,
             dotnetInfo.path,
             logger
         );

--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscodeAdapter from './vscodeAdapter';
+import * as vscode from 'vscode';
 import { RazorLanguageServerOptions } from './razorLanguageServerOptions';
 import { RazorLogger } from './razorLogger';
 import { LogLevel } from './logLevel';
@@ -44,7 +45,9 @@ function findLanguageServerExecutable(withinDir: string) {
     }
 
     if (!fs.existsSync(fullPath)) {
-        throw new Error(`Could not find Razor Language Server executable within directory '${withinDir}'`);
+        throw new Error(
+            vscode.l10n.t("Could not find Razor Language Server executable within directory '{0}'", withinDir)
+        );
     }
 
     return fullPath;

--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -7,7 +7,6 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscodeAdapter from './vscodeAdapter';
-import * as vscode from 'vscode';
 import { RazorLanguageServerOptions } from './razorLanguageServerOptions';
 import { RazorLogger } from './razorLogger';
 import { LogLevel } from './logLevel';
@@ -35,23 +34,17 @@ export function resolveRazorLanguageServerOptions(
 }
 
 function findLanguageServerExecutable(withinDir: string) {
-    const extension = isWindows() ? '.exe' : '';
-    const executablePath = path.join(withinDir, `rzls${extension}`);
+    const isSelfContained = fs.existsSync(path.join(withinDir, 'coreclr.dll'));
     let fullPath = '';
-
-    if (fs.existsSync(executablePath)) {
-        fullPath = executablePath;
+    if (isSelfContained) {
+        const fileName = isWindows() ? 'rzls.exe' : 'rzls';
+        fullPath = path.join(withinDir, fileName);
     } else {
-        // Exe doesn't exist.
-        const dllPath = path.join(withinDir, 'rzls.dll');
+        fullPath = path.join(withinDir, 'rzls.dll');
+    }
 
-        if (!fs.existsSync(dllPath)) {
-            throw new Error(
-                vscode.l10n.t("Could not find Razor Language Server executable within directory '{0}'", withinDir)
-            );
-        }
-
-        fullPath = dllPath;
+    if (!fs.existsSync(fullPath)) {
+        throw new Error(`Could not find Razor Language Server executable within directory '${withinDir}'`);
     }
 
     return fullPath;

--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -35,18 +35,16 @@ export function resolveRazorLanguageServerOptions(
 }
 
 function findLanguageServerExecutable(withinDir: string) {
-    const isSelfContained = fs.existsSync(path.join(withinDir, 'coreclr.dll'));
-    let fullPath = '';
-    if (isSelfContained) {
-        const fileName = isWindows() ? 'rzls.exe' : 'rzls';
-        fullPath = path.join(withinDir, fileName);
-    } else {
+    // Prefer using executable over fallback to dll.
+    const fileName = isWindows() ? 'rzls.exe' : 'rzls';
+    let fullPath = path.join(withinDir, fileName);
+    if (!fs.existsSync(fullPath)) {
         fullPath = path.join(withinDir, 'rzls.dll');
     }
 
     if (!fs.existsSync(fullPath)) {
         throw new Error(
-            vscode.l10n.t("Could not find Razor Language Server executable within directory '{0}'", withinDir)
+            vscode.l10n.t("Could not find Razor Language Server executable '{0}' within directory", fullPath)
         );
     }
 


### PR DESCRIPTION
- Updates where to pick up dotnet.exe.
- Contributes to making rzls move away from being self-contained.
- Unifies how roslyn and razor servers acquire dotnet path/env variables.
- Picks up leftover changes from https://github.com/dotnet/vscode-csharp/pull/5855 into main
