### PR TITLE
Ensure failures to connect to the named pipe are propagated

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -629,12 +629,15 @@ export class RoslynLanguageServer {
             throw new Error('Timeout. Named pipe information not received from server.');
         }
 
-        const socketPromise = new Promise<net.Socket>((resolve) => {
+        const socketPromise = new Promise<net.Socket>((resolve, reject) => {
             _channel.appendLine('attempting to connect client to server...');
             const socket = net.createConnection(pipeConnectionInfo.pipeName, () => {
                 _channel.appendLine('client has connected to server');
                 resolve(socket);
             });
+
+            // If we failed to connect for any reason, ensure the error is propagated.
+            socket.on('error', (err) => reject(err));
         });
 
         // Wait for the client to connect to the named pipe.


### PR DESCRIPTION
Related to https://github.com/dotnet/vscode-csharp/issues/6870

Instead of showing a timeout, we'll now output the error if the connection failed in the C# logs, e.g.
```
Error: connect ENOENT \\.\pipe\BAD
    at PipeConnectWrap.afterConnect [as oncomplete] (node:net:1495:16)
    at PipeConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)
```