### PR TITLE
Add option to disable completion in argument lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # Latest
+* Add option `dotnet.completion.triggerCompletionInArgumentLists` to disable completion in argument lists (PR: [#7446](https://github.com/dotnet/vscode-csharp/pull/7446))
+* Bump Roslyn to 4.12.0-2.24417.1 (PR: [#7446](https://github.com/dotnet/vscode-csharp/pull/7446))
+  * Fix issue projects would fail to load with missing output path error (PR: [#74791](https://github.com/dotnet/roslyn/pull/74791))
+  * Expose option to disable completion triggers argument list (PR: [#74792](https://github.com/dotnet/roslyn/pull/74792))
+
+# 2.44.x
 * Bump Roslyn to 4.12.0-2.24416.3 (PR: [#7448](https://github.com/dotnet/vscode-csharp/pull/7448))
   * Use EnableCodeStyleSeverity instead of AnalysisLevel to control new diagnostic severity behavior (PR: [#73843](https://github.com/dotnet/roslyn/pull/73843))
   * Cleanup LSP error reporting (PR: [#74530](https://github.com/dotnet/roslyn/pull/74530))

--- a/package.json
+++ b/package.json
@@ -788,6 +788,12 @@
             "description": "%configuration.dotnet.completion.provideRegexCompletions%",
             "order": 20
           },
+          "dotnet.completion.triggerCompletionInArgumentLists": {
+            "type": "boolean",
+            "default": "true",
+            "description": "%configuration.dotnet.completion.triggerCompletionInArgumentLists%",
+            "order": 20
+          },
           "dotnet.backgroundAnalysis.analyzerDiagnosticsScope": {
             "type": "string",
             "enum": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "defaults": {
-    "roslyn": "4.12.0-2.24416.3",
+    "roslyn": "4.12.0-2.24417.1",
     "omniSharp": "1.39.11",
     "razor": "9.0.0-preview.24366.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",

--- a/package.nls.json
+++ b/package.nls.json
@@ -51,6 +51,7 @@
   "configuration.dotnet.completion.showCompletionItemsFromUnimportedNamespaces": "Enables support for showing unimported types and unimported extension methods in completion lists. When committed, the appropriate using directive will be added at the top of the current file. (Previously `omnisharp.enableImportCompletion`)",
   "configuration.dotnet.completion.showNameCompletionSuggestions": "Perform automatic object name completion for the members that you have recently selected.",
   "configuration.dotnet.completion.provideRegexCompletions": "Show regular expressions in completion list.",
+  "configuration.dotnet.completion.triggerCompletionInArgumentLists": "Automatically show completion list in argument lists",
   "configuration.dotnet.backgroundAnalysis.analyzerDiagnosticsScope": "Run background code analysis for: (Previously `omnisharp.enableRoslynAnalyzers`)",
   "configuration.dotnet.backgroundAnalysis.analyzerDiagnosticsScope.openFiles": "Open documents",
   "configuration.dotnet.backgroundAnalysis.analyzerDiagnosticsScope.fullSolution": "Entire solution",


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/6501 by exposing the existing option.

Requires server side change (https://github.com/dotnet/roslyn/pull/74792)

![completion_trigger_arg_list](https://github.com/user-attachments/assets/1b251cf4-971b-4968-8167-b21d668b14e8)
