### PR TITLE
Move projectPath check into UnavaliableLaunchServiceError

### DIFF
--- a/src/shared/dotnetConfigurationProvider.ts
+++ b/src/shared/dotnetConfigurationProvider.ts
@@ -110,12 +110,13 @@ export class DotnetConfigurationResolver implements vscode.DebugConfigurationPro
                     throw new UnavaliableLaunchServiceError();
                 }
             } catch (e) {
-                if (!projectPath) {
-                    throw new LaunchServiceError(
-                        vscode.l10n.t("'{0}' was not provided in the debug configuration.", 'projectPath')
-                    );
-                }
                 if (e instanceof UnavaliableLaunchServiceError) {
+                    if (!projectPath) {
+                        throw new LaunchServiceError(
+                            vscode.l10n.t("'{0}' was not provided in the debug configuration.", 'projectPath')
+                        );
+                    }
+
                     return await this.resolveDebugConfigurationWithWorkspaceDebugInformationProvider(
                         folder,
                         projectPath


### PR DESCRIPTION
This PR moves the projectPath check into the scenario where UnavaliableLaunchServiceError as this is the fallback if C# Dev Kit is not installed. This requires the `dotnet` configuration to have a projectPath.