### PR TITLE
Use rzls.dll on macOS

### DIFF
--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -59,7 +59,7 @@ function findLanguageServerExecutable(withinDir: string) {
         pathWithExtension = `${fileName}.dll`;
     }
 
-    let fullPath = path.join(withinDir, pathWithExtension);
+    const fullPath = path.join(withinDir, pathWithExtension);
 
     if (!fs.existsSync(fullPath)) {
         throw new Error(


### PR DESCRIPTION
https://github.com/dotnet/vscode-csharp/commit/c2666b4af8f1f56bb7eccc773cc923f17a1ef1e6 but for Razor

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2111269

My hypothesis is that now that we use nupkgs, our publishing happens on windows so can't be signed in a mac compatible way.