### PR TITLE
Bump xamlTools to 17.12.35216.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # Latest
-* Bump xamltools to 17.12.35214.29 (PR: [#7444](https://github.com/dotnet/vscode-csharp/pull/7444))
+* Bump xamltools to 17.12.35216.22 (PR: [#7447](https://github.com/dotnet/vscode-csharp/pull/7447))
 
 # 2.43.x
 * Bump Roslyn to 4.12.0-2.24408.4 (PR: [#7429](https://github.com/dotnet/vscode-csharp/pull/7429))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "omniSharp": "1.39.11",
     "razor": "9.0.0-preview.24366.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",
-    "xamlTools": "17.12.35214.29"
+    "xamlTools": "17.12.35216.22"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
Weekly insertion - bumping xamlTools to 17.12.35216.22

No changes to add to changelog.