### PR TITLE
Adding changes to support use monovsdbg to debug wasm apps.

### DIFF
--- a/omnisharptest/omnisharpUnitTests/assets.test.ts
+++ b/omnisharptest/omnisharpUnitTests/assets.test.ts
@@ -505,7 +505,8 @@ function createMSBuildWorkspaceInformation(
     isExe = true,
     isWebProject = false,
     isBlazorWebAssemblyStandalone = false,
-    isBlazorWebAssemblyHosted = false
+    isBlazorWebAssemblyHosted = false,
+    isWebAssemblyProject = false
 ): ProjectDebugInformation[] {
     return [
         {
@@ -527,6 +528,7 @@ function createMSBuildWorkspaceInformation(
             isWebProject: isWebProject,
             isBlazorWebAssemblyHosted: isBlazorWebAssemblyHosted,
             isBlazorWebAssemblyStandalone: isBlazorWebAssemblyStandalone,
+            isWebAssemblyProject: isWebAssemblyProject,
         },
     ];
 }

--- a/package.json
+++ b/package.json
@@ -1412,6 +1412,11 @@
             "description": "%generateOptionsSchema.expressionEvaluationOptions.showRawValues.description%",
             "default": false
           },
+          "csharp.mono.debug.useVSDbg": {
+            "type": "boolean",
+            "description": "%generateOptionsSchema.useVSDbg.description%",
+            "default": false
+          },
           "dotnet.unitTestDebuggingOptions": {
             "type": "object",
             "description": "%configuration.dotnet.unitTestDebuggingOptions%",
@@ -4817,6 +4822,11 @@
               "env": {
                 "type": "object",
                 "description": "Environment variables passed to dotnet. Only valid for hosted apps."
+              },
+              "useVSDbg": {
+                "type": "boolean",
+                "default": false,
+                "description": "%generateOptionsSchema.useVSDbg.description%"
               },
               "dotNetConfig": {
                 "description": "Options passed to the underlying .NET debugger. For more info, see https://github.com/dotnet/vscode-csharp/blob/main/debugger.md.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -435,5 +435,6 @@
     "comment": [
       "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     ]
-  }
+  },
+  "generateOptionsSchema.useVSDbg.description": "Enable new .NET 8+ Mono Debugger (preview)"
 }

--- a/src/coreclrDebug/activate.ts
+++ b/src/coreclrDebug/activate.ts
@@ -92,12 +92,6 @@ export async function activate(
             new BaseVsDbgConfigurationProvider(platformInformation, csharpOutputChannel)
         )
     );
-    context.subscriptions.push(
-        vscode.debug.registerDebugConfigurationProvider(
-            'monovsdbg',
-            new BaseVsDbgConfigurationProvider(platformInformation, csharpOutputChannel)
-        )
-    );
     disposables.add(vscode.debug.registerDebugAdapterDescriptorFactory('coreclr', factory));
     disposables.add(vscode.debug.registerDebugAdapterDescriptorFactory('clr', factory));
     disposables.add(vscode.debug.registerDebugAdapterDescriptorFactory('monovsdbg', factory));

--- a/src/csharpExtensionExports.ts
+++ b/src/csharpExtensionExports.ts
@@ -26,6 +26,7 @@ export interface CSharpExtensionExports {
     determineBrowserType: () => Promise<string | undefined>;
     experimental: CSharpExtensionExperimentalExports;
     getComponentFolder: (componentName: string) => string;
+    tryToUseVSDbgForMono: (urlStr: string) => Promise<[string, number, number]>;
 }
 
 export interface CSharpExtensionExperimentalExports {

--- a/src/lsptoolshost/debugger.ts
+++ b/src/lsptoolshost/debugger.ts
@@ -52,6 +52,11 @@ export function registerDebugger(
     context.subscriptions.push(
         vscode.debug.registerDebugConfigurationProvider('coreclr', dotnetWorkspaceConfigurationProvider)
     );
+
+    context.subscriptions.push(
+        vscode.debug.registerDebugConfigurationProvider('monovsdbg', dotnetWorkspaceConfigurationProvider)
+    );
+
     context.subscriptions.push(
         vscode.commands.registerCommand('dotnet.generateAssets', async (selectedIndex) =>
             generateAssets(workspaceInformationProvider, selectedIndex)

--- a/src/lsptoolshost/roslynWorkspaceDebugConfigurationProvider.ts
+++ b/src/lsptoolshost/roslynWorkspaceDebugConfigurationProvider.ts
@@ -9,7 +9,12 @@ import {
     IWorkspaceDebugInformationProvider,
     ProjectDebugInformation,
 } from '../shared/IWorkspaceDebugInformationProvider';
-import { isBlazorWebAssemblyHosted, isBlazorWebAssemblyProject, isWebProject } from '../shared/utils';
+import {
+    isBlazorWebAssemblyHosted,
+    isBlazorWebAssemblyProject,
+    isWebProject,
+    isWebAssemblyProject,
+} from '../shared/utils';
 import { RoslynLanguageServer } from './roslynLanguageServer';
 import {
     ProjectDebugConfiguration,
@@ -50,6 +55,7 @@ export class RoslynWorkspaceDebugInformationProvider implements IWorkspaceDebugI
         // LSP serializes and deserializes URIs as (URI formatted) strings not actual types.  So convert to the actual type here.
         const projects: ProjectDebugInformation[] | undefined = await mapAsync(response, async (p) => {
             const webProject = isWebProject(p.projectPath);
+            const webAssemblyProject = isWebAssemblyProject(p.projectPath);
             const webAssemblyBlazor = await isBlazorWebAssemblyProject(p.projectPath);
             return {
                 projectPath: p.projectPath,
@@ -58,6 +64,7 @@ export class RoslynWorkspaceDebugInformationProvider implements IWorkspaceDebugI
                 targetsDotnetCore: p.targetsDotnetCore,
                 isExe: p.isExe,
                 isWebProject: webProject,
+                isWebAssemblyProject: webAssemblyProject,
                 isBlazorWebAssemblyHosted: isBlazorWebAssemblyHosted(
                     p.isExe,
                     webProject,

--- a/src/main.ts
+++ b/src/main.ts
@@ -371,6 +371,7 @@ export async function activate(
             getComponentFolder: (componentName) => {
                 return getComponentFolder(componentName, languageServerOptions);
             },
+            tryToUseVSDbgForMono: BlazorDebugConfigurationProvider.tryToUseVSDbgForMono,
         };
     } else {
         return {

--- a/src/omnisharp/protocol.ts
+++ b/src/omnisharp/protocol.ts
@@ -343,6 +343,7 @@ export interface MSBuildProject {
     IsWebProject: boolean;
     IsBlazorWebAssemblyStandalone: boolean;
     IsBlazorWebAssemblyHosted: boolean;
+    IsWebAssemblyProject: boolean;
 }
 
 export interface TargetFramework {

--- a/src/omnisharp/utils.ts
+++ b/src/omnisharp/utils.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { CancellationToken } from 'vscode-languageserver-protocol';
 import {
     isWebProject,
+    isWebAssemblyProject,
     isBlazorWebAssemblyProject,
     isBlazorWebAssemblyHosted,
     findNetCoreTargetFramework,
@@ -171,7 +172,7 @@ export async function requestWorkspaceInformation(server: OmniSharpServer) {
     if (response.MsBuild && response.MsBuild.Projects) {
         for (const project of response.MsBuild.Projects) {
             project.IsWebProject = isWebProject(project.Path);
-
+            project.IsWebAssemblyProject = isWebAssemblyProject(project.Path);
             const isProjectBlazorWebAssemblyProject = await isBlazorWebAssemblyProject(project.Path);
 
             const targetsDotnetCore =

--- a/src/omnisharpWorkspaceDebugInformationProvider.ts
+++ b/src/omnisharpWorkspaceDebugInformationProvider.ts
@@ -36,6 +36,7 @@ export class OmnisharpWorkspaceDebugInformationProvider implements IWorkspaceDeb
                 isWebProject: p.IsWebProject,
                 isBlazorWebAssemblyHosted: p.IsBlazorWebAssemblyHosted,
                 isBlazorWebAssemblyStandalone: p.IsBlazorWebAssemblyStandalone,
+                isWebAssemblyProject: p.IsWebAssemblyProject,
                 solutionPath: null,
             };
         });

--- a/src/razor/src/blazorDebug/constants.ts
+++ b/src/razor/src/blazorDebug/constants.ts
@@ -5,3 +5,5 @@
 
 export const SERVER_APP_NAME = '.NET Application Server';
 export const JS_DEBUG_NAME = 'Debug Blazor Web Assembly in Browser';
+export const ONLY_JS_DEBUG_NAME = 'JavaScript Debugger';
+export const MANAGED_DEBUG_NAME = 'Wasm Managed Debugger';

--- a/src/shared/IWorkspaceDebugInformationProvider.ts
+++ b/src/shared/IWorkspaceDebugInformationProvider.ts
@@ -56,4 +56,9 @@ export interface ProjectDebugInformation {
      * If this is a standalone blazor web assembly project.
      */
     isBlazorWebAssemblyStandalone: boolean;
+
+    /**
+     * If this is a web assembly project.
+     */
+    isWebAssemblyProject: boolean;
 }

--- a/src/shared/assets.ts
+++ b/src/shared/assets.ts
@@ -344,6 +344,18 @@ export class AssetGenerator {
 
         return result;
     }
+
+    public getAssetsPathAndProgram(): [string, string] {
+        let assetsPath = ``;
+        this.executableProjects.forEach((project) => {
+            if (project.isWebAssemblyProject) {
+                assetsPath += path.join(path.dirname(project.outputPath), path.sep);
+                assetsPath += ';';
+            }
+        });
+        assetsPath = assetsPath.slice(0, -1);
+        return [assetsPath, this.executableProjects[0].outputPath];
+    }
 }
 
 export enum ProgramLaunchType {

--- a/src/shared/configurationProvider.ts
+++ b/src/shared/configurationProvider.ts
@@ -18,6 +18,7 @@ import {
 import { PlatformInformation } from './platform';
 import { getCSharpDevKit } from '../utils/getCSharpDevKit';
 import { commonOptions } from './options';
+import { DotnetWorkspaceConfigurationProvider } from './workspaceConfigurationProvider';
 
 /**
  * Class used for debug configurations that will be sent to the debugger registered by {@link DebugAdapterExecutableFactory}
@@ -148,7 +149,18 @@ export class BaseVsDbgConfigurationProvider implements vscode.DebugConfiguration
                 this.checkForDevCerts(commonOptions.dotnetPath);
             }
         }
-
+        if (debugConfiguration.type === 'monovsdbg' && this instanceof DotnetWorkspaceConfigurationProvider) {
+            const configProvider = this as DotnetWorkspaceConfigurationProvider;
+            if (
+                folder &&
+                debugConfiguration.monoDebuggerOptions.platform === 'browser' &&
+                debugConfiguration.monoDebuggerOptions.assetsPath == null
+            ) {
+                const [assetsPath, programName] = await configProvider.getAssetsPathAndProgram(folder);
+                debugConfiguration.monoDebuggerOptions.assetsPath = assetsPath;
+                debugConfiguration.program = programName;
+            }
+        }
         return debugConfiguration;
     }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -43,6 +43,14 @@ export function isWebProject(projectPath: string): boolean {
     return projectFileText.toLowerCase().indexOf('sdk="microsoft.net.sdk.web"') >= 0;
 }
 
+export function isWebAssemblyProject(projectPath: string): boolean {
+    const projectFileText = fs.readFileSync(projectPath, 'utf8');
+
+    // Assume that this is an MSBuild project. In that case, look for the 'Sdk="Microsoft.NET.Sdk.BlazorWebAssembly"' attribute.
+    // TODO: Have OmniSharp provide the list of SDKs used by a project and check that list instead.
+    return projectFileText.toLowerCase().indexOf('sdk="microsoft.net.sdk.blazorwebassembly"') >= 0;
+}
+
 export async function isBlazorWebAssemblyProject(projectPath: string): Promise<boolean> {
     const projectDirectory = path.dirname(projectPath);
     const launchSettingsPath = path.join(projectDirectory, 'Properties', 'launchSettings.json');

--- a/src/shared/workspaceConfigurationProvider.ts
+++ b/src/shared/workspaceConfigurationProvider.ts
@@ -96,4 +96,13 @@ export class DotnetWorkspaceConfigurationProvider extends BaseVsDbgConfiguration
             return [createFallbackLaunchConfiguration(), parse(createAttachConfiguration())];
         }
     }
+
+    async getAssetsPathAndProgram(folder: vscode.WorkspaceFolder): Promise<[string, string]> {
+        const info = await this.workspaceDebugInfoProvider.getWorkspaceDebugInformation(folder.uri);
+        if (!info) {
+            return ['', ''];
+        }
+        const generator = new AssetGenerator(info, folder);
+        return generator.getAssetsPathAndProgram();
+    }
 }


### PR DESCRIPTION
Adding changes to support debug wasm apps using monovsdbg.

It's a draft becauls I'm still waiting for VSWebAssemblyBridge publication to consume it.