### PR TITLE
Test more versions of .NET using docker containers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+    <PropertyGroup>
+        <!--
+            Defines the lowest supported target framework for the extension.
+            Used by server download / integration tests to ensure they run when only this SDK is installed.
+        -->
+        <LowestSupportedTargetFramework>net6.0</LowestSupportedTargetFramework>
+    </PropertyGroup>
+</Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,27 +18,58 @@ stages:
   parameters:
     isOfficial: false
 
-- stage: Test
-  displayName: Test
+- stage: Test_Linux_Stage
+  displayName: Test Linux
   dependsOn: []
   jobs:
-  - template: azure-pipelines/test.yml
-    parameters:
-      jobName: Linux
-      poolName: NetCore-Public
-      demandsName: 1es-ubuntu-2004-open
+  - job: Test_Linux_Job
+    displayName:  Test Linux
+    strategy:
+      matrix:
+        DotNet6:
+          containerName: mcr.microsoft.com/dotnet/sdk:6.0
+        DotNet7:
+          containerName: mcr.microsoft.com/dotnet/sdk:7.0
+        DotNet8:
+          containerName: mcr.microsoft.com/dotnet/sdk:8.0
+    pool:
+      name: NetCore-Public
+      demands: ImageOverride -equals 1es-ubuntu-2004-open
+    container: $[ variables['containerName'] ]
+    steps:
+    - template: azure-pipelines/test.yml
+      parameters:
+        # Prefer the dotnet from the container.
+        installDotNet: false
+        installAdditionalLinuxDependencies: true
 
-  - template: azure-pipelines/test.yml
-    parameters:
-      jobName: Windows
-      poolName: NetCore-Public
-      demandsName: 1es-windows-2022-open
+- stage: Test_Windows_Stage
+  displayName: Test Windows
+  dependsOn: []
+  jobs:
+  - job: Test_Windows_Job
+    displayName: Test Windows
+    pool:
+      name: NetCore-Public
+      demands: ImageOverride -equals 1es-windows-2022-open
+    steps:
+    - template: azure-pipelines/test.yml
+      parameters:
+        installDotNet: true
 
-  - template: azure-pipelines/test.yml
-    parameters:
-      jobName: MacOS
-      poolName: Azure Pipelines
-      vmImageName: macOS-13
+- stage: Test_MacOS_Stage
+  displayName: Test MacOS
+  dependsOn: []
+  jobs:
+  - job: Test_MacOS_Job
+    displayName: Test MacOS
+    pool:
+      name: Azure Pipelines
+      vmImage: macOS-13
+    steps:
+    - template: azure-pipelines/test.yml
+      parameters:
+        installDotNet: true
 
 - stage: Test_OmniSharp
   displayName: Test OmniSharp

--- a/azure-pipelines/prereqs.yml
+++ b/azure-pipelines/prereqs.yml
@@ -2,6 +2,9 @@ parameters:
   - name: versionNumberOverride
     type: string
     default: 'default'
+  - name: installDotNet
+    type: boolean
+    default: true
 
 steps:
 
@@ -13,13 +16,18 @@ steps:
   inputs:
     versionSpec: '18.x'
 
-- task: UseDotNet@2
-  displayName: 'Install .NET Core SDKs'
-  inputs:
-    version: '8.x'
+# Some tests use predefined docker images with a specific version of .NET installed.
+# So we avoid installing .NET in those cases.
+- ${{ if eq(parameters.installDotNet, true) }}:
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core SDKs'
+    inputs:
+      version: '8.x'
 
-- script: |
-    dotnet tool install --tool-path $(Agent.BuildDirectory) nbgv
+- script: dotnet --info
+  displayName: Display dotnet info
+
+- script: dotnet tool install --tool-path $(Agent.BuildDirectory) nbgv
   displayName: Install nbgv
 
 # If we want to override the version, update the version.json here - vsix packaging will see this value

--- a/azure-pipelines/test-linux-docker-prereqs.yml
+++ b/azure-pipelines/test-linux-docker-prereqs.yml
@@ -1,0 +1,19 @@
+steps:
+- script: echo "##vso[task.setvariable variable=containerId;]$(docker ps --latest --quiet)"
+  displayName: Set containerId variable
+  target: host
+  condition: eq(variables['Agent.OS'], 'Linux')
+
+- script: echo "containerId is $(containerId)"
+  displayName: Read containerId variable
+  target: host
+  condition: eq(variables['Agent.OS'], 'Linux')
+
+# The docker containers we use for linux require some additional dependencies to run VSCode.
+# Installing the dependencies requires root, but the docker image we're using doesn't have root permissions (nor sudo)
+# We can exec as root from outside the container from the host machine.
+# Really we should create our own image with these pre-installed, but we'll need to figure out how to publish the image.
+- script: docker exec --user root $(containerId) bash -c 'apt-get update -y && apt-get install -y libglib2.0-0 libnss3 libatk-bridge2.0-dev libdrm2 libgtk-3-0 libgbm-dev libasound2 xvfb'
+  displayName: 'Install additional Linux dependencies'
+  target: host
+  condition: eq(variables['Agent.OS'], 'Linux')

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -1,55 +1,47 @@
 parameters:
-  - name: jobName
-    type: string
-  - name: poolName
-    type: string
-  - name: demandsName
-    type: string
-    default: ''
-  - name: vmImageName
-    type: string
-    default: ''
+  - name: installDotNet
+    type: boolean
+  - name: installAdditionalLinuxDependencies
+    type: boolean
+    default: false
 
-jobs:
-- job: Test_${{ parameters.jobName }}
-  displayName: 'Test ${{ parameters.jobName }}'
-  pool:
-    ${{ if ne(parameters.poolName, '') }}:
-      name: ${{ parameters.poolName }}
-    ${{ if ne(parameters.demandsName, '') }}:
-      demands: ImageOverride -equals ${{ parameters.demandsName }}
-    ${{ if ne(parameters.vmImageName, '') }}:
-      vmImage: ${{ parameters.vmImageName }}
-  steps:
-  - checkout: self
-    clean: true
-    submodules: true
-    fetchTags: false
-    fetchDepth: 1
+steps:
+- checkout: self
+  clean: true
+  submodules: true
+  fetchTags: false
+  fetchDepth: 1
 
-  - template: prereqs.yml
+- template: prereqs.yml
+  parameters:
+    installDotNet: ${{ parameters.installDotNet }}
 
-  - template: test-prereqs.yml
+- ${{ if eq(parameters.installAdditionalLinuxDependencies, true) }}:
+  - template: test-linux-docker-prereqs.yml
 
-  - script: npm run test
-    displayName: 🧪 Run unit and integration tests
-    env:
-      DISPLAY: :99.0
+- template: test-prereqs.yml
+  parameters:
+    installAdditionalLinuxDependencies: ${{ parameters.installAdditionalLinuxDependencies }}
 
-  - task: PublishTestResults@2
-    condition: succeededOrFailed()
-    displayName: 'Publish Test Results'
-    inputs:
-      testResultsFormat: 'JUnit'
-      testResultsFiles: '*junit.xml'
-      searchFolder: '$(Build.SourcesDirectory)/out'
-      publishRunAttachments: true
-      mergeTestResults: true
-      testRunTitle: $(Agent.JobName) (Attempt $(System.JobAttempt))
+- script: npm run test
+  displayName: 🧪 Run unit and integration tests
+  env:
+    DISPLAY: :99.0
 
-  - task: PublishPipelineArtifact@1
-    condition: failed()
-    displayName: 'Upload integration test logs'
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/.vscode-test/user-data/logs'
-      artifactName: 'VSCode Test Logs ($(Agent.JobName)-$(System.JobAttempt))'
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '*junit.xml'
+    searchFolder: '$(Build.SourcesDirectory)/out'
+    publishRunAttachments: true
+    mergeTestResults: true
+    testRunTitle: $(Agent.JobName) (Attempt $(System.JobAttempt))
+
+- task: PublishPipelineArtifact@1
+  condition: failed()
+  displayName: 'Upload integration test logs'
+  inputs:
+    targetPath: '$(Build.SourcesDirectory)/.vscode-test/user-data/logs'
+    artifactName: 'VSCode Test Logs ($(Agent.JobName)-$(System.JobAttempt))'

--- a/server/ServerDownload.csproj
+++ b/server/ServerDownload.csproj
@@ -11,8 +11,8 @@
         <RestorePackagesPath>../out/.nuget/</RestorePackagesPath>
         <!-- It's still PackageReference, so project intermediates are still created. -->
         <MSBuildProjectExtensionsPath>$(RestorePackagesPath)obj/</MSBuildProjectExtensionsPath>
-        <!-- This is not super relevant, as long as your SDK version supports it. -->
-        <TargetFramework>net8.0</TargetFramework>
+        <!-- We use the lowest supported target framework so we can build and run integration tests against the lowest supported target framework -->
+        <TargetFramework>net6.0</TargetFramework>
         <!-- If a package is resolved to a fallback folder, it may not be downloaded.-->
         <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
         <!-- We don't want to build this project, so we do not need the reference assemblies for the framework we chose.-->

--- a/server/ServerDownload.csproj
+++ b/server/ServerDownload.csproj
@@ -12,7 +12,7 @@
         <!-- It's still PackageReference, so project intermediates are still created. -->
         <MSBuildProjectExtensionsPath>$(RestorePackagesPath)obj/</MSBuildProjectExtensionsPath>
         <!-- We use the lowest supported target framework so we can build and run integration tests against the lowest supported target framework -->
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>$(LowestSupportedTargetFramework)</TargetFramework>
         <!-- If a package is resolved to a fallback folder, it may not be downloaded.-->
         <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
         <!-- We don't want to build this project, so we do not need the reference assemblies for the framework we chose.-->

--- a/test/integrationTests/testAssets/slnWithCsproj/src/app/app.csproj
+++ b/test/integrationTests/testAssets/slnWithCsproj/src/app/app.csproj
@@ -4,7 +4,7 @@
  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LowestSupportedTargetFramework)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test/integrationTests/testAssets/slnWithCsproj/src/app/app.csproj
+++ b/test/integrationTests/testAssets/slnWithCsproj/src/app/app.csproj
@@ -4,7 +4,7 @@
  </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test/integrationTests/testAssets/slnWithCsproj/test/test.csproj
+++ b/test/integrationTests/testAssets/slnWithCsproj/test/test.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Allow tests to execute against higher runtimes in integration tests -->
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/integrationTests/testAssets/slnWithCsproj/test/test.csproj
+++ b/test/integrationTests/testAssets/slnWithCsproj/test/test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(LowestSupportedTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Adds CI runs for net6/7/8 on Linux.

Windows is possible in the future, but we likely need to create custom containers for it - the dotnet ones are based on windows server nano which doesn't seem to include powershell, a hard requirement for windows Azdo containers.  Encountered this issue without it - https://github.com/microsoft/azure-pipelines-tasks/issues/11448