### PR TITLE
Add grammar support for new directives: rendermode, preservewhitespace and typeparam

### DIFF
--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -898,7 +898,7 @@
         "3": {
           "patterns": [
             {
-              "include": "source.cs#type"
+              "include": "source.cs#boolean-literal"
             }
           ]
         }

--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -525,6 +525,15 @@
         },
         {
           "include": "#using-directive"
+        },
+        {
+          "include": "#rendermode-directive"
+        },
+        {
+          "include": "#preservewhitespace-directive"
+        },
+        {
+          "include": "#typeparam-directive"
         }
       ]
     },
@@ -846,6 +855,75 @@
         },
         "4": {
           "name": "entity.name.variable.property.cs"
+        }
+      }
+    },
+    "rendermode-directive": {
+      "name": "meta.directive",
+      "match": "(@)(rendermode)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.rendermode"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "preservewhitespace-directive": {
+      "name": "meta.directive",
+      "match": "(@)(preservewhitespace)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.preservewhitespace"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "typeparam-directive": {
+      "name": "meta.directive",
+      "match": "(@)(typeparam)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.typeparam"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
         }
       }
     },

--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -441,7 +441,7 @@ repository:
     captures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.razor.directive.preservewhitespace'}
-      3: { patterns: [ include: 'source.cs#type' ] }
+      3: { patterns: [ include: 'source.cs#boolean-literal' ] }
 
   #>>>>> @typeparam <<<<<
 

--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -281,6 +281,9 @@ repository:
       - include: '#section-directive'
       - include: '#layout-directive'
       - include: '#using-directive'
+      - include: '#rendermode-directive'
+      - include: '#preservewhitespace-directive'
+      - include: '#typeparam-directive'
 
   #>>>>> @code and @functions <<<<<
 
@@ -419,6 +422,36 @@ repository:
       2: { name: 'keyword.control.razor.directive.inject'}
       3: { patterns: [ include: 'source.cs#type' ] }
       4: { name: 'entity.name.variable.property.cs' }
+
+  #>>>>> @rendermode <<<<<
+
+  rendermode-directive:
+    name: 'meta.directive'
+    match: '(@)(rendermode)\s+([^$]+)?'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.rendermode'}
+      3: { patterns: [ include: 'source.cs#type' ] }
+
+  #>>>>> @preservewhitespace <<<<<
+
+  preservewhitespace-directive:
+    name: 'meta.directive'
+    match: '(@)(preservewhitespace)\s+([^$]+)?'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.preservewhitespace'}
+      3: { patterns: [ include: 'source.cs#type' ] }
+
+  #>>>>> @typeparam <<<<<
+
+  typeparam-directive:
+    name: 'meta.directive'
+    match: '(@)(typeparam)\s+([^$]+)?'
+    captures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.razor.directive.typeparam'}
+      3: { patterns: [ include: 'source.cs#type' ] }
 
   #>>>>> @attribute <<<<<
 

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/grammarTests.test.ts.snap
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/grammarTests.test.ts.snap
@@ -2820,7 +2820,16 @@ exports[`Grammar tests @page directive Routed spaced 1`] = `
 "
 `;
 
-exports[`Grammar tests @preservewhitespace directive Bool provided 1`] = `
+exports[`Grammar tests @preservewhitespace directive Bool provided (false) 1`] = `
+"Line: @preservewhitespace false
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 20 to 25 (false) with scopes text.aspnetcorerazor, meta.directive, constant.language.boolean.false.cs
+"
+`;
+
+exports[`Grammar tests @preservewhitespace directive Bool provided (true) 1`] = `
 "Line: @preservewhitespace true
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
@@ -2919,7 +2928,7 @@ exports[`Grammar tests @removeTagHelper directive Unquoted parameter 1`] = `
 "
 `;
 
-exports[`Grammar tests @rendermode directive Incomplete mode, generic 1`] = `
+exports[`Grammar tests @rendermode directive Incomplete mode 1`] = `
 "Line: @rendermode InteractiveWebAssemb
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 11 (rendermode) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.rendermode
@@ -3744,6 +3753,18 @@ exports[`Grammar tests @try { ... } catch/finally { ... } Single line 1`] = `
  - token from 111 to 114 (456) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
  - token from 114 to 115 (;) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
  - token from 115 to 116 (}) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @typeparam directive Complete type, generic 1`] = `
+"Line: @typeparam SomeViewBase<string>
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 10 (typeparam) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.typeparam
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 11 to 23 (SomeViewBase) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+ - token from 23 to 24 (<) with scopes text.aspnetcorerazor, meta.directive, punctuation.definition.typeparameters.begin.cs
+ - token from 24 to 30 (string) with scopes text.aspnetcorerazor, meta.directive, keyword.type.cs
+ - token from 30 to 31 (>) with scopes text.aspnetcorerazor, meta.directive, punctuation.definition.typeparameters.end.cs
 "
 `;
 

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/grammarTests.test.ts.snap
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/grammarTests.test.ts.snap
@@ -2825,7 +2825,7 @@ exports[`Grammar tests @preservewhitespace directive Bool provided 1`] = `
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
  - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive
- - token from 20 to 24 (true) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+ - token from 20 to 24 (true) with scopes text.aspnetcorerazor, meta.directive, constant.language.boolean.true.cs
 "
 `;
 
@@ -2834,7 +2834,7 @@ exports[`Grammar tests @preservewhitespace directive Bool provided spaced 1`] = 
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
  - token from 19 to 33 (              ) with scopes text.aspnetcorerazor, meta.directive
- - token from 33 to 38 (false) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+ - token from 33 to 38 (false) with scopes text.aspnetcorerazor, meta.directive, constant.language.boolean.false.cs
  - token from 38 to 48 (         ) with scopes text.aspnetcorerazor, meta.directive
 "
 `;
@@ -2844,7 +2844,7 @@ exports[`Grammar tests @preservewhitespace directive Incomplete bool 1`] = `
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
  - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
  - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive
- - token from 20 to 23 (fal) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+ - token from 20 to 24 (fal) with scopes text.aspnetcorerazor, meta.directive
 "
 `;
 

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/grammarTests.test.ts.snap
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/grammarTests.test.ts.snap
@@ -2820,6 +2820,49 @@ exports[`Grammar tests @page directive Routed spaced 1`] = `
 "
 `;
 
+exports[`Grammar tests @preservewhitespace directive Bool provided 1`] = `
+"Line: @preservewhitespace true
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 20 to 24 (true) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+"
+`;
+
+exports[`Grammar tests @preservewhitespace directive Bool provided spaced 1`] = `
+"Line: @preservewhitespace              false         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
+ - token from 19 to 33 (              ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 33 to 38 (false) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+ - token from 38 to 48 (         ) with scopes text.aspnetcorerazor, meta.directive
+"
+`;
+
+exports[`Grammar tests @preservewhitespace directive Incomplete bool 1`] = `
+"Line: @preservewhitespace fal
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 20 to 23 (fal) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+"
+`;
+
+exports[`Grammar tests @preservewhitespace directive No bool 1`] = `
+"Line: @preservewhitespace
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
+"
+`;
+
+exports[`Grammar tests @preservewhitespace directive No bool spaced 1`] = `
+"Line: @preservewhitespace              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 19 (preservewhitespace) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.preservewhitespace
+ - token from 19 to 34 (              ) with scopes text.aspnetcorerazor, meta.directive
+"
+`;
+
 exports[`Grammar tests @removeTagHelper directive Incomplete parameter 1`] = `
 "Line: @removeTagHelper "
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
@@ -2873,6 +2916,49 @@ exports[`Grammar tests @removeTagHelper directive Unquoted parameter 1`] = `
  - token from 1 to 16 (removeTagHelper) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.removeTagHelper
  - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.directive
  - token from 17 to 56 (*, Microsoft.AspNetCore.Mvc.TagHelpers) with scopes text.aspnetcorerazor, meta.directive, string.quoted.double.cs
+"
+`;
+
+exports[`Grammar tests @rendermode directive Incomplete mode, generic 1`] = `
+"Line: @rendermode InteractiveWebAssemb
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 11 (rendermode) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.rendermode
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 12 to 32 (InteractiveWebAssemb) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+"
+`;
+
+exports[`Grammar tests @rendermode directive Mode provided 1`] = `
+"Line: @rendermode InteractiveServer
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 11 (rendermode) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.rendermode
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 12 to 29 (InteractiveServer) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+"
+`;
+
+exports[`Grammar tests @rendermode directive Mode provided spaced 1`] = `
+"Line: @rendermode              InteractiveAuto         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 11 (rendermode) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.rendermode
+ - token from 11 to 25 (              ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 25 to 40 (InteractiveAuto) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+ - token from 40 to 50 (         ) with scopes text.aspnetcorerazor, meta.directive
+"
+`;
+
+exports[`Grammar tests @rendermode directive No mode 1`] = `
+"Line: @rendermode
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 11 (rendermode) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.rendermode
+"
+`;
+
+exports[`Grammar tests @rendermode directive No mode spaced 1`] = `
+"Line: @rendermode              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 11 (rendermode) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.rendermode
+ - token from 11 to 26 (              ) with scopes text.aspnetcorerazor, meta.directive
 "
 `;
 
@@ -3658,6 +3744,51 @@ exports[`Grammar tests @try { ... } catch/finally { ... } Single line 1`] = `
  - token from 111 to 114 (456) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, constant.numeric.decimal.cs
  - token from 114 to 115 (;) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.terminator.statement.cs
  - token from 115 to 116 (}) with scopes text.aspnetcorerazor, meta.statement.finally.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @typeparam directive Incomplete type, generic 1`] = `
+"Line: @typeparam SomeViewBase<string
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 10 (typeparam) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.typeparam
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 11 to 23 (SomeViewBase) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+ - token from 23 to 24 (<) with scopes text.aspnetcorerazor, meta.directive, punctuation.definition.typeparameters.begin.cs
+ - token from 24 to 30 (string) with scopes text.aspnetcorerazor, meta.directive, keyword.type.cs
+"
+`;
+
+exports[`Grammar tests @typeparam directive No type 1`] = `
+"Line: @typeparam
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 10 (typeparam) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.typeparam
+"
+`;
+
+exports[`Grammar tests @typeparam directive No type spaced 1`] = `
+"Line: @typeparam              
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 10 (typeparam) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.typeparam
+ - token from 10 to 25 (              ) with scopes text.aspnetcorerazor, meta.directive
+"
+`;
+
+exports[`Grammar tests @typeparam directive Type provided 1`] = `
+"Line: @typeparam Person
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 10 (typeparam) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.typeparam
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 11 to 17 (Person) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+"
+`;
+
+exports[`Grammar tests @typeparam directive Type provided spaced 1`] = `
+"Line: @typeparam              Person         
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.directive, keyword.control.cshtml.transition
+ - token from 1 to 10 (typeparam) with scopes text.aspnetcorerazor, meta.directive, keyword.control.razor.directive.typeparam
+ - token from 10 to 24 (              ) with scopes text.aspnetcorerazor, meta.directive
+ - token from 24 to 30 (Person) with scopes text.aspnetcorerazor, meta.directive, entity.name.type.cs
+ - token from 30 to 40 (         ) with scopes text.aspnetcorerazor, meta.directive
 "
 `;
 

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/grammarTests.test.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/grammarTests.test.ts
@@ -39,6 +39,9 @@ import { RunTryStatementSuite } from './tryStatement';
 import { RunUsingDirectiveSuite } from './usingDirective';
 import { RunUsingStatementSuite } from './usingStatement';
 import { RunWhileStatementSuite } from './whileStatement';
+import { RunRendermodeDirectiveSuite } from './rendermodeDirective';
+import { RunPreservewhitespaceDirectiveSuite } from './preservewhitespaceDirective';
+import { RunTypeparamDirectiveSuite } from './typeparamDirective';
 
 // We bring together all test suites and wrap them in one here. The reason behind this is that
 // modules get reloaded per test suite and the vscode-textmate library doesn't support the way
@@ -71,6 +74,9 @@ describe('Grammar tests', () => {
     RunSectionDirectiveSuite();
     RunLayoutDirectiveSuite();
     RunUsingDirectiveSuite();
+    RunRendermodeDirectiveSuite();
+    RunPreservewhitespaceDirectiveSuite();
+    RunTypeparamDirectiveSuite();
 
     // Razor C# Control Structures
     RunUsingStatementSuite();

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/preservewhitespaceDirective.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/preservewhitespaceDirective.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, it } from '@jest/globals';
+import { assertMatchesSnapshot } from './infrastructure/testUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunPreservewhitespaceDirectiveSuite() {
+    describe('@preservewhitespace directive', () => {
+        it('No bool', async () => {
+            await assertMatchesSnapshot('@preservewhitespace');
+        });
+
+        it('No bool spaced', async () => {
+            await assertMatchesSnapshot('@preservewhitespace              ');
+        });
+
+        it('Incomplete bool', async () => {
+            await assertMatchesSnapshot('@preservewhitespace fal');
+        });
+
+        it('Bool provided', async () => {
+            await assertMatchesSnapshot('@preservewhitespace true');
+        });
+
+        it('Bool provided spaced', async () => {
+            await assertMatchesSnapshot('@preservewhitespace              false         ');
+        });
+    });
+}

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/preservewhitespaceDirective.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/preservewhitespaceDirective.ts
@@ -22,8 +22,12 @@ export function RunPreservewhitespaceDirectiveSuite() {
             await assertMatchesSnapshot('@preservewhitespace fal');
         });
 
-        it('Bool provided', async () => {
+        it('Bool provided (true)', async () => {
             await assertMatchesSnapshot('@preservewhitespace true');
+        });
+
+        it('Bool provided (false)', async () => {
+            await assertMatchesSnapshot('@preservewhitespace false');
         });
 
         it('Bool provided spaced', async () => {

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/rendermodeDirective.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/rendermodeDirective.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, it } from '@jest/globals';
+import { assertMatchesSnapshot } from './infrastructure/testUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunRendermodeDirectiveSuite() {
+    describe('@rendermode directive', () => {
+        it('No mode', async () => {
+            await assertMatchesSnapshot('@rendermode');
+        });
+
+        it('No mode spaced', async () => {
+            await assertMatchesSnapshot('@rendermode              ');
+        });
+
+        it('Incomplete mode, generic', async () => {
+            await assertMatchesSnapshot('@rendermode InteractiveWebAssemb');
+        });
+
+        it('Mode provided', async () => {
+            await assertMatchesSnapshot('@rendermode InteractiveServer');
+        });
+
+        it('Mode provided spaced', async () => {
+            await assertMatchesSnapshot('@rendermode              InteractiveAuto         ');
+        });
+    });
+}

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/rendermodeDirective.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/rendermodeDirective.ts
@@ -18,7 +18,7 @@ export function RunRendermodeDirectiveSuite() {
             await assertMatchesSnapshot('@rendermode              ');
         });
 
-        it('Incomplete mode, generic', async () => {
+        it('Incomplete mode', async () => {
             await assertMatchesSnapshot('@rendermode InteractiveWebAssemb');
         });
 

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/typeparamDirective.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/typeparamDirective.ts
@@ -22,6 +22,10 @@ export function RunTypeparamDirectiveSuite() {
             await assertMatchesSnapshot('@typeparam SomeViewBase<string');
         });
 
+        it('Complete type, generic', async () => {
+            await assertMatchesSnapshot('@typeparam SomeViewBase<string>');
+        });
+
         it('Type provided', async () => {
             await assertMatchesSnapshot('@typeparam Person');
         });

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/typeparamDirective.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/typeparamDirective.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, it } from '@jest/globals';
+import { assertMatchesSnapshot } from './infrastructure/testUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunTypeparamDirectiveSuite() {
+    describe('@typeparam directive', () => {
+        it('No type', async () => {
+            await assertMatchesSnapshot('@typeparam');
+        });
+
+        it('No type spaced', async () => {
+            await assertMatchesSnapshot('@typeparam              ');
+        });
+
+        it('Incomplete type, generic', async () => {
+            await assertMatchesSnapshot('@typeparam SomeViewBase<string');
+        });
+
+        it('Type provided', async () => {
+            await assertMatchesSnapshot('@typeparam Person');
+        });
+
+        it('Type provided spaced', async () => {
+            await assertMatchesSnapshot('@typeparam              Person         ');
+        });
+    });
+}


### PR DESCRIPTION
This pull request fixes dotnet/razor#9882 in the razor repository. It updates the TextMate grammar to include code coloring for three new Razor directives: rendermode, preservewhitespace, and typeparam. You can find more information about these directives in the [razor documentation](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/razor?view=aspnetcore-8.0#preservewhitespace).

## Changes Summary

### tmLanguage.yml

This file defines the TextMate grammar. I added support for the three new Razor directives, following the same format as the existing directives.

 ### tmLanguage.json

This file is automatically generated to reflect the changes in tmLanguage.yml. You can update it by running the razorTests or the `npm run compile:razorTextMate` command.

### razorTests

I added three new entries in grammarTests.test.ts and created three new test files for the new directives. These tests follow the same format as the existing tests for other Razor directives. 

## Visualization

### Before
<img width="314" alt="before_vs_code" src="https://github.com/dotnet/vscode-csharp/assets/17770319/0dce7f83-ad3d-4efa-b40e-0646931ae718">

### After
<img width="285" alt="after_vs_code_2" src="https://github.com/dotnet/vscode-csharp/assets/17770319/2676e33f-9509-4f53-955c-1d8152570be6">

