### PR TITLE
Bump xamlTools package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   * Pool CodeWriter ReadOnlyMemory<char> pages (#10585) (PR: [#10585](https://github.com/dotnet/razor/pull/10585))
   * Improve performance of `DefaultRazorTagHelperContextDiscoveryPhase` (#10602) (PR: [#10602](https://github.com/dotnet/razor/pull/10602))
   * Flesh out `PooledArrayBuilder<T>` a bit (#10606) (PR: [#10606](https://github.com/dotnet/razor/pull/10606))
-* Bump xamltools to 17.12.35124.29 (PR: [#7387](https://github.com/dotnet/vscode-csharp/pull/7387))
+* Bump xamltools to 17.12.35126.17 (PR: [#7392](https://github.com/dotnet/vscode-csharp/pull/7392))
 
 # 2.40.x
 * Add option to disable server gc (PR: [#7155](https://github.com/dotnet/vscode-csharp/pull/7155))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "omniSharp": "1.39.11",
     "razor": "9.0.0-preview.24366.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",
-    "xamlTools": "17.12.35124.29"
+    "xamlTools": "17.12.35126.17"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
Bump xamlTools to `17.12.35126.17`

 - Nothing to add to the changelog for this bump.
