### PR TITLE
Fix gotodef integration test failures throwing cancellation

### DIFF
--- a/src/lsptoolshost/services/projectContextService.ts
+++ b/src/lsptoolshost/services/projectContextService.ts
@@ -104,7 +104,7 @@ export class ProjectContextService {
         const textDocument = TextDocumentIdentifier.create(uriString);
 
         try {
-            return this._languageServer.sendRequest(
+            return await this._languageServer.sendRequest(
                 VSGetProjectContextsRequest.type,
                 { _vs_textDocument: textDocument },
                 token


### PR DESCRIPTION
Promise was being returned immediately, so the catch block never got hit when the request was cancelled.