### PR TITLE
Bump xamlTools to 17.12.35223.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 * Bump Roslyn to 4.12.0-2.24417.1 (PR: [#7446](https://github.com/dotnet/vscode-csharp/pull/7446))
   * Fix issue projects would fail to load with missing output path error (PR: [#74791](https://github.com/dotnet/roslyn/pull/74791))
   * Expose option to disable completion triggers argument list (PR: [#74792](https://github.com/dotnet/roslyn/pull/74792))
-* Bump xamltools to 17.12.35221.21 (PR: [#7457](https://github.com/dotnet/vscode-csharp/pull/7457))
+* Bump xamltools to 17.12.35223.16 (PR: [#7464](https://github.com/dotnet/vscode-csharp/pull/7464))
+* Added XAML Hot Reload support for x:FactoryMethod and x:Arguments
 
 # 2.44.x
 * Bump Roslyn to 4.12.0-2.24416.3 (PR: [#7448](https://github.com/dotnet/vscode-csharp/pull/7448))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "omniSharp": "1.39.11",
     "razor": "9.0.0-preview.24418.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
-    "xamlTools": "17.12.35221.21"
+    "xamlTools": "17.12.35223.16"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
 Weekly insertion - bumping xamlTools to 17.12.35223.16. 

### Additional Changelog updates:
* [Added XAML Hot Reload support for x:FactoryMethod and x:Arguments](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/571576)