### PR TITLE
Fix NRE in completion.

### DIFF
--- a/src/razor/src/completion/completionHandler.ts
+++ b/src/razor/src/completion/completionHandler.ts
@@ -201,6 +201,9 @@ export class CompletionHandler {
             provideCompletionsCommand,
             params
         );
+        if (!csharpCompletions) {
+            return CompletionHandler.emptyCompletionList;
+        }
         CompletionHandler.adjustCSharpCompletionList(csharpCompletions, triggerCharacter);
         return csharpCompletions;
     }


### PR DESCRIPTION
Roslyn return nulls as completion command result rather than empty list when there are no completion items available.

Fixes internal issue https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2100167