### PR TITLE
Update roslyn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 ## Latest
-* Add oboslete classification definitions to default themes (PR: [#<>](https://github.com/dotnet/vscode-csharp/pull/<>))
+* Add oboslete classification definitions to vs2019 themes (PR: [#<>](https://github.com/dotnet/vscode-csharp/pull/<>))
 * Bump Roslyn to 4.11.0-1.24179.11 (PR: [#<>](https://github.com/dotnet/vscode-csharp/pull/<>))
   * Add feature to strike out obsolete symbols (PR: [#72156](https://github.com/dotnet/roslyn/pull/72156))
   * Fix issue where some file changes would be ignored on Windows due to casing (PR: [#72555](https://github.com/dotnet/roslyn/pull/72555))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 ## Latest
-* Add oboslete classification definitions to vs2019 themes (PR: [#<>](https://github.com/dotnet/vscode-csharp/pull/<>))
-* Bump Roslyn to 4.11.0-1.24179.11 (PR: [#<>](https://github.com/dotnet/vscode-csharp/pull/<>))
+* Add oboslete classification definitions to vs2019 themes (PR: [#7011](https://github.com/dotnet/vscode-csharp/pull/7011))
+* Bump Roslyn to 4.11.0-1.24179.11 (PR: [#7011](https://github.com/dotnet/vscode-csharp/pull/7011))
   * Add feature to strike out obsolete symbols (PR: [#72156](https://github.com/dotnet/roslyn/pull/72156))
   * Fix issue where some file changes would be ignored on Windows due to casing (PR: [#72555](https://github.com/dotnet/roslyn/pull/72555))
   * Drop win32-ia32 language server support (PR: [#72605](https://github.com/dotnet/roslyn/pull/72605))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 ## Latest
+* Add oboslete classification definitions to default themes (PR: [#<>](https://github.com/dotnet/vscode-csharp/pull/<>))
+* Bump Roslyn to 4.11.0-1.24179.11 (PR: [#<>](https://github.com/dotnet/vscode-csharp/pull/<>))
+  * Add feature to strike out obsolete symbols (PR: [#72156](https://github.com/dotnet/roslyn/pull/72156))
+  * Fix issue where some file changes would be ignored on Windows due to casing (PR: [#72555](https://github.com/dotnet/roslyn/pull/72555))
+  * Drop win32-ia32 language server support (PR: [#72605](https://github.com/dotnet/roslyn/pull/72605))
+  * Use built in Razor source generator instead of generator from SDK. (PR: [#72482](https://github.com/dotnet/roslyn/pull/72482))
+  * Always log LSP server processId and increase attach timeout (PR: [#72531](https://github.com/dotnet/roslyn/pull/72531))
 * Bump razor and update changelog (PR: [#7005](https://github.com/dotnet/vscode-csharp/pull/7005))
   * Tweak RazorConfigurationFormatter to account for serialization format change (PR: [#10157](https://github.com/dotnet/razor/pull/10157))
   * Use PooledArrayBuilder<SyntaxToken> throughout parsers and tokenizer (PR [#10095](https://github.com/dotnet/razor/pull/10095))

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "defaults": {
-    "roslyn": "4.10.0-3.24168.8",
+    "roslyn": "4.11.0-1.24179.11",
     "omniSharp": "1.39.11",
     "razor": "7.0.0-preview.24175.3",
     "razorOmnisharp": "7.0.0-preview.23363.1",

--- a/themes/vs2019_dark.json
+++ b/themes/vs2019_dark.json
@@ -24,6 +24,11 @@
         "sideBarSectionHeader.border": "#ccc3"
     },
     "semanticHighlighting": true,
+    "semanticTokenColors": {
+        "*.deprecated": {
+            "strikethrough": true
+        }
+    },
     // https://github.com/microsoft/vscode/blob/master/extensions/theme-defaults/themes/dark_vs.json
     "tokenColors": [
         {

--- a/themes/vs2019_light.json
+++ b/themes/vs2019_light.json
@@ -24,6 +24,11 @@
         "sideBarSectionHeader.border": "#61616130"
     },
     "semanticHighlighting": true,
+    "semanticTokenColors": {
+        "*.deprecated": {
+            "strikethrough": true
+        }
+    },
     // https://github.com/microsoft/vscode/blob/master/extensions/theme-defaults/themes/light_vs.json
     "tokenColors": [
         {


### PR DESCRIPTION
Updates Roslyn to https://dnceng.visualstudio.com/internal/_build/results?buildId=2418271&view=results

Also adds support for the obsolete classification in the default themes:
![image](https://github.com/dotnet/vscode-csharp/assets/5749229/5deba1cb-0ef8-4481-abf9-f83558f9f489)
