### PR TITLE
Include tooltip to Razor provisional completion

### DIFF
--- a/src/razor/src/completion/completionHandler.ts
+++ b/src/razor/src/completion/completionHandler.ts
@@ -307,6 +307,8 @@ export class CompletionHandler {
         return positionIndex;
     }
 
+    // Provide completions using standard vscode executeCompletionItemProvider command
+    // Used in HTML context
     private async provideVscodeCompletions(
         virtualDocumentUri: vscode.Uri,
         projectedPosition: Position,

--- a/src/razor/src/csharp/csharpProjectedDocument.ts
+++ b/src/razor/src/csharp/csharpProjectedDocument.ts
@@ -13,7 +13,9 @@ export class CSharpProjectedDocument implements IProjectedDocument {
 
     private content = '';
     private preProvisionalContent: string | undefined;
+    private preResolveProvisionalContent: string | undefined;
     private provisionalEditAt: number | undefined;
+    private resolveProvisionalEditAt: number | undefined;
     private hostDocumentVersion: number | null = null;
     private projectedDocumentVersion = 0;
 
@@ -80,12 +82,49 @@ export class CSharpProjectedDocument implements IProjectedDocument {
         if (this.provisionalEditAt && this.preProvisionalContent) {
             // Undo provisional edit if one was applied.
             this.setContent(this.preProvisionalContent);
+            this.resolveProvisionalEditAt = this.provisionalEditAt;
             this.provisionalEditAt = undefined;
             this.preProvisionalContent = undefined;
             return true;
         }
 
         return false;
+    }
+
+    public addResolveProvisionalDotAt() {
+        //remove the last resolve provisional dot it it exists
+        this.removeResolveProvisionalDot();
+        if (this.resolveProvisionalEditAt) {
+            const newContent = this.getEditedContent(
+                '.',
+                this.resolveProvisionalEditAt,
+                this.resolveProvisionalEditAt,
+                this.content
+            );
+            this.preResolveProvisionalContent = this.content;
+            this.setContent(newContent);
+            return true;
+        }
+        return false;
+    }
+
+    public removeResolveProvisionalDot(clearEditIndex = false) {
+        if (this.resolveProvisionalEditAt && this.preResolveProvisionalContent) {
+            if (clearEditIndex) {
+                this.resolveProvisionalEditAt = undefined;
+            }
+            // Undo provisional edit if one was applied.
+            this.setContent(this.preResolveProvisionalContent);
+            this.provisionalEditAt = undefined;
+            this.preResolveProvisionalContent = undefined;
+            return true;
+        }
+
+        return false;
+    }
+
+    public getResolveProvisionalEditIndex() {
+        return this.resolveProvisionalEditAt;
     }
 
     private getEditedContent(newText: string, start: number, end: number, content: string) {

--- a/src/razor/src/csharp/csharpProjectedDocument.ts
+++ b/src/razor/src/csharp/csharpProjectedDocument.ts
@@ -91,6 +91,9 @@ export class CSharpProjectedDocument implements IProjectedDocument {
         return false;
     }
 
+    // add resolve provisional dot if a provisional completion request was made
+    // A resolve provisional dot is the same as a provisional dot, but it remembers the
+    // last provisional dot inserted location and is used for the roslyn.resolveCompletion API
     public addResolveProvisionalDotAt() {
         //remove the last resolve provisional dot it it exists
         this.removeResolveProvisionalDot();
@@ -108,11 +111,8 @@ export class CSharpProjectedDocument implements IProjectedDocument {
         return false;
     }
 
-    public removeResolveProvisionalDot(clearEditIndex = false) {
+    public removeResolveProvisionalDot() {
         if (this.resolveProvisionalEditAt && this.preResolveProvisionalContent) {
-            if (clearEditIndex) {
-                this.resolveProvisionalEditAt = undefined;
-            }
             // Undo provisional edit if one was applied.
             this.setContent(this.preResolveProvisionalContent);
             this.provisionalEditAt = undefined;
@@ -125,6 +125,13 @@ export class CSharpProjectedDocument implements IProjectedDocument {
 
     public getResolveProvisionalEditIndex() {
         return this.resolveProvisionalEditAt;
+    }
+
+    // since multiple roslyn.resolveCompletion requests can be made for each completion,
+    // we need to clear the resolveProvisionalEditIndex (currently when a new completion request is made,
+    // this works if resolve requests are always preceded by a completion request)
+    public clearResolveProvisionalEditIndex() {
+        this.resolveProvisionalEditAt = undefined;
     }
 
     private getEditedContent(newText: string, start: number, end: number, content: string) {


### PR DESCRIPTION
This resolves #7250. The cause was that when we added a provisional dot to the generated virtual csharp document, the change didn't get reflected on disk before the Roslyn server took the completion request.

Changes made in completionHandler.ts:
1. Made changes so that both provisional and non-provisional code completion uses the same `provideCompletionsCommand` (roslyn.provideCompletions).
2. On top of adding a temporary provisional dot "." after each provisional completion request, we are adding a "resolve" provisional dot for each resolve completion request. The dot is essential for the resolve request to be correct and therefor for the tooltip to show up.
3. Use vscode.workspace.onDidChangeTextDocument to ensure that the virtual documents get updated before sending the request to the roslyn server for both completion and resolve completion requests.

#### Before
![image](https://github.com/user-attachments/assets/09e040d4-c39c-4525-82ce-a1ab4c621f98)

#### What could have gone wrong if it wasn't for David's comment

https://github.com/user-attachments/assets/8147402c-a93e-4b59-aaff-fc682073bb8e

#### After
<img width="894" alt="image" src="https://github.com/user-attachments/assets/ce7da6ec-4c60-4a39-9bb8-8208948a59a5">

https://github.com/user-attachments/assets/534ca754-9cbe-4a03-9ba6-3b08c39416b2

