### PR TITLE
adds-init-only-property-snippet

### DIFF
--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -347,12 +347,26 @@
         ],
         "description": "An automatically implemented property with a 'get' accessor and a private 'set' accessor. C# 3.0 or higher"
     },
+    "propi": {
+        "prefix": "propi",
+        "body": [
+            "public ${1:int} ${2:MyProperty} { get; private init; }$0"
+        ],
+        "description": "An automatically implemented property with a 'get' accessor and a private 'init' accessor. C# 9.0 or higher"
+    },
     "prop": {
         "prefix": "prop",
         "body": [
             "public ${1:int} ${2:MyProperty} { get; set; }$0"
         ],
         "description": "An automatically implemented property. C# 3.0 or higher"
+    },
+    "iprop": {
+        "prefix": "iprop",
+        "body": [
+            "public ${1:int} ${2:MyProperty} { get; init; }$0"
+        ],
+        "description": "An automatically implemented immutable property. C# 9.0 or higher"
     },
     "sim": {
         "prefix": "sim",


### PR DESCRIPTION
## Summary

This pull request is a proposal to include snippets for init-only properties.

### iprop

This can be read by a user as either `immutable property` or `init-only property` (following the existing `prop` name that denotes a `mutable property`).

![20240203083106](https://github.com/dotnet/vscode-csharp/assets/29714040/9a5214d9-a5d4-44f3-ae4e-ea5a0984a102)

### propi

This is used to denote a private `init` setter (following the existing `propg` name that denotes a private `get` setter).

![20240203083123](https://github.com/dotnet/vscode-csharp/assets/29714040/596152e9-49ca-45f6-af4b-823f4bbefbc2)