### PR TITLE
Add github action for scheduled branch merge

### DIFF
--- a/.config/branch-merge.json
+++ b/.config/branch-merge.json
@@ -1,0 +1,14 @@
+{
+    "merge-flow-configurations": {
+        // Merge any prerelease only changes to main.
+        "prerelease": {
+            "MergeToBranch": "main",
+            "ExtraSwitches": "-QuietComments"
+        },
+        // Merge any release only changes to main.
+        "release": {
+            "MergeToBranch": "release",
+            "ExtraSwitches": "-QuietComments"
+        }
+    }
+}

--- a/.github/workflows/branch-merge.yml
+++ b/.github/workflows/branch-merge.yml
@@ -1,0 +1,17 @@
+# Merges any changes from release/prerelease to main (e.g. servicing changes)
+
+name: Flow release/prerelease changes to main
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */3 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-script:
+    uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
+    with:
+      configuration_file_path: '.config/branch-merge.json'


### PR DESCRIPTION
An idea.

Once this is confirmed working we can remove the roslyn-tools configuration for this repo.