### PR TITLE
Fix completion handler bug that causes language server to crash

### DIFF
--- a/src/razor/src/completion/completionHandler.ts
+++ b/src/razor/src/completion/completionHandler.ts
@@ -156,7 +156,10 @@ export class CompletionHandler {
         // TODO: Snippet support
 
         try {
-            if (delegatedCompletionItemResolveParams.originatingKind != LanguageKind.CSharp) {
+            if (
+                delegatedCompletionItemResolveParams.originatingKind != LanguageKind.CSharp ||
+                delegatedCompletionItemResolveParams.completionItem.data.TextDocument == null
+            ) {
                 return delegatedCompletionItemResolveParams.completionItem;
             } else {
                 const newItem = await vscode.commands.executeCommand<CompletionItem>(
@@ -187,6 +190,7 @@ export class CompletionHandler {
         try {
             if (provisionalTextEdit) {
                 // provisional C# completion
+                console.log('provisional completion');
                 return this.provideCSharpProvisionalCompletions(triggerCharacter, virtualDocument, projectedPosition);
             }
 

--- a/src/razor/src/completion/completionHandler.ts
+++ b/src/razor/src/completion/completionHandler.ts
@@ -190,7 +190,6 @@ export class CompletionHandler {
         try {
             if (provisionalTextEdit) {
                 // provisional C# completion
-                console.log('provisional completion');
                 return this.provideCSharpProvisionalCompletions(triggerCharacter, virtualDocument, projectedPosition);
             }
 


### PR DESCRIPTION
This resolves bug [2171350 LanguageServer crashing after typing '.' in razor file](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2171350/) by filtering out a wrong "roslyn.resolveCompletion" request sent to the Roslyn server. Currently provisional code completion via Roslyn doesn't work and is tracked by https://github.com/dotnet/vscode-csharp/issues/7250.

Currently, after we receive completion items from Roslyn we need to send them back to get more detailed information such as documentation and edit information (through the resolve completion command). Since provisional code completion is not done via Roslyn, we send an empty list back thus crashing the server.
