### PR TITLE
Bump xamlTools to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "razor": "7.0.0-preview.24266.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "razorTelemetry": "7.0.0-preview.24178.4",
-    "xamlTools": "17.11.34924.19" 
+    "xamlTools": "17.11.34924.19"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "razor": "7.0.0-preview.24266.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "razorTelemetry": "7.0.0-preview.24178.4",
-    "xamlTools": "17.11.34917.22"
+    "xamlTools": "17.11.34924.19"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "razor": "7.0.0-preview.24266.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "razorTelemetry": "7.0.0-preview.24178.4",
-    "xamlTools": "17.11.34924.19"
+    "xamlTools": "17.11.34924.19" 
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
Bump to the latest xamlTools assemblies, from
https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl/NuGet/Microsoft.VisualStudio.DesignToolsBase/overview/17.11.34924.19

This is needed for next week's prerelease update, for MAUI IntelliSense and Hot Reload support.