### PR TITLE
Add Project Context status item

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -161,6 +161,8 @@
   "Fix All: ": "Fix All: ",
   "C# Workspace Status": "C# Workspace Status",
   "Open solution": "Open solution",
+  "C# Project Context Status": "C# Project Context Status",
+  "Project Context": "Project Context",
   "Pick a fix all scope": "Pick a fix all scope",
   "Fix All Code Action": "Fix All Code Action",
   "pipeArgs must be a string or a string array type": "pipeArgs must be a string or a string array type",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -162,7 +162,7 @@
   "C# Workspace Status": "C# Workspace Status",
   "Open solution": "Open solution",
   "C# Project Context Status": "C# Project Context Status",
-  "Project Context": "Project Context",
+  "Active File Context": "Active File Context",
   "Pick a fix all scope": "Pick a fix all scope",
   "Fix All Code Action": "Fix All Code Action",
   "pipeArgs must be a string or a string array type": "pipeArgs must be a string or a string array type",

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -65,6 +65,7 @@ import { BuildDiagnosticsService } from './buildDiagnosticsService';
 import { getComponentPaths } from './builtInComponents';
 import { OnAutoInsertFeature } from './onAutoInsertFeature';
 import { registerLanguageStatusItems } from './languageStatusBar';
+import { ProjectContextService } from './services/projectContextService';
 
 let _channel: vscode.OutputChannel;
 let _traceChannel: vscode.OutputChannel;
@@ -106,6 +107,7 @@ export class RoslynLanguageServer {
     public readonly _onAutoInsertFeature: OnAutoInsertFeature;
 
     public _buildDiagnosticService: BuildDiagnosticsService;
+    public _projectContextService: ProjectContextService;
 
     constructor(
         private _languageClient: RoslynLanguageClient,
@@ -124,6 +126,8 @@ export class RoslynLanguageServer {
         const diagnosticsReportedByBuild = vscode.languages.createDiagnosticCollection('csharp-build');
         this._buildDiagnosticService = new BuildDiagnosticsService(diagnosticsReportedByBuild);
         this.registerDocumentOpenForDiagnostics();
+
+        this._projectContextService = new ProjectContextService(this);
 
         // Register Razor dynamic file info handling
         this.registerDynamicFileInfo();

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -127,7 +127,7 @@ export class RoslynLanguageServer {
         this._buildDiagnosticService = new BuildDiagnosticsService(diagnosticsReportedByBuild);
         this.registerDocumentOpenForDiagnostics();
 
-        this._projectContextService = new ProjectContextService(this);
+        this._projectContextService = new ProjectContextService(this, this._languageServerEvents);
 
         // Register Razor dynamic file info handling
         this.registerDynamicFileInfo();

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -8,6 +8,21 @@ import * as lsp from 'vscode-languageserver-protocol';
 import { CodeAction, TextDocumentRegistrationOptions } from 'vscode-languageserver-protocol';
 import { ProjectConfigurationMessage } from '../shared/projectConfiguration';
 
+export interface VSProjectContextList {
+    _vs_projectContexts: VSProjectContext[];
+    _vs_defaultIndex: number;
+}
+
+export interface VSProjectContext {
+    _vs_label: string;
+    _vs_id: string;
+    _vs_kind: string;
+}
+
+export interface VSTextDocumentIdentifier extends lsp.TextDocumentIdentifier {
+    _vs_projectContext: VSProjectContext | undefined;
+}
+
 export interface WorkspaceDebugConfigurationParams {
     /**
      * Workspace path containing the solution/projects to get debug information for.
@@ -86,6 +101,13 @@ export interface RegisterSolutionSnapshotResponseItem {
      * Represents a solution snapshot.
      */
     id: lsp.integer;
+}
+
+export interface VSGetProjectContextParams {
+    /**
+     * The document the project context is being requested for.
+     */
+    _vs_textDocument: lsp.TextDocumentIdentifier;
 }
 
 export interface RunTestsParams extends lsp.WorkDoneProgressParams, lsp.PartialResultParams {
@@ -208,6 +230,12 @@ export namespace RegisterSolutionSnapshotRequest {
     export const method = 'workspace/_vs_registerSolutionSnapshot';
     export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
     export const type = new lsp.RequestType0<RegisterSolutionSnapshotResponseItem, void>(method);
+}
+
+export namespace VSGetProjectContextsRequest {
+    export const method = 'textDocument/_vs_getProjectContexts';
+    export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
+    export const type = new lsp.RequestType<VSGetProjectContextParams, VSProjectContextList, void>(method);
 }
 
 export namespace ProjectInitializationCompleteNotification {

--- a/src/lsptoolshost/services/projectContextService.ts
+++ b/src/lsptoolshost/services/projectContextService.ts
@@ -30,7 +30,7 @@ export class ProjectContextService {
             }
         });
 
-        vscode.window.onDidChangeActiveTextEditor(this.refresh);
+        vscode.window.onDidChangeActiveTextEditor(async (_) => this.refresh());
     }
 
     public get onActiveFileContextChanged(): vscode.Event<ProjectContextChangeEvent> {

--- a/src/lsptoolshost/services/projectContextService.ts
+++ b/src/lsptoolshost/services/projectContextService.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { RoslynLanguageServer } from '../roslynLanguageServer';
+import { VSGetProjectContextsRequest, VSProjectContext, VSProjectContextList } from '../roslynProtocol';
+import { TextDocumentIdentifier } from 'vscode-languageserver-protocol';
+import { UriConverter } from '../uriConverter';
+
+export class ProjectContextService {
+    /** Track the project contexts for a particular document uri. */
+    private _projectContexts: { [uri: string]: Promise<VSProjectContextList> | VSProjectContextList } = {};
+
+    constructor(private languageServer: RoslynLanguageServer) {}
+
+    clear() {
+        this._projectContexts = {};
+    }
+
+    async getCurrentProjectContext(uri: string | vscode.Uri): Promise<VSProjectContext | undefined> {
+        const projectContexts = await this.getProjectContexts(uri);
+        return projectContexts?._vs_projectContexts[projectContexts._vs_defaultIndex];
+    }
+
+    async getProjectContexts(uri: string | vscode.Uri): Promise<VSProjectContextList | undefined> {
+        const uriString = uri instanceof vscode.Uri ? UriConverter.serialize(uri) : uri;
+
+        if (!(uriString in this._projectContexts)) {
+            const source = new vscode.CancellationTokenSource();
+            this._projectContexts[uriString] = this.languageServer
+                .sendRequest(
+                    VSGetProjectContextsRequest.type,
+                    { _vs_textDocument: TextDocumentIdentifier.create(uriString) },
+                    source.token
+                )
+                .then((contextList) => (this._projectContexts[uriString] = contextList));
+        }
+
+        return this._projectContexts[uriString];
+    }
+}

--- a/src/lsptoolshost/services/projectContextService.ts
+++ b/src/lsptoolshost/services/projectContextService.ts
@@ -8,36 +8,71 @@ import { RoslynLanguageServer } from '../roslynLanguageServer';
 import { VSGetProjectContextsRequest, VSProjectContext, VSProjectContextList } from '../roslynProtocol';
 import { TextDocumentIdentifier } from 'vscode-languageserver-protocol';
 import { UriConverter } from '../uriConverter';
+import { LanguageServerEvents } from '../languageServerEvents';
+import { ServerState } from '../serverStateChange';
+
+export interface ProjectContextChangeEvent {
+    uri: vscode.Uri;
+    context: VSProjectContext;
+}
 
 export class ProjectContextService {
-    /** Track the project contexts for a particular document uri. */
-    private _projectContexts: { [uri: string]: Promise<VSProjectContextList> | VSProjectContextList } = {};
+    private readonly _contextChangeEmitter = new vscode.EventEmitter<ProjectContextChangeEvent>();
+    private _source = new vscode.CancellationTokenSource();
 
-    constructor(private languageServer: RoslynLanguageServer) {}
+    constructor(private _languageServer: RoslynLanguageServer, _languageServerEvents: LanguageServerEvents) {
+        _languageServerEvents.onServerStateChange((e) => {
+            // When the project initialization is complete, open files
+            // could move from the miscellaneous workspace context into
+            // an open project.
+            if (e.state === ServerState.ProjectInitializationComplete) {
+                this.refresh();
+            }
+        });
 
-    clear() {
-        this._projectContexts = {};
+        vscode.window.onDidChangeActiveTextEditor(this.refresh);
     }
 
-    async getCurrentProjectContext(uri: string | vscode.Uri): Promise<VSProjectContext | undefined> {
-        const projectContexts = await this.getProjectContexts(uri);
-        return projectContexts?._vs_projectContexts[projectContexts._vs_defaultIndex];
+    public get onActiveFileContextChanged(): vscode.Event<ProjectContextChangeEvent> {
+        return this._contextChangeEmitter.event;
     }
 
-    async getProjectContexts(uri: string | vscode.Uri): Promise<VSProjectContextList | undefined> {
-        const uriString = uri instanceof vscode.Uri ? UriConverter.serialize(uri) : uri;
-
-        if (!(uriString in this._projectContexts)) {
-            const source = new vscode.CancellationTokenSource();
-            this._projectContexts[uriString] = this.languageServer
-                .sendRequest(
-                    VSGetProjectContextsRequest.type,
-                    { _vs_textDocument: TextDocumentIdentifier.create(uriString) },
-                    source.token
-                )
-                .then((contextList) => (this._projectContexts[uriString] = contextList));
+    public async refresh() {
+        const textEditor = vscode.window.activeTextEditor;
+        if (textEditor?.document?.languageId !== 'csharp') {
+            return;
         }
 
-        return this._projectContexts[uriString];
+        const uri = textEditor.document.uri;
+
+        // If we have an open request, cancel it.
+        this._source.cancel();
+        this._source = new vscode.CancellationTokenSource();
+
+        try {
+            const contextList = await this.getProjectContexts(uri, this._source.token);
+            if (!contextList) {
+                return;
+            }
+
+            const context = contextList._vs_projectContexts[contextList._vs_defaultIndex];
+            this._contextChangeEmitter.fire({ uri, context });
+        } catch {
+            // This request was cancelled
+        }
+    }
+
+    private async getProjectContexts(
+        uri: vscode.Uri,
+        token: vscode.CancellationToken
+    ): Promise<VSProjectContextList | undefined> {
+        const uriString = UriConverter.serialize(uri);
+        const textDocument = TextDocumentIdentifier.create(uriString);
+
+        return this._languageServer.sendRequest(
+            VSGetProjectContextsRequest.type,
+            { _vs_textDocument: textDocument },
+            token
+        );
     }
 }

--- a/test/integrationTests/documentDiagnostics.integration.test.ts
+++ b/test/integrationTests/documentDiagnostics.integration.test.ts
@@ -85,8 +85,6 @@ describe(`[${testAssetWorkspace.description}] Test diagnostics`, function () {
                 analyzer: AnalysisSetting.OpenFiles,
             });
 
-            await integrationHelpers.restartLanguageServer();
-
             await waitForExpectedFileDiagnostics((diagnostics) => {
                 expect(diagnostics).toHaveLength(4);
 


### PR DESCRIPTION
Adds a status item to display the project context of the active C# file.

For files in the open workspace:
![image](https://github.com/user-attachments/assets/046511a3-02ce-446d-80c4-c52b5be4358d)

For files in the misc workspace:
![image](https://github.com/user-attachments/assets/fef403da-de68-48d7-8c0f-ec4ea29b0b1f)

When running with DevKit:
<img width="370" alt="image" src="https://github.com/user-attachments/assets/20e403e3-6aaf-4564-af12-360378cad7f1">
