### PR TITLE
Bump xamlTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # Latest
-* Update xamlTools to 17.11.34924.19 (PR: [#7192](https://github.com/dotnet/vscode-csharp/pull/7192))
+* Update xamlTools to 17.11.34931.156 (PR: [#7195](https://github.com/dotnet/vscode-csharp/pull/7195))
+  * Support XAML Hot Reload on iOS physical devices
+  * Encrypt Hot Reload connection
+  * Fix issue where WinUI Hot Reload stops working on successive debug sessions
+  * Fix issue where Hot Reload sometimes doesn't work on first debug launch
 * Include process environment variables when running shell commands (PR: [#7152](https://github.com/dotnet/vscode-csharp/pull/7152))
 
 # 2.32.14

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "razor": "7.0.0-preview.24266.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "razorTelemetry": "7.0.0-preview.24178.4",
-    "xamlTools": "17.11.34924.19"
+    "xamlTools": "17.11.34931.108"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "razor": "7.0.0-preview.24266.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "razorTelemetry": "7.0.0-preview.24178.4",
-    "xamlTools": "17.11.34931.108"
+    "xamlTools": "17.11.34931.156"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
Bump xamlTools to 17.11.34931.156

This is from the VS build late Friday, 5/31. It includes all available XAML Hot Reload
fixes, including iPhone support, for the prerelease update planned for 6/4.
Also updated CHANGELOG.
