### PR TITLE
Fix default value for Razor setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1731,7 +1731,7 @@
           "razor.completion.commitElementsWithSpace": {
             "type": "boolean",
             "scope": "window",
-            "default": "false",
+            "default": false,
             "description": "Specifies whether to commit tag helper and component elements with a space."
           }
         }


### PR DESCRIPTION
This should be boolean, but its a string. Not a problem for VS Code, or Newtonsoft.Json, but in converting Razor to System.Text.Json it is either more fussy, or I don't know the right API to use, but either way this fixes the issue and is better.