### PR TITLE
Textmate: fix Razor expression classification inside of HTML tags

### DIFF
--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -64,6 +64,16 @@
         }
       ]
     },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#explicit-razor-expression"
+        },
+        {
+          "include": "#implicit-expression"
+        }
+      ]
+    },
     "escaped-transition": {
       "name": "constant.character.escape.razor.transition",
       "match": "@@"

--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -64,7 +64,7 @@
         }
       ]
     },
-    "expression": {
+    "implicit-or-explicit-expression": {
       "patterns": [
         {
           "include": "#explicit-razor-expression"

--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -32,7 +32,7 @@ repository:
       - include: '#implicit-expression'
 
   # a clause to combine the explicit and implicit razor expressions, used by the html grammar
-  expression:
+  implicit-or-explicit-expression:
     patterns:
       - include: '#explicit-razor-expression'
       - include: '#implicit-expression'

--- a/src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/razor/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -31,6 +31,12 @@ repository:
       - include: '#optionally-transitioned-csharp-control-structures'
       - include: '#implicit-expression'
 
+  # a clause to combine the explicit and implicit razor expressions, used by the html grammar
+  expression:
+    patterns:
+      - include: '#explicit-razor-expression'
+      - include: '#implicit-expression'
+
   escaped-transition:
     name: constant.character.escape.razor.transition
     match: '@@'

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/embeddedGrammars/html.tmLanguage.json
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/embeddedGrammars/html.tmLanguage.json
@@ -114,7 +114,7 @@
 											"name": "string.quoted.double.html",
 											"patterns": [
 												{
-													"include": "text.aspnetcorerazor#expression"
+													"include": "text.aspnetcorerazor#implicit-or-explicit-expression"
 												},
 												{
 													"include": "#entities"
@@ -141,7 +141,7 @@
 											"name": "string.quoted.single.html",
 											"patterns": [
 												{
-													"include": "text.aspnetcorerazor#expression"
+													"include": "text.aspnetcorerazor#implicit-or-explicit-expression"
 												},
 												{
 													"include": "#entities"
@@ -410,7 +410,7 @@
 							"name": "string.quoted.double.html",
 							"patterns": [
 								{
-									"include": "text.aspnetcorerazor#expression"
+									"include": "text.aspnetcorerazor#implicit-or-explicit-expression"
 								},
 								{
 									"include": "#entities"
@@ -433,7 +433,7 @@
 							"name": "string.quoted.single.html",
 							"patterns": [
 								{
-									"include": "text.aspnetcorerazor#expression"
+									"include": "text.aspnetcorerazor#implicit-or-explicit-expression"
 								},
 								{
 									"include": "#entities"

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/embeddedGrammars/html.tmLanguage.json
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/embeddedGrammars/html.tmLanguage.json
@@ -114,6 +114,9 @@
 											"name": "string.quoted.double.html",
 											"patterns": [
 												{
+													"include": "text.aspnetcorerazor#expression"
+												},
+												{
 													"include": "#entities"
 												}
 											]
@@ -137,6 +140,9 @@
 											},
 											"name": "string.quoted.single.html",
 											"patterns": [
+												{
+													"include": "text.aspnetcorerazor#expression"
+												},
 												{
 													"include": "#entities"
 												}
@@ -404,6 +410,9 @@
 							"name": "string.quoted.double.html",
 							"patterns": [
 								{
+									"include": "text.aspnetcorerazor#expression"
+								},
+								{
 									"include": "#entities"
 								}
 							]
@@ -423,6 +432,9 @@
 							},
 							"name": "string.quoted.single.html",
 							"patterns": [
+								{
+									"include": "text.aspnetcorerazor#expression"
+								},
 								{
 									"include": "#entities"
 								}

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/grammarTests.test.ts.snap
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/grammarTests.test.ts.snap
@@ -4480,7 +4480,10 @@ exports[`Grammar tests Explicit Expressions In Attributes Double Quotes Class ex
  - token from 5 to 10 (class) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, entity.other.attribute-name.html
  - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, punctuation.separator.key-value.html
  - token from 11 to 12 (") with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 12 to 30 (@(NavMenuCssClass)) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 13 to 14 (() with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 14 to 29 (NavMenuCssClass) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 30 to 31 (") with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 31 to 32 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
  - token from 32 to 34 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
@@ -4497,7 +4500,9 @@ exports[`Grammar tests Explicit Expressions In Attributes Double Quotes Empty 1`
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 21 (@()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 21 to 22 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 23 to 25 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4514,68 +4519,106 @@ exports[`Grammar tests Explicit Expressions In Attributes Double Quotes Multi li
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 21 (@() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
 
 Line:     Html.BeginForm(
- - token from 0 to 20 (    Html.BeginForm() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 4 to 8 (Html) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 8 to 9 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 9 to 18 (BeginForm) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
 
 Line:         "Login",
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
- - token from 8 to 9 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 9 to 14 (Login) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.Login.html, entity.other.attribute-name.html
- - token from 14 to 16 (",) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, invalid.illegal.character-not-allowed-here.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 8 to 9 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 9 to 14 (Login) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 14 to 15 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 15 to 16 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:         "Home",
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html
- - token from 8 to 15 ("Home",) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, invalid.illegal.character-not-allowed-here.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 8 to 9 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 9 to 13 (Home) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 13 to 14 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 14 to 15 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:         new
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html
- - token from 8 to 11 (new) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.new.html, entity.other.attribute-name.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 8 to 11 (new) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.other.new.cs
 
 Line:         {
- - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html
- - token from 8 to 9 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.{.html, entity.other.attribute-name.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 8 to 9 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
 
 Line:             @class = "someClass",
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html
- - token from 12 to 18 (@class) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@class.html, entity.other.attribute-name.html
- - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@class.html
- - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@class.html, punctuation.separator.key-value.html
- - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@class.html
- - token from 21 to 22 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 22 to 31 (someClass) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@class.html, string.quoted.double.html
- - token from 31 to 32 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@class.html, string.quoted.double.html, punctuation.definition.string.end.html
- - token from 32 to 33 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.,.html, entity.other.attribute-name.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 12 to 18 (@class) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.operator.assignment.cs
+ - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 21 to 22 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 22 to 31 (someClass) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 31 to 32 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 32 to 33 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:             notValid = Html.DisplayFor<object>(
- - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html
- - token from 12 to 20 (notValid) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.notValid.html, entity.other.attribute-name.html
- - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.notValid.html
- - token from 21 to 22 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.notValid.html, punctuation.separator.key-value.html
- - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.notValid.html
- - token from 23 to 38 (Html.DisplayFor) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.notValid.html, string.unquoted.html
- - token from 38 to 45 (<object) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, invalid.illegal.character-not-allowed-here.html
- - token from 45 to 46 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
- - token from 46 to 48 (() with scopes text.aspnetcorerazor
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 12 to 20 (notValid) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 21 to 22 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.operator.assignment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 23 to 27 (Html) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 28 to 38 (DisplayFor) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 38 to 39 (<) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 39 to 45 (object) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 45 to 46 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 46 to 47 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
 
 Line:                 (_) => Model,
- - token from 0 to 30 (                (_) => Model,) with scopes text.aspnetcorerazor
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 17 to 18 (_) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, entity.name.variable.parameter.cs
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 20 to 22 (=>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.operator.arrow.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 23 to 28 (Model) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 28 to 29 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:                 "name",
- - token from 0 to 24 (                "name",) with scopes text.aspnetcorerazor
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 16 to 17 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 17 to 21 (name) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 21 to 22 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 22 to 23 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:                 "someName",
- - token from 0 to 28 (                "someName",) with scopes text.aspnetcorerazor
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 16 to 17 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 17 to 25 (someName) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 25 to 26 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 26 to 27 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:                 new { })
- - token from 0 to 25 (                new { })) with scopes text.aspnetcorerazor
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 16 to 19 (new) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.other.new.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 20 to 21 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 22 to 23 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 23 to 24 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
 
 Line:         })
- - token from 0 to 11 (        })) with scopes text.aspnetcorerazor
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
 
 Line: )"></button>
- - token from 0 to 3 ()">) with scopes text.aspnetcorerazor
+ - token from 0 to 1 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 1 to 2 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 2 to 3 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 3 to 5 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
  - token from 5 to 11 (button) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, entity.name.tag.html
  - token from 11 to 12 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.end.html
@@ -4590,7 +4633,12 @@ exports[`Grammar tests Explicit Expressions In Attributes Double Quotes Onclick 
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 36 (@(ToggleNavMenu())) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 20 to 33 (ToggleNavMenu) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 33 to 34 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 34 to 35 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 36 to 37 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 37 to 38 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 38 to 40 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4607,7 +4655,60 @@ exports[`Grammar tests Explicit Expressions In Attributes Double Quotes Single l
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 127 (@(456 + new Array<int>(){1,2,3}[0] + await GetValueAsync<string>() ?? someArray[await DoMoreAsync(() => {})])) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 20 to 23 (456) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 24 to 25 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.operator.arithmetic.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 26 to 29 (new) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.other.new.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 30 to 35 (Array) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, entity.name.type.cs
+ - token from 35 to 36 (<) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 36 to 39 (int) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 40 to 41 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 41 to 42 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 42 to 43 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 43 to 44 (1) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 44 to 45 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+ - token from 45 to 46 (2) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 46 to 47 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+ - token from 47 to 48 (3) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 48 to 49 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 49 to 50 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.squarebracket.open.cs
+ - token from 50 to 51 (0) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 51 to 52 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.squarebracket.close.cs
+ - token from 52 to 53 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 53 to 54 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.operator.arithmetic.cs
+ - token from 54 to 55 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 55 to 60 (await) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.other.await.cs
+ - token from 60 to 61 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 61 to 74 (GetValueAsync) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 74 to 75 (<) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 75 to 81 (string) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 81 to 82 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 82 to 83 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 83 to 84 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 84 to 85 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 85 to 87 (??) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.operator.null-coalescing.cs
+ - token from 87 to 88 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 88 to 97 (someArray) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.object.property.cs
+ - token from 97 to 98 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.squarebracket.open.cs
+ - token from 98 to 103 (await) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.other.await.cs
+ - token from 103 to 104 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 104 to 115 (DoMoreAsync) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 115 to 116 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 116 to 117 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 117 to 118 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 118 to 119 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 119 to 121 (=>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.operator.arrow.cs
+ - token from 121 to 122 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml
+ - token from 122 to 123 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 123 to 124 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 124 to 125 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 125 to 126 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.squarebracket.close.cs
+ - token from 126 to 127 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 127 to 128 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 128 to 129 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 129 to 131 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4624,7 +4725,12 @@ exports[`Grammar tests Explicit Expressions In Attributes Double Quotes Single l
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 33 (@(DateTime.Now)) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 20 to 28 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, variable.other.object.property.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 33 to 34 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 35 to 37 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4641,7 +4747,10 @@ exports[`Grammar tests Explicit Expressions In Attributes Single Quotes Class ex
  - token from 5 to 10 (class) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, entity.other.attribute-name.html
  - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, punctuation.separator.key-value.html
  - token from 11 to 12 (') with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 12 to 30 (@(NavMenuCssClass)) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 13 to 14 (() with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 14 to 29 (NavMenuCssClass) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 30 to 31 (') with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 31 to 32 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
  - token from 32 to 34 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
@@ -4658,7 +4767,9 @@ exports[`Grammar tests Explicit Expressions In Attributes Single Quotes Empty 1`
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 21 (@()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 21 to 22 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 23 to 25 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4675,46 +4786,104 @@ exports[`Grammar tests Explicit Expressions In Attributes Single Quotes Multi li
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 21 (@() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
 
 Line:     Html.BeginForm(
- - token from 0 to 20 (    Html.BeginForm() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 4 to 8 (Html) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 8 to 9 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 9 to 18 (BeginForm) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 18 to 19 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
 
 Line:         "Login",
- - token from 0 to 17 (        "Login",) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 8 to 9 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 9 to 14 (Login) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 14 to 15 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 15 to 16 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:         "Home",
- - token from 0 to 16 (        "Home",) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 8 to 9 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 9 to 13 (Home) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 13 to 14 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 14 to 15 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:         new
- - token from 0 to 12 (        new) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 8 to 11 (new) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.other.new.cs
 
 Line:         {
- - token from 0 to 10 (        {) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 8 to 9 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
 
 Line:             @class = "someClass",
- - token from 0 to 34 (            @class = "someClass",) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 12 to 18 (@class) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 19 to 20 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.operator.assignment.cs
+ - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 21 to 22 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 22 to 31 (someClass) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 31 to 32 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 32 to 33 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:             notValid = Html.DisplayFor<object>(
- - token from 0 to 48 (            notValid = Html.DisplayFor<object>() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 12 to 20 (notValid) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 21 to 22 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.operator.assignment.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 23 to 27 (Html) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 28 to 38 (DisplayFor) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 38 to 39 (<) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 39 to 45 (object) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 45 to 46 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 46 to 47 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
 
 Line:                 (_) => Model,
- - token from 0 to 30 (                (_) => Model,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 17 to 18 (_) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, entity.name.variable.parameter.cs
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 20 to 22 (=>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.operator.arrow.cs
+ - token from 22 to 23 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 23 to 28 (Model) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.readwrite.cs
+ - token from 28 to 29 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:                 "name",
- - token from 0 to 24 (                "name",) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 16 to 17 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 17 to 21 (name) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 21 to 22 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 22 to 23 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:                 "someName",
- - token from 0 to 28 (                "someName",) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 16 to 17 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 17 to 25 (someName) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs
+ - token from 25 to 26 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 26 to 27 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
 
 Line:                 new { })
- - token from 0 to 25 (                new { })) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 16 (                ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 16 to 19 (new) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.other.new.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 20 to 21 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 22 to 23 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 23 to 24 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
 
 Line:         })
- - token from 0 to 11 (        })) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
 
 Line: )'></button>
- - token from 0 to 1 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 1 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 1 to 2 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 2 to 3 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 3 to 5 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4731,7 +4900,12 @@ exports[`Grammar tests Explicit Expressions In Attributes Single Quotes Onclick 
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 36 (@(ToggleNavMenu())) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 20 to 33 (ToggleNavMenu) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 33 to 34 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 34 to 35 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 35 to 36 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 36 to 37 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 37 to 38 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 38 to 40 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4748,7 +4922,60 @@ exports[`Grammar tests Explicit Expressions In Attributes Single Quotes Single l
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 127 (@(456 + new Array<int>(){1,2,3}[0] + await GetValueAsync<string>() ?? someArray[await DoMoreAsync(() => {})])) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 20 to 23 (456) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 24 to 25 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.operator.arithmetic.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 26 to 29 (new) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.other.new.cs
+ - token from 29 to 30 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 30 to 35 (Array) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, entity.name.type.cs
+ - token from 35 to 36 (<) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 36 to 39 (int) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 40 to 41 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 41 to 42 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 42 to 43 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 43 to 44 (1) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 44 to 45 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+ - token from 45 to 46 (2) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 46 to 47 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.separator.comma.cs
+ - token from 47 to 48 (3) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 48 to 49 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 49 to 50 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.squarebracket.open.cs
+ - token from 50 to 51 (0) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, constant.numeric.decimal.cs
+ - token from 51 to 52 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.squarebracket.close.cs
+ - token from 52 to 53 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 53 to 54 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.operator.arithmetic.cs
+ - token from 54 to 55 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 55 to 60 (await) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.other.await.cs
+ - token from 60 to 61 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 61 to 74 (GetValueAsync) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 74 to 75 (<) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.begin.cs
+ - token from 75 to 81 (string) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.type.cs
+ - token from 81 to 82 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.definition.typeparameters.end.cs
+ - token from 82 to 83 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 83 to 84 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 84 to 85 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 85 to 87 (??) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.operator.null-coalescing.cs
+ - token from 87 to 88 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 88 to 97 (someArray) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.object.property.cs
+ - token from 97 to 98 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.squarebracket.open.cs
+ - token from 98 to 103 (await) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.other.await.cs
+ - token from 103 to 104 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 104 to 115 (DoMoreAsync) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, entity.name.function.cs
+ - token from 115 to 116 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 116 to 117 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.open.cs
+ - token from 117 to 118 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 118 to 119 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 119 to 121 (=>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.operator.arrow.cs
+ - token from 121 to 122 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml
+ - token from 122 to 123 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.curlybrace.open.cs
+ - token from 123 to 124 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.curlybrace.close.cs
+ - token from 124 to 125 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.parenthesis.close.cs
+ - token from 125 to 126 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.squarebracket.close.cs
+ - token from 126 to 127 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 127 to 128 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 128 to 129 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 129 to 131 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4765,7 +4992,12 @@ exports[`Grammar tests Explicit Expressions In Attributes Single Quotes Single l
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 33 (@(DateTime.Now)) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 20 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 20 to 28 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, punctuation.accessor.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, variable.other.object.property.cs
+ - token from 32 to 33 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.explicit.cshtml, keyword.control.cshtml
  - token from 33 to 34 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 34 to 35 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 35 to 37 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -4955,6 +5187,114 @@ exports[`Grammar tests Explicit expressions Single line simple 1`] = `
 "
 `;
 
+exports[`Grammar tests HTML dynamic (razor) attribute double quotes inside single quotes 1`] = `
+"Line: <button @onclick='myFunction("test")'>Test</button>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 7 (button) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, entity.name.tag.html
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html
+ - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
+ - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
+ - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
+ - token from 18 to 36 (myFunction("test")) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 36 to 37 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
+ - token from 37 to 38 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
+ - token from 38 to 42 (Test) with scopes text.aspnetcorerazor
+ - token from 42 to 44 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
+ - token from 44 to 50 (button) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, entity.name.tag.html
+ - token from 50 to 51 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests HTML dynamic (razor) attribute razor inside attribute 1`] = `
+"Line: <div id="@("")"> </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html
+ - token from 5 to 7 (id) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, entity.other.attribute-name.html
+ - token from 7 to 8 (=) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, punctuation.separator.key-value.html
+ - token from 8 to 9 (") with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 9 to 10 (@) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml.transition
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 11 to 12 (") with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 12 to 13 (") with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, string.quoted.double.html, meta.expression.explicit.cshtml, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 13 to 14 ()) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, string.quoted.double.html, meta.expression.explicit.cshtml, keyword.control.cshtml
+ - token from 14 to 15 (") with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.id.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 15 to 16 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor
+ - token from 17 to 19 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 19 to 22 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 22 to 23 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests HTML dynamic (razor) attribute single quotes in side double quotes 1`] = `
+"Line: <button @onclick="myFunction('test')">Test</button>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 7 (button) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, entity.name.tag.html
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html
+ - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
+ - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
+ - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 18 to 36 (myFunction('test')) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 36 to 37 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 37 to 38 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
+ - token from 38 to 42 (Test) with scopes text.aspnetcorerazor
+ - token from 42 to 44 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
+ - token from 44 to 50 (button) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, entity.name.tag.html
+ - token from 50 to 51 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests HTML dynamic (razor) attribute using @viewData 1`] = `
+"Line: <a asp-page="@ViewData["Page"]">Test</a>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 2 (a) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, entity.name.tag.html
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html
+ - token from 3 to 11 (asp-page) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, entity.other.attribute-name.html
+ - token from 11 to 12 (=) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, punctuation.separator.key-value.html
+ - token from 12 to 13 (") with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 13 to 14 (@) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 14 to 22 (ViewData) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 22 to 23 ([) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 23 to 24 (") with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 24 to 28 (Page) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, string.quoted.double.cs
+ - token from 28 to 29 (") with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 29 to 30 (]) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 30 to 31 (") with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, meta.attribute.unrecognized.asp-page.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 31 to 32 (>) with scopes text.aspnetcorerazor, meta.tag.inline.a.start.html, punctuation.definition.tag.end.html
+ - token from 32 to 36 (Test) with scopes text.aspnetcorerazor
+ - token from 36 to 38 (</) with scopes text.aspnetcorerazor, meta.tag.inline.a.end.html, punctuation.definition.tag.begin.html
+ - token from 38 to 39 (a) with scopes text.aspnetcorerazor, meta.tag.inline.a.end.html, entity.name.tag.html
+ - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.inline.a.end.html, punctuation.definition.tag.end.html
+"
+`;
+
+exports[`Grammar tests HTML dynamic (razor) attribute using data string array 1`] = `
+"Line: <p data-string-array="['test', '@Localizer["test"]']">Test</p>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 2 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, entity.name.tag.html
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html
+ - token from 3 to 20 (data-string-array) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, entity.other.attribute-name.html
+ - token from 20 to 21 (=) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, punctuation.separator.key-value.html
+ - token from 21 to 22 (") with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, punctuation.definition.string.begin.html
+ - token from 22 to 32 (['test', ') with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html
+ - token from 32 to 33 (@) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 33 to 42 (Localizer) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 42 to 43 ([) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 43 to 44 (") with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, string.quoted.double.cs, punctuation.definition.string.begin.cs
+ - token from 44 to 48 (test) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, string.quoted.double.cs
+ - token from 48 to 49 (") with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, string.quoted.double.cs, punctuation.definition.string.end.cs
+ - token from 49 to 50 (]) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 50 to 52 (']) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html
+ - token from 52 to 53 (") with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, meta.attribute.data-x.data-string-array.html, string.quoted.double.html, punctuation.definition.string.end.html
+ - token from 53 to 54 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.start.html, punctuation.definition.tag.end.html
+ - token from 54 to 58 (Test) with scopes text.aspnetcorerazor
+ - token from 58 to 60 (</) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.begin.html
+ - token from 60 to 61 (p) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, entity.name.tag.html
+ - token from 61 to 62 (>) with scopes text.aspnetcorerazor, meta.tag.structure.p.end.html, punctuation.definition.tag.end.html
+"
+`;
+
 exports[`Grammar tests Implicit Expressions Awaited method invocation 1`] = `
 "Line: @await AsyncMethod()
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
@@ -5048,7 +5388,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Awaited 
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 38 (@await AsyncMethod()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 25 (await ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, keyword.other.await.cs
+ - token from 25 to 36 (AsyncMethod) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 36 to 37 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 37 to 38 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 38 to 39 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5065,7 +5409,9 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Awaited 
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 38 (@await AsyncProperty) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 25 (await ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, keyword.other.await.cs
+ - token from 25 to 38 (AsyncProperty) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 38 to 39 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5082,7 +5428,8 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Class im
  - token from 5 to 10 (class) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, entity.other.attribute-name.html
  - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, punctuation.separator.key-value.html
  - token from 11 to 12 (") with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 12 to 28 (@NavMenuCssClass) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 13 to 28 (NavMenuCssClass) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 28 to 29 (") with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
  - token from 30 to 32 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
@@ -5099,7 +5446,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Close cu
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (}@DateTime.Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 19 to 20 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 20 to 28 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 32 to 33 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5116,7 +5467,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Close cu
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (@DateTime.Now}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 31 to 32 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
  - token from 32 to 33 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5133,7 +5488,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Close pa
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (@DateTime.Now)) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
  - token from 32 to 33 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5150,7 +5509,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Close pa
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (@DateTime.Now]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 31 to 32 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
  - token from 32 to 33 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5167,7 +5530,12 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Combined
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 38 (<p>@DateTime.Now</p>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 21 (<p>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 21 to 22 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 22 to 30 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 30 to 31 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 31 to 34 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 34 to 38 (</p>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
  - token from 38 to 39 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5201,7 +5569,7 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Empty 1`
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
  - token from 19 to 20 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 21 to 23 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5218,37 +5586,103 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Multi li
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 42 (@DateTime!.Now()[1234 +) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 29 (!.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 32 to 33 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 34 to 35 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 35 to 39 (1234) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 40 to 41 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
 
 Line: 5678](
- - token from 0 to 7 (5678]() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 4 (5678) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 4 to 5 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 5 to 6 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
 
 Line: abc()!.Current,
- - token from 0 to 16 (abc()!.Current,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 3 (abc) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 3 to 4 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 5 to 6 (!) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.logical.cs
+ - token from 6 to 7 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 7 to 14 (Current) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.object.property.cs
+ - token from 14 to 16 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
 
 Line: 1 + 2 + getValue())?.ToString[123](
- - token from 0 to 36 (1 + 2 + getValue())?.ToString[123]() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 1 (1) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 1 to 2 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 2 to 3 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 5 (2) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 6 to 7 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 16 (getValue) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 17 to 18 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 19 to 21 (?.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 21 to 29 (ToString) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 29 to 30 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 30 to 33 (123) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 33 to 34 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
 
 Line: () =>
- - token from 0 to 6 (() =>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 1 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 3 to 5 (=>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
 
 Line: {
- - token from 0 to 2 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.curlybrace.open.cs
 
 Line:     var x = 123;
- - token from 0 to 17 (    var x = 123;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 12 to 15 (123) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 15 to 16 (;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
 Line:     var y = true;
- - token from 0 to 18 (    var y = true;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 9 (y) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 12 to 16 (true) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.language.boolean.true.cs
+ - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
 Line: 
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
 
 Line:     return y ? x : 457;
- - token from 0 to 24 (    return y ? x : 457;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 10 (return) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.control.flow.return.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 11 to 12 (y) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 13 to 14 (?) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.conditional.question-mark.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 15 to 16 (x) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.conditional.colon.cs
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 19 to 22 (457) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
 Line: })"></button>
- - token from 0 to 2 (})) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.curlybrace.close.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 2 to 3 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 3 to 4 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5282,7 +5716,10 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Onclick 
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 34 (@ToggleNavMenu()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 32 (ToggleNavMenu) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 32 to 33 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 34 to 35 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 35 to 36 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 36 to 38 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5299,7 +5736,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Open cur
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (@DateTime.Now{) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
  - token from 32 to 33 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5316,7 +5757,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Parenthe
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 32 ()@DateTime.Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 19 to 20 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 20 to 28 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 32 to 33 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5333,7 +5778,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Punctuat
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (.@DateTime.Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 19 to 20 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 20 to 28 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 32 to 33 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5350,7 +5799,52 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Single l
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 109 (@DateTime!.Now()[1234 + 5678](abc()!.Current, 1 + 2 + getValue())?.ToString[123](() => 456)) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 29 (!.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 32 to 33 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 34 to 35 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 35 to 39 (1234) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 40 to 41 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
+ - token from 41 to 42 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 42 to 46 (5678) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 46 to 47 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 47 to 48 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 48 to 51 (abc) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 51 to 52 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 52 to 53 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 53 to 54 (!) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.logical.cs
+ - token from 54 to 55 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 55 to 62 (Current) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.object.property.cs
+ - token from 62 to 64 (, ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 64 to 65 (1) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 65 to 66 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 66 to 67 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 67 to 68 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 68 to 69 (2) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 69 to 70 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 70 to 71 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 71 to 72 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 72 to 80 (getValue) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 80 to 81 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 81 to 82 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 82 to 83 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 83 to 85 (?.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 85 to 93 (ToString) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 93 to 94 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 94 to 97 (123) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 97 to 98 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 98 to 99 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 99 to 100 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 100 to 101 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 101 to 102 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 102 to 104 (=>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
+ - token from 104 to 105 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 105 to 108 (456) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 108 to 109 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 109 to 110 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 110 to 111 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 111 to 113 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5367,7 +5861,10 @@ exports[`Grammar tests Implicit Expressions In Attributes Double Quotes Single l
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.begin.html
- - token from 18 to 31 (@DateTime.Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 31 to 32 (") with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.double.html, punctuation.definition.string.end.html
  - token from 32 to 33 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 33 to 35 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5384,7 +5881,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Awaited 
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 38 (@await AsyncMethod()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 25 (await ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, keyword.other.await.cs
+ - token from 25 to 36 (AsyncMethod) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 36 to 37 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 37 to 38 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 38 to 39 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5401,7 +5902,9 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Awaited 
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 38 (@await AsyncProperty) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 25 (await ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, keyword.other.await.cs
+ - token from 25 to 38 (AsyncProperty) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 38 to 39 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5418,7 +5921,8 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Class im
  - token from 5 to 10 (class) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, entity.other.attribute-name.html
  - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, punctuation.separator.key-value.html
  - token from 11 to 12 (') with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 12 to 28 (@NavMenuCssClass) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html
+ - token from 12 to 13 (@) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 13 to 28 (NavMenuCssClass) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 28 to 29 (') with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, meta.attribute.class.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 29 to 30 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
  - token from 30 to 32 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
@@ -5435,7 +5939,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Close cu
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (}@DateTime.Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 19 to 20 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 20 to 28 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 32 to 33 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5452,7 +5960,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Close cu
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (@DateTime.Now}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 31 to 32 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
  - token from 32 to 33 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5469,7 +5981,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Close pa
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (@DateTime.Now)) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
  - token from 32 to 33 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5486,7 +6002,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Close pa
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (@DateTime.Now]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 31 to 32 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
  - token from 32 to 33 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5503,7 +6023,12 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Combined
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 38 (<p>@DateTime.Now</p>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 21 (<p>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 21 to 22 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 22 to 30 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 30 to 31 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 31 to 34 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 34 to 38 (</p>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
  - token from 38 to 39 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 39 to 40 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 40 to 42 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5537,7 +6062,7 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Empty 1`
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
  - token from 19 to 20 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 20 to 21 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 21 to 23 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5554,37 +6079,103 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Multi li
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 42 (@DateTime!.Now()[1234 +) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 29 (!.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 32 to 33 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 34 to 35 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 35 to 39 (1234) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 40 to 41 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
 
 Line: 5678](
- - token from 0 to 7 (5678]() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 4 (5678) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 4 to 5 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 5 to 6 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
 
 Line: abc()!.Current,
- - token from 0 to 16 (abc()!.Current,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 3 (abc) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 3 to 4 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 4 to 5 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 5 to 6 (!) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.logical.cs
+ - token from 6 to 7 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 7 to 14 (Current) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.object.property.cs
+ - token from 14 to 16 (,) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
 
 Line: 1 + 2 + getValue())?.ToString[123](
- - token from 0 to 36 (1 + 2 + getValue())?.ToString[123]() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 1 (1) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 1 to 2 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 2 to 3 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 5 (2) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 6 to 7 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 16 (getValue) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 16 to 17 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 17 to 18 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 19 to 21 (?.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 21 to 29 (ToString) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 29 to 30 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 30 to 33 (123) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 33 to 34 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 34 to 35 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
 
 Line: () =>
- - token from 0 to 6 (() =>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 1 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 2 to 3 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 3 to 5 (=>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
 
 Line: {
- - token from 0 to 2 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.curlybrace.open.cs
 
 Line:     var x = 123;
- - token from 0 to 17 (    var x = 123;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 9 (x) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 12 to 15 (123) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 15 to 16 (;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
 Line:     var y = true;
- - token from 0 to 18 (    var y = true;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 7 (var) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.other.var.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 8 to 9 (y) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.variable.local.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 10 to 11 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.assignment.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 12 to 16 (true) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.language.boolean.true.cs
+ - token from 16 to 17 (;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
 Line: 
- - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 1 () with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
 
 Line:     return y ? x : 457;
- - token from 0 to 24 (    return y ? x : 457;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 4 to 10 (return) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.control.flow.return.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 11 to 12 (y) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 13 to 14 (?) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.conditional.question-mark.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 15 to 16 (x) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.readwrite.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 17 to 18 (:) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.conditional.colon.cs
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 19 to 22 (457) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 22 to 23 (;) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.terminator.statement.cs
 
 Line: })'></button>
- - token from 0 to 2 (})) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.curlybrace.close.cs
+ - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 2 to 3 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 3 to 4 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 4 to 6 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5618,7 +6209,10 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Onclick 
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 34 (@ToggleNavMenu()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 32 (ToggleNavMenu) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 32 to 33 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 34 to 35 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 35 to 36 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 36 to 38 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5635,7 +6229,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Open cur
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (@DateTime.Now{) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
  - token from 32 to 33 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5652,7 +6250,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Parenthe
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 32 ()@DateTime.Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 19 to 20 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 20 to 28 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 32 to 33 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5669,7 +6271,11 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Punctuat
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 32 (.@DateTime.Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 19 to 20 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 20 to 28 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 28 to 29 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 32 to 33 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 33 to 34 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 34 to 36 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5686,7 +6292,52 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Single l
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 109 (@DateTime!.Now()[1234 + 5678](abc()!.Current, 1 + 2 + getValue())?.ToString[123](() => 456)) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 29 (!.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 29 to 32 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, entity.name.function.cs
+ - token from 32 to 33 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 33 to 34 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 34 to 35 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 35 to 39 (1234) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 39 to 40 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 40 to 41 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, keyword.operator.arithmetic.cs
+ - token from 41 to 42 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets
+ - token from 42 to 46 (5678) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 46 to 47 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 47 to 48 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 48 to 51 (abc) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 51 to 52 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 52 to 53 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 53 to 54 (!) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.logical.cs
+ - token from 54 to 55 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.accessor.cs
+ - token from 55 to 62 (Current) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, variable.other.object.property.cs
+ - token from 62 to 64 (, ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 64 to 65 (1) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 65 to 66 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 66 to 67 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 67 to 68 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 68 to 69 (2) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 69 to 70 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 70 to 71 (+) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arithmetic.cs
+ - token from 71 to 72 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 72 to 80 (getValue) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, entity.name.function.cs
+ - token from 80 to 81 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 81 to 82 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 82 to 83 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 83 to 85 (?.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 85 to 93 (ToString) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
+ - token from 93 to 94 ([) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.open.cs
+ - token from 94 to 97 (123) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, constant.numeric.decimal.cs
+ - token from 97 to 98 (]) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.brackets, punctuation.squarebracket.close.cs
+ - token from 98 to 99 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 99 to 100 (() with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.open.cs
+ - token from 100 to 101 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
+ - token from 101 to 102 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 102 to 104 (=>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, keyword.operator.arrow.cs
+ - token from 104 to 105 ( ) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis
+ - token from 105 to 108 (456) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, constant.numeric.decimal.cs
+ - token from 108 to 109 ()) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, razor.test.balanced.parenthesis, punctuation.parenthesis.close.cs
  - token from 109 to 110 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 110 to 111 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 111 to 113 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html
@@ -5703,7 +6354,10 @@ exports[`Grammar tests Implicit Expressions In Attributes Single Quotes Single l
  - token from 8 to 16 (@onclick) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, entity.other.attribute-name.html
  - token from 16 to 17 (=) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, punctuation.separator.key-value.html
  - token from 17 to 18 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.begin.html
- - token from 18 to 31 (@DateTime.Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html
+ - token from 18 to 19 (@) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
+ - token from 19 to 27 (DateTime) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
+ - token from 27 to 28 (.) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs
+ - token from 28 to 31 (Now) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, meta.expression.implicit.cshtml, source.cs, variable.other.object.property.cs
  - token from 31 to 32 (') with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, meta.attribute.unrecognized.@onclick.html, string.quoted.single.html, punctuation.definition.string.end.html
  - token from 32 to 33 (>) with scopes text.aspnetcorerazor, meta.tag.structure.button.start.html, punctuation.definition.tag.end.html
  - token from 33 to 35 (</) with scopes text.aspnetcorerazor, meta.tag.structure.button.end.html, punctuation.definition.tag.begin.html

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/grammarTests.test.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/grammarTests.test.ts
@@ -42,6 +42,7 @@ import { RunWhileStatementSuite } from './whileStatement';
 import { RunRendermodeDirectiveSuite } from './rendermodeDirective';
 import { RunPreservewhitespaceDirectiveSuite } from './preservewhitespaceDirective';
 import { RunTypeparamDirectiveSuite } from './typeparamDirective';
+import { RunHTMLDynamicAttributeSuite } from './htmlDynamicAttribute';
 
 // We bring together all test suites and wrap them in one here. The reason behind this is that
 // modules get reloaded per test suite and the vscode-textmate library doesn't support the way
@@ -93,4 +94,5 @@ describe('Grammar tests', () => {
     // Html stuff
     RunScriptBlockSuite();
     RunStyleBlockSuite();
+    RunHTMLDynamicAttributeSuite();
 });

--- a/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/htmlDynamicAttribute.ts
+++ b/test/razorTests/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/htmlDynamicAttribute.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, it } from '@jest/globals';
+import { assertMatchesSnapshot } from './infrastructure/testUtilities';
+
+// See GrammarTests.test.ts for details on exporting this test suite instead of running in place.
+
+export function RunHTMLDynamicAttributeSuite() {
+    describe('HTML dynamic (razor) attribute', () => {
+        it('razor inside attribute', async () => {
+            await assertMatchesSnapshot('<div id="@("")"> </div>');
+        });
+
+        it('single quotes in side double quotes', async () => {
+            await assertMatchesSnapshot('<button @onclick="myFunction(\'test\')">Test</button>');
+        });
+
+        it('double quotes inside single quotes', async () => {
+            await assertMatchesSnapshot('<button @onclick=\'myFunction("test")\'>Test</button>');
+        });
+
+        it('using data string array', async () => {
+            await assertMatchesSnapshot('<p data-string-array="[\'test\', \'@Localizer["test"]\']">Test</p>');
+        });
+
+        it('using @viewData', async () => {
+            await assertMatchesSnapshot('<a asp-page="@ViewData["Page"]">Test</a>');
+        });
+    });
+}


### PR DESCRIPTION
- added textmate grammar to both razor and html (test) files so that we can correctly label razor components that are within html tags. We will need to update the html grammar used in razor as well
- updated tests to reflect the desire behavior, note that we changed some of the classification from existing tests as they were not correctly labeling razor grammar in html tags either

### Before 
<img width="542" alt="before_vs_code" src="https://github.com/dotnet/vscode-csharp/assets/17770319/8edefc62-d270-4ce0-a7cd-a99b1d3a480c">



### After
<img width="442" alt="after_vs_code" src="https://github.com/dotnet/vscode-csharp/assets/17770319/9e0ae841-9f59-419a-b659-74bba28bcfe4">


