### PR TITLE
Fix Attach to .NET Process before Roslyn LSP is ready

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -191,6 +191,7 @@
   "Unexpected message received from debugger.": "Unexpected message received from debugger.",
   "[ERROR]: C# Extension failed to install the debugger package.": "[ERROR]: C# Extension failed to install the debugger package.",
   "Could not find a process id to attach.": "Could not find a process id to attach.",
+  "Unable to launch Attach to Process Listing. ": "Unable to launch Attach to Process Listing. ",
   "[ERROR] The debugger cannot be installed. The debugger is not supported on '{0}'": "[ERROR] The debugger cannot be installed. The debugger is not supported on '{0}'",
   "[ERROR] The debugger cannot be installed. The debugger requires macOS 12 (Monterey) or newer.": "[ERROR] The debugger cannot be installed. The debugger requires macOS 12 (Monterey) or newer.",
   "[WARNING]: x86 Windows is not supported by the .NET debugger. Debugging will not be available.": "[WARNING]: x86 Windows is not supported by the .NET debugger. Debugging will not be available.",

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -191,7 +191,7 @@
   "Unexpected message received from debugger.": "Unexpected message received from debugger.",
   "[ERROR]: C# Extension failed to install the debugger package.": "[ERROR]: C# Extension failed to install the debugger package.",
   "Could not find a process id to attach.": "Could not find a process id to attach.",
-  "Unable to launch Attach to Process Listing. ": "Unable to launch Attach to Process Listing. ",
+  "Unable to launch Attach to Process dialog: ": "Unable to launch Attach to Process dialog: ",
   "[ERROR] The debugger cannot be installed. The debugger is not supported on '{0}'": "[ERROR] The debugger cannot be installed. The debugger is not supported on '{0}'",
   "[ERROR] The debugger cannot be installed. The debugger requires macOS 12 (Monterey) or newer.": "[ERROR] The debugger cannot be installed. The debugger requires macOS 12 (Monterey) or newer.",
   "[WARNING]: x86 Windows is not supported by the .NET debugger. Debugging will not be available.": "[WARNING]: x86 Windows is not supported by the .NET debugger. Debugging will not be available.",

--- a/src/coreclrDebug/activate.ts
+++ b/src/coreclrDebug/activate.ts
@@ -20,7 +20,6 @@ import { RemoteAttachPicker } from '../features/processPicker';
 import CompositeDisposable from '../compositeDisposable';
 import { BaseVsDbgConfigurationProvider } from '../shared/configurationProvider';
 import { omnisharpOptions } from '../shared/options';
-import { RoslynLanguageServer } from '../lsptoolshost/roslynLanguageServer';
 
 export async function activate(
     thisExtension: vscode.Extension<any>,
@@ -28,7 +27,7 @@ export async function activate(
     platformInformation: PlatformInformation,
     eventStream: EventStream,
     csharpOutputChannel: vscode.OutputChannel,
-    roslynLanguageServerStartedPromise: Promise<RoslynLanguageServer> | undefined
+    languageServerStartedPromise: Promise<any> | undefined
 ) {
     const disposables = new CompositeDisposable();
 
@@ -69,9 +68,9 @@ export async function activate(
     disposables.add(
         vscode.commands.registerCommand('csharp.attachToProcess', async () => {
             // Ensure dotnetWorkspaceConfigurationProvider is registered
-            if (roslynLanguageServerStartedPromise) {
+            if (languageServerStartedPromise) {
                 try {
-                    await roslynLanguageServerStartedPromise;
+                    await languageServerStartedPromise;
                 } catch (e: any) {
                     if (e as Error) {
                         throw new Error(vscode.l10n.t('Unable to launch Attach to Process dialog: ') + e.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -324,7 +324,7 @@ export async function activate(
             platformInfo,
             eventStream,
             csharpChannel,
-            roslynLanguageServerStartedPromise
+            roslynLanguageServerStartedPromise ?? omnisharpLangServicePromise
         );
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -323,7 +323,8 @@ export async function activate(
             context,
             platformInfo,
             eventStream,
-            csharpChannel
+            csharpChannel,
+            roslynLanguageServerStartedPromise
         );
     }
 


### PR DESCRIPTION
This PR passes the roslynServerStartedProcess to the coreClrDebug activate call as the Roslyn Server registers the 'coreclr' DebugConfigurationProvider that will handle the process listing for the user to select the process ID.

If the configuration provider is not registered but the adapter factory is, it will send it to the debugger without a processName or processId and will fail with that error.

Fixes: https://github.com/microsoft/vscode-dotnettools/issues/1350