### PR TITLE
Add missing env to `GetUnixArchitecture`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -58,8 +58,8 @@ export function safeLength<T>(arr: T[] | undefined) {
 
 export async function execChildProcess(
     command: string,
-    workingDirectory: string = getExtensionPath(),
-    env: NodeJS.ProcessEnv = {}
+    workingDirectory: string,
+    env: NodeJS.ProcessEnv
 ): Promise<string> {
     return new Promise<string>((resolve, reject) => {
         cp.exec(command, { cwd: workingDirectory, maxBuffer: 500 * 1024, env: env }, (error, stdout, stderr) => {

--- a/src/shared/platform.ts
+++ b/src/shared/platform.ts
@@ -173,7 +173,7 @@ export class PlatformInformation {
     }
 
     private static async GetUnixArchitecture(): Promise<string> {
-        const architecture = (await util.execChildProcess('uname -m', __dirname)).trim();
+        const architecture = (await util.execChildProcess('uname -m', __dirname, process.env)).trim();
         if (architecture === 'aarch64') {
             return 'arm64';
         }

--- a/src/shared/platform.ts
+++ b/src/shared/platform.ts
@@ -183,7 +183,7 @@ export class PlatformInformation {
     // Emulates https://github.com/dotnet/install-scripts/blob/3c6cc06/src/dotnet-install.sh#L187-L189.
     private static async GetIsMusl(): Promise<boolean> {
         try {
-            const output = await util.execChildProcess('ldd --version', __dirname);
+            const output = await util.execChildProcess('ldd --version', __dirname, process.env);
             return output.includes('musl');
         } catch (err) {
             return err instanceof Error ? err.message.includes('musl') : false;

--- a/test/vscodeLauncher.ts
+++ b/test/vscodeLauncher.ts
@@ -69,7 +69,7 @@ async function main() {
             }
 
             const dotnetPath = path.join(process.env.DOTNET_ROOT, 'dotnet');
-            await execChildProcess(`${dotnetPath} build ${sln}`, workspacePath);
+            await execChildProcess(`${dotnetPath} build ${sln}`, workspacePath, process.env);
         }
 
         // Download VS Code, unzip it and run the integration test


### PR DESCRIPTION
Add missing environment when acquiring the UNIX architecture. Not providing the environment, breaks systems that don't have `uname` in the `$PATH` by default, such as NixOS. Demonstrated by this issue: #5575.

Personally, I would also recommend removing the default value for the `env` parameter, forcing the programmer to think about their intention, instead of just leaving it out.
https://github.com/dotnet/vscode-csharp/blob/76829925bc570eec384a63687af5648ce19c9532/src/common.ts#L62

If that is something you are interested in, let me know, and I will adjust the function, and necessary call sites. There don't appear to be too many.

Fixes #5575.