### PR TITLE
Use XML settings for XAML language-configuration.json

### DIFF
--- a/src/xaml/language-configuration.json
+++ b/src/xaml/language-configuration.json
@@ -1,46 +1,59 @@
 {
-    "comments": {
-      "blockComment": [ "<!--", "-->" ]
+	"comments": {
+		"blockComment": [ "<!--", "-->" ]
+	},
+  "brackets": [
+    [ "<!--", "-->" ],
+    [ "<", ">" ],
+    [ "{", "}" ],
+    [ "(", ")" ]
+  ],
+  "autoClosingPairs": [
+    {
+      "open": "{",
+      "close": "}"
     },
-    "brackets": [
-      [ "<", ">" ],
-      [ "{", "}" ]
-    ],
-    "autoClosingPairs": [
-      {
-        "open": "{",
-        "close": "}"
-      },
-      {
-        "open": "'",
-        "close": "'",
-        "notIn": [ "string", "comment" ]
-      },
-      {
-        "open": "\"",
-        "close": "\"",
-        "notIn": [ "string", "comment" ]
-      },
-      {
-        "open": "<!--",
-        "close": "-->",
-        "notIn": [ "string" ]
-      },
-      {
-        "open": "<![CDATA[",
-        "close": "]]>",
-        "notIn": [ "string" ]
-      },
-      {
-        "open": "<?",
-        "close": "?>",
-        "notIn": [ "string" ]
-      }
-    ],
-    "autoCloseBefore": "}/>\"' \r\n\t",
-    "surroundingPairs": [
-      [ "{", "}" ],
-      [ "'", "'" ],
-      [ "\"", "\"" ]
-    ]
-  }
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "\"",
+      "close": "\"",
+      "notIn": [ "string" ]
+    },
+    {
+      "open": "'",
+      "close": "'",
+      "notIn": [ "string" ]
+    },
+    {
+      "open": "<!--",
+      "close": "-->",
+      "notIn": [ "comment", "string" ]
+    }
+  ],
+	"surroundingPairs": [
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "<", "close": ">" }
+	],
+	"colorizedBracketPairs": [
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*<!--\\s*#region\\b.*-->",
+			"end": "^\\s*<!--\\s*#endregion\\b.*-->"
+		}
+	},
+	"wordPattern": {
+		"pattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\$\\%\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)"
+	}
+}


### PR DESCRIPTION
Replacing XAML language-configuration.json with [XML ones](https://github.com/microsoft/vscode/blob/main/extensions/xml/xml.language-configuration.json) fixes "extra quotes" issues, e.g. typing `"` at `Text=|"` ends up `Text=""|"`  