### PR TITLE
Set eol for generated tmlLanguage json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@ l10n/bundle.l10n.json text eol=lf
 
 # This is a Unix shell script, so it always use the 'lf' line ends
 scripts/remoteProcessPickerScript text eol=lf
+
+# This is a generated file. Set it to 'lf' so we don't get git errors when it is generated on Windows.
+src/razor/syntaxes/aspnetcorerazor.tmLanguage.json eol=lf


### PR DESCRIPTION
When compiling on Windows, the aspnetcorerazor tmLanguage file get crlf line endings which make git unhappy. This change tells git to always use lf line endings when committing this file.