### PR TITLE
Update CONTRIBUTING.md to mention required upstream permissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,8 @@ To package this extension, we need to create VSIX Packages. The VSIX packages ca
 
 ## Updating the `Roslyn` Language Server Version
 
+In order to pull in new packages from upstreams into the msft_consumption feed we use for restoring, you will need to be a member of the 'CSharp VS Code Extension contributors' group in the [Azure Devops instance](https://dev.azure.com/azure-public/vside/_settings/teams).  
+
 To update the version of the roslyn server used by the extension do the following:
 1.  Find the the Roslyn signed build you want from [here](https://dnceng.visualstudio.com/internal/_build?definitionId=327&_a=summary).  Typically the latest successful build of main is fine.
 2.  In the official build stage, look for the `Publish Assets` step.  In there you will see it publishing the `Microsoft.CodeAnalysis.LanguageServer.neutral` package with some version, e.g. `4.6.0-3.23158.4`.  Take note of that version number.


### PR DESCRIPTION
We use an azdo feed (msft_consumption) with upstreams to restore roslyn LSP server bits.  In order to pull in new package versions into the feed, a set of additional permissions are required.  Adding a note about it in the docs