### PR TITLE
Add temporary option to allow suppression of recoverable LSP error toasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1666,6 +1666,11 @@
             "default": null,
             "description": "%configuration.dotnet.server.crashDumpPath%"
           },
+          "dotnet.server.suppressLspErrorToasts": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.dotnet.server.suppressLspErrorToasts%"
+          },
           "dotnet.projects.binaryLogPath": {
             "scope": "machine-overridable",
             "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -31,6 +31,7 @@
   "configuration.dotnet.server.trace": "Sets the logging level for the language server",
   "configuration.dotnet.server.extensionPaths": "Override for path to language server --extension arguments",
   "configuration.dotnet.server.crashDumpPath": "Sets a folder path where crash dumps are written to if the language server crashes.  Must be writeable by the user.",
+  "configuration.dotnet.server.suppressLspErrorToasts": "Suppresses error toasts from showing up if the server encounters a recoverable error.",
   "configuration.dotnet.projects.enableAutomaticRestore": "Enables automatic NuGet restore if the extension detects assets are missing.",
   "configuration.dotnet.preferCSharpExtension": "Forces projects to load with the C# extension only.  This can be useful when using legacy project types that are not supported by C# Dev Kit. (Requires window reload)",
   "configuration.dotnet.implementType.insertionBehavior": "The insertion location of properties, events, and methods When implement interface or abstract class.",

--- a/src/lsptoolshost/roslynLanguageClient.ts
+++ b/src/lsptoolshost/roslynLanguageClient.ts
@@ -21,8 +21,6 @@ import { languageServerOptions } from '../shared/options';
 export class RoslynLanguageClient extends LanguageClient {
     private readonly _disposables: CompositeDisposable;
 
-    //private readonly Map<
-
     constructor(
         id: string,
         name: string,

--- a/src/lsptoolshost/roslynLanguageClient.ts
+++ b/src/lsptoolshost/roslynLanguageClient.ts
@@ -3,9 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
+import {
+    CancellationToken,
+    LanguageClient,
+    LanguageClientOptions,
+    MessageSignature,
+    ServerOptions,
+} from 'vscode-languageclient/node';
 import CompositeDisposable from '../compositeDisposable';
 import { IDisposable } from '../disposable';
+import { languageServerOptions } from '../shared/options';
 
 /**
  * Implementation of the base LanguageClient type that allows for additional items to be disposed of
@@ -13,6 +20,8 @@ import { IDisposable } from '../disposable';
  */
 export class RoslynLanguageClient extends LanguageClient {
     private readonly _disposables: CompositeDisposable;
+
+    //private readonly Map<
 
     constructor(
         id: string,
@@ -29,6 +38,27 @@ export class RoslynLanguageClient extends LanguageClient {
     override async dispose(timeout?: number | undefined): Promise<void> {
         this._disposables.dispose();
         return super.dispose(timeout);
+    }
+
+    override handleFailedRequest<T>(
+        type: MessageSignature,
+        token: CancellationToken | undefined,
+        error: any,
+        defaultValue: T,
+        showNotification?: boolean
+    ) {
+        // Temporarily allow LSP error toasts to be suppressed if configured.
+        // There are a few architectural issues preventing us from solving some of the underlying problems,
+        // for example Razor cohosting to fix text mismatch issues and unification of serialization libraries
+        // to fix URI identification issues.  Once resolved, we should remove this option.
+        //
+        // See also https://github.com/microsoft/vscode-dotnettools/issues/722
+        // https://github.com/dotnet/vscode-csharp/issues/6973
+        // https://github.com/microsoft/vscode-languageserver-node/issues/1449
+        if (languageServerOptions.suppressLspErrorToasts) {
+            return super.handleFailedRequest(type, token, error, defaultValue, false);
+        }
+        return super.handleFailedRequest(type, token, error, defaultValue, showNotification);
     }
 
     /**

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -77,6 +77,7 @@ export interface LanguageServerOptions {
     readonly crashDumpPath: string | undefined;
     readonly analyzerDiagnosticScope: string;
     readonly compilerDiagnosticScope: string;
+    readonly suppressLspErrorToasts: boolean;
 }
 
 export interface RazorOptions {
@@ -396,6 +397,9 @@ class LanguageServerOptionsImpl implements LanguageServerOptions {
     }
     public get compilerDiagnosticScope() {
         return readOption<string>('dotnet.backgroundAnalysis.compilerDiagnosticsScope', 'openFiles');
+    }
+    public get suppressLspErrorToasts() {
+        return readOption<boolean>('dotnet.server.suppressLspErrorToasts', false);
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6977

Add temporary option to suppress LSP recoverable errors until we can resolve the architectural issues causing the failed requests.
Related to https://github.com/dotnet/vscode-csharp/issues/6973, https://github.com/microsoft/vscode-dotnettools/issues/722 and more

Implemented as suggested in https://github.com/microsoft/vscode-languageserver-node/issues/1449#issuecomment-2074436676

Additional notes
1.  VSCode's notification settings intentionally do not allow errors to be suppressed.
2.  Ideally we could look at VSCode's do not disturb settings or notification settings for the extension instead of our own option, but the API for that does not exist.