### PR TITLE
Don't download razor telemetry if disabled by vscode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -131,7 +131,7 @@ export async function activate(
 
     if (!useOmnisharpServer) {
         // Download Razor server telemetry bits if DevKit is installed.
-        if (csharpDevkitExtension) {
+        if (csharpDevkitExtension && vscode.env.isTelemetryEnabled) {
             const razorTelemetryDownloader = new RazorTelemetryDownloader(
                 networkSettingsProvider,
                 eventStream,

--- a/src/razor/src/extension.ts
+++ b/src/razor/src/extension.ts
@@ -98,13 +98,15 @@ export async function activate(
         if (csharpDevkitExtension) {
             await setupDevKitEnvironment(dotnetInfo.env, csharpDevkitExtension, logger);
 
-            const telemetryExtensionPath = path.join(
-                util.getExtensionPath(),
-                '.razortelemetry',
-                'Microsoft.VisualStudio.DevKit.Razor.dll'
-            );
-            if (await util.fileExists(telemetryExtensionPath)) {
-                telemetryExtensionDllPath = telemetryExtensionPath;
+            if (vscode.env.isTelemetryEnabled) {
+                const telemetryExtensionPath = path.join(
+                    util.getExtensionPath(),
+                    '.razortelemetry',
+                    'Microsoft.VisualStudio.DevKit.Razor.dll'
+                );
+                if (await util.fileExists(telemetryExtensionPath)) {
+                    telemetryExtensionDllPath = telemetryExtensionPath;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10028

We were correctly adhering to telemetry levels in the server/client for reporting, but the extension was downloading updated bits even if they were not needed. This skips the download entirely. 

This change also depends on the Roslyn server hookup for watching if telemetry changes and alerting the user. There's no point in adding one for Razor as well because that would just double alert the user and probably be annoying.