### PR TITLE
Add optional command to onAutoInsert response

### DIFF
--- a/src/lsptoolshost/onAutoInsert.ts
+++ b/src/lsptoolshost/onAutoInsert.ts
@@ -88,7 +88,11 @@ async function applyAutoInsertEdit(
 
         const applied = vscode.workspace.applyEdit(edit);
         if (!applied) {
-            throw new Error('Tried to insert a comment but an error occurred.');
+            throw new Error('Tried to apply an edit but an error occurred.');
+        }
+
+        if (response.command !== undefined) {
+            vscode.commands.executeCommand(response.command.command, response.command.arguments);
         }
     }
 }

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -59,6 +59,11 @@ export interface OnAutoInsertParams {
 export interface OnAutoInsertResponseItem {
     _vs_textEditFormat: lsp.InsertTextFormat;
     _vs_textEdit: lsp.TextEdit;
+
+    /**
+     * An optional command that is executed *after* inserting.
+     */
+    command?: Command;
 }
 
 /**


### PR DESCRIPTION
The response item for this message is currently defined like this:
```TypeScript
export interface OnAutoInsertResponseItem {
    _vs_textEditFormat: lsp.InsertTextFormat;
    _vs_textEdit: lsp.TextEdit;
}
```
The purpose of this message is similar to inserting completions. However, it's lacking one thing that completion items provide - the ability to provide an optional command to retrigger completions for example.
 
This is especially useful for markup languages like XAML where you would use = as a trigger character to automatically insert the attribute quotes and place the caret in between, so that you would end up with this ="|". The expectation though is to offer completions for attribute values at this point, but there is currently no way to automatically trigger completions. This is made even more painful in VS Code where the default editor setting does not even trigger completions within strings.
 
I propose the following addition to the response item in the same way it exists for CompletionItem, which should be ignorable by any client that does not support the optional parameter:
```TypeScript
export interface OnAutoInsertResponseItem {
    _vs_textEditFormat: lsp.InsertTextFormat;
    _vs_textEdit: lsp.TextEdit;
    /**
     * An optional command that is executed *after* inserting.
     */
    command?: Command;
}
```
I have a local prototype for the vscode-csharp extension that works just beautifully like this.