### PR TITLE
Fix `Attribute` snippet

### DIFF
--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -3,7 +3,7 @@
         "prefix": "attribute",
         "body": [
             "[System.AttributeUsage(System.AttributeTargets.${1:All}, Inherited = ${2:false}, AllowMultiple = ${3:true})]",
-            "sealed class ${$TM_FILENAME_BASE}Attribute : System.Attribute",
+            "sealed class ${4:$TM_FILENAME_BASE}Attribute : System.Attribute",
             "{",
             "\t// See the attribute guidelines at",
             "\t//  http://go.microsoft.com/fwlink/?LinkId=85236",


### PR DESCRIPTION
This PR aims to correct the `attribute` snippet. Currently the attribute type is defined with a syntax error on the second line like ```sealed class ${Class1}Attribute : System.Attribute``` 
where 'Class1.cs' is the file name.
It also makes it so it changes the attribute prefix on the class definition and the ctor at the same time