### PR TITLE
No longer activate on the presence of .sln or .slnf files

### DIFF
--- a/package.json
+++ b/package.json
@@ -957,7 +957,7 @@
     "onCommand:o.showOutput",
     "onCommand:omnisharp.registerLanguageMiddleware",
     "workspaceContains:project.json",
-    "workspaceContains:**/*.{csproj,sln,slnf,csx,cake}"
+    "workspaceContains:**/*.{csproj,csx,cake}"
   ],
   "contributes": {
     "themes": [


### PR DESCRIPTION
Solution files can be used for languages other than C#. Any solution file that will result in a usable C# workspace must reference .csproj files. We already search for .csproj files as part of the activation event.

Resolves #5794