### PR TITLE
Bump xamlTools to latest signed release (17.11.34917.22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "razor": "7.0.0-preview.24178.4",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "razorTelemetry": "7.0.0-preview.24178.4",
-    "xamlTools": "17.11.34907.35"
+    "xamlTools": "17.11.34917.22"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
I verified the following:
- onTypeFormat no longer causes exceptions when typing in XAML
- Format Document/Selection works as expected
- onAutoInsert no longer requires a space after the tag name to work
- completion item documentation tooltips are back