### PR TITLE
Enable Project Context status item for Razor files

### DIFF
--- a/src/lsptoolshost/languageStatusBar.ts
+++ b/src/lsptoolshost/languageStatusBar.ts
@@ -50,12 +50,13 @@ class WorkspaceStatus {
 
 class ProjectContextStatus {
     static createStatusItem(context: vscode.ExtensionContext, languageServer: RoslynLanguageServer) {
+        const documentSelector = combineDocumentSelectors(
+            languageServerOptions.documentSelector,
+            RazorLanguage.documentSelector
+        );
         const projectContextService = languageServer._projectContextService;
 
-        const item = vscode.languages.createLanguageStatusItem(
-            'csharp.projectContextStatus',
-            languageServerOptions.documentSelector
-        );
+        const item = vscode.languages.createLanguageStatusItem('csharp.projectContextStatus', documentSelector);
         item.name = vscode.l10n.t('C# Project Context Status');
         item.detail = vscode.l10n.t('Active File Context');
         context.subscriptions.push(item);

--- a/src/razor/src/document/razorDocumentSynchronizer.ts
+++ b/src/razor/src/document/razorDocumentSynchronizer.ts
@@ -119,6 +119,8 @@ export class RazorDocumentSynchronizer {
     }
 
     private removeSynchronization(context: SynchronizationContext) {
+        context.dispose();
+
         const documentKey = getUriPath(context.projectedDocument.uri);
         const synchronizations = this.synchronizations[documentKey];
         clearTimeout(context.timeoutId);
@@ -165,6 +167,11 @@ export class RazorDocumentSynchronizer {
             cancel: (reason) => {
                 for (const reject of rejectionsForCancel) {
                     reject(reason);
+                }
+            },
+            dispose: () => {
+                while (rejectionsForCancel.length > 0) {
+                    rejectionsForCancel.pop();
                 }
             },
             projectedDocumentSynchronized,
@@ -271,4 +278,5 @@ interface SynchronizationContext {
     readonly projectedTextDocumentSynchronized: () => void;
     readonly onProjectedTextDocumentSynchronized: Promise<void>;
     readonly cancel: (reason: string) => void;
+    readonly dispose: () => void;
 }

--- a/test/razorIntegrationTests/formatting.integration.test.ts
+++ b/test/razorIntegrationTests/formatting.integration.test.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { describe, beforeAll, afterAll, test, expect } from '@jest/globals';
+import { describe, beforeAll, afterAll, test, expect, beforeEach } from '@jest/globals';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
 import * as integrationHelpers from '../integrationTests/integrationHelpers';
 
@@ -20,8 +20,11 @@ describe(`Razor Formatting ${testAssetWorkspace.description}`, function () {
         const htmlConfig = vscode.workspace.getConfiguration('html');
         await htmlConfig.update('format.enable', true);
 
-        await integrationHelpers.openFileInWorkspaceAsync(path.join('Pages', 'BadlyFormatted.razor'));
         await integrationHelpers.activateCSharpExtension();
+    });
+
+    beforeEach(async function () {
+        await integrationHelpers.openFileInWorkspaceAsync(path.join('Pages', 'BadlyFormatted.razor'));
     });
 
     afterAll(async () => {

--- a/test/razorIntegrationTests/hover.integration.test.ts
+++ b/test/razorIntegrationTests/hover.integration.test.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { describe, beforeAll, afterAll, test, expect } from '@jest/globals';
+import { describe, beforeAll, afterAll, test, expect, beforeEach } from '@jest/globals';
 import testAssetWorkspace from './testAssets/testAssetWorkspace';
 import * as integrationHelpers from '../integrationTests/integrationHelpers';
 
@@ -15,8 +15,11 @@ describe(`Razor Hover ${testAssetWorkspace.description}`, function () {
             return;
         }
 
-        await integrationHelpers.openFileInWorkspaceAsync(path.join('Pages', 'Index.cshtml'));
         await integrationHelpers.activateCSharpExtension();
+    });
+
+    beforeEach(async function () {
+        await integrationHelpers.openFileInWorkspaceAsync(path.join('Pages', 'Index.cshtml'));
     });
 
     afterAll(async () => {


### PR DESCRIPTION
Requests the virtual C# file path and uses that to get project context information.

![image](https://github.com/user-attachments/assets/8386bcbb-4c95-4c64-8ffe-cdc713d3fb04)

When used with DevKit:
<img width="370" alt="image" src="https://github.com/user-attachments/assets/9a2a9aac-d47e-4a2b-856d-f84716b23719">
