### PR TITLE
Switch to on branch push for merges

### DIFF
--- a/.config/branch-merge.json
+++ b/.config/branch-merge.json
@@ -7,7 +7,7 @@
         },
         // Merge any release only changes to main.
         "release": {
-            "MergeToBranch": "release",
+            "MergeToBranch": "main",
             "ExtraSwitches": "-QuietComments"
         }
     }

--- a/.github/workflows/branch-merge.yml
+++ b/.github/workflows/branch-merge.yml
@@ -2,9 +2,10 @@
 
 name: Flow release/prerelease changes to main
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 */3 * * *'
+  push:
+   branches:
+     - 'release'
+     - 'prerelease'
 
 permissions:
   contents: write


### PR DESCRIPTION
Scheduled merge doesn't work since it always runs on the default branch (main), whereas the arcade merge tool is expecting to be run on the branch with changes to merge into the other branch,