### PR TITLE
Bump XAML for latest fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "razor": "9.0.0-preview.24311.4",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "razorTelemetry": "7.0.0-preview.24178.4",
-    "xamlTools": "17.11.34931.156"
+    "xamlTools": "17.11.35013.26"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
Here are all the changes in XAML affecting VS Code:
	
- Merged PR 557373: Bug 2087318: VSCode: AutoInsert is broken in latest C# extension
- Updating Roslyn from 20240607.3 (e867be9) to 20240610.10 (32b7b6b)
- Merged PR 556430: Support GUID properties when parsing XAML
- Merged PR 554970: Improve support for x:DataType in MAUI