### PR TITLE
Don't use VS Code document versions anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # Latest
+* Bump Razor to 9.0.0-preview.24427.2  (PR: [#7471](https://github.com/dotnet/vscode-csharp/pull/7471))
+  * Suppress unique ids (#10791) (PR: [#10791](https://github.com/dotnet/razor/pull/10791))
+  * Self-versioned documents (#10747) (PR: [#10747](https://github.com/dotnet/razor/pull/10747))
+  * Remove ItemCollection from CodeRenderingContext (#10764) (PR: [#10764](https://github.com/dotnet/razor/pull/10764))
+  * Moving formatting service to common layer (#10761) (PR: [#10761](https://github.com/dotnet/razor/pull/10761))
+  * Allow LSP and cohosting to provide specialized methods to get a syntax tree (#10765) (PR: [#10765](https://github.com/dotnet/razor/pull/10765))
+  * Update NOTICE.txt (#10768) (PR: [#10768](https://github.com/dotnet/razor/pull/10768))
+  * Allow @@ as a fallback (#10752) (PR: [#10752](https://github.com/dotnet/razor/pull/10752))
+  * Support component rename from an end tag (#10762) (PR: [#10762](https://github.com/dotnet/razor/pull/10762))
 
 # 2.45.17
 * Fix check for rzls being present (PR: [#7462](https://github.com/dotnet/vscode-csharp/pull/7462))
 * Bump Razor to 9.0.0-preview.24418.1 (PR: [#7456](https://github.com/dotnet/vscode-csharp/pull/7456))
   * Don't add already known documents to the misc files project (#10753) (PR: [#10753](https://github.com/dotnet/razor/pull/10753))
   * Remove ItemCollection from TagHelperDescriptorProviderContext (#10720) (PR: [#10720](https://github.com/dotnet/razor/pull/10720))
-  * Cohost inlay hint support (#10672) (PR: [#10672](https://github.com/dotnet/razor/pull/10672))
   * Fix excerpt service to allow for multi line verbatim strings (#10675) (PR: [#10675](https://github.com/dotnet/razor/pull/10675))
   * Fix attribute parsing recovery (#10620) (PR: [#10620](https://github.com/dotnet/razor/pull/10620))
   * Turn off trailing whitespace triming in strings (#10646) (PR: [#10646](https://github.com/dotnet/razor/pull/10646))

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "defaults": {
     "roslyn": "4.12.0-2.24422.6",
     "omniSharp": "1.39.11",
-    "razor": "9.0.0-preview.24418.1",
+    "razor": "9.0.0-preview.24427.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.12.35223.16"
   },

--- a/src/razor/src/csharp/csharpProjectedDocument.ts
+++ b/src/razor/src/csharp/csharpProjectedDocument.ts
@@ -19,7 +19,6 @@ export class CSharpProjectedDocument implements IProjectedDocument {
     private resolveProvisionalEditAt: number | undefined;
     private ProvisionalDotPosition: Position | undefined;
     private hostDocumentVersion: number | null = null;
-    private projectedDocumentVersion = 0;
 
     public constructor(public readonly uri: vscode.Uri) {
         this.path = getUriPath(uri);
@@ -27,10 +26,6 @@ export class CSharpProjectedDocument implements IProjectedDocument {
 
     public get hostDocumentSyncVersion(): number | null {
         return this.hostDocumentVersion;
-    }
-
-    public get projectedDocumentSyncVersion(): number {
-        return this.projectedDocumentVersion;
     }
 
     public get length(): number {
@@ -153,7 +148,6 @@ export class CSharpProjectedDocument implements IProjectedDocument {
     }
 
     private setContent(content: string) {
-        this.projectedDocumentVersion++;
         this.content = content;
     }
 }

--- a/src/razor/src/csharp/csharpProjectedDocumentContentProvider.ts
+++ b/src/razor/src/csharp/csharpProjectedDocumentContentProvider.ts
@@ -29,7 +29,7 @@ export class CSharpProjectedDocumentContentProvider implements vscode.TextDocume
         return this.onDidChangeEmitter.event;
     }
 
-    public async provideTextDocumentContent(uri: vscode.Uri) {
+    public provideTextDocumentContent(uri: vscode.Uri) {
         const razorDocument = this.findRazorDocument(uri);
         if (!razorDocument) {
             // Document was removed from the document manager, meaning there's no more content for this
@@ -46,7 +46,7 @@ export class CSharpProjectedDocumentContentProvider implements vscode.TextDocume
         }
 
         const content = `${razorDocument.csharpDocument.getContent()}
-// ${razorDocument.csharpDocument.projectedDocumentSyncVersion}`;
+// ${razorDocument.csharpDocument.hostDocumentSyncVersion}`;
 
         return content;
     }

--- a/src/razor/src/document/razorDocumentSynchronizer.ts
+++ b/src/razor/src/document/razorDocumentSynchronizer.ts
@@ -41,20 +41,8 @@ export class RazorDocumentSynchronizer {
             const ehdv = expectedHostDocumentVersion;
             this.logger.logVerbose(
                 `${logId} - Synchronizing '${documentKey}':
-    Currently at ${projectedDocument.hostDocumentSyncVersion}, synchronizing to version '${ehdv}'.
-    Current host document version: '${hostDocument.version}'
-    Current projected document version: '${projectedDocument.projectedDocumentSyncVersion}'`
+    Currently at ${projectedDocument.hostDocumentSyncVersion}, synchronizing to version '${ehdv}'.'`
             );
-        }
-
-        if (hostDocument.version !== expectedHostDocumentVersion) {
-            if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(
-                    `${logId} - toHostDocumentVersion and hostDocument.version already out of date.`
-                );
-            }
-
-            // Already out-of-date. Allowing synchronizations for now to see if this actually causes any issues.
         }
 
         const context: SynchronizationContext = this.createSynchronizationContext(
@@ -84,7 +72,7 @@ export class RazorDocumentSynchronizer {
 
             const projectedTextDocument = await vscode.workspace.openTextDocument(projectedDocument.uri);
             const projectedTextDocumentVersion = this.getProjectedTextDocumentVersion(projectedTextDocument);
-            if (projectedDocument.projectedDocumentSyncVersion !== projectedTextDocumentVersion) {
+            if (projectedDocument.hostDocumentSyncVersion !== projectedTextDocumentVersion) {
                 if (this.logger.verboseEnabled) {
                     this.logger.logVerbose(
                         `${logId} - Projected text document not in sync with data type, waiting for update...
@@ -162,7 +150,6 @@ export class RazorDocumentSynchronizer {
             logIdentifier: this.synchronizationIdentifier,
             timeoutId,
             toHostDocumentVersion,
-            hostDocumentVersion: hostDocument.version,
             cancel: (reason) => {
                 for (const reject of rejectionsForCancel) {
                     reject(reason);
@@ -210,7 +197,7 @@ export class RazorDocumentSynchronizer {
         }
 
         for (const context of synchronizationContexts) {
-            if (context.projectedDocument.projectedDocumentSyncVersion === projectedTextDocumentVersion) {
+            if (context.projectedDocument.hostDocumentSyncVersion === projectedTextDocumentVersion) {
                 if (this.logger.verboseEnabled) {
                     const li = context.logIdentifier;
                     const ptdv = projectedTextDocumentVersion;
@@ -269,7 +256,6 @@ interface SynchronizationContext {
     readonly projectedDocument: IProjectedDocument;
     readonly logIdentifier: number;
     readonly toHostDocumentVersion: number;
-    readonly hostDocumentVersion: number;
     readonly timeoutId: NodeJS.Timer;
     readonly projectedDocumentSynchronized: () => void;
     readonly onProjectedDocumentSynchronized: Promise<void>;

--- a/src/razor/src/documentHighlight/razorDocumentHighlightProvider.ts
+++ b/src/razor/src/documentHighlight/razorDocumentHighlightProvider.ts
@@ -46,7 +46,7 @@ export class RazorDocumentHighlightProvider
                 continue;
             }
 
-            if (document.version !== remappedResponse.hostDocumentVersion) {
+            if (projection.hostDocumentVersion !== remappedResponse.hostDocumentVersion) {
                 // This highlight result is for a different version of the text document, bail.
                 continue;
             }

--- a/src/razor/src/hover/razorHoverProvider.ts
+++ b/src/razor/src/hover/razorHoverProvider.ts
@@ -48,7 +48,7 @@ export class RazorHoverProvider extends RazorLanguageFeatureBase implements vsco
             return;
         }
 
-        if (document.version !== remappedResponse.hostDocumentVersion) {
+        if (projection.hostDocumentVersion !== remappedResponse.hostDocumentVersion) {
             // This hover result is for a different version of the text document, bail.
             return;
         }

--- a/src/razor/src/html/htmlProjectedDocument.ts
+++ b/src/razor/src/html/htmlProjectedDocument.ts
@@ -12,7 +12,6 @@ export class HtmlProjectedDocument implements IProjectedDocument {
     public readonly path: string;
     private content = '';
     private hostDocumentVersion: number | null = null;
-    private projectedDocumentVersion = 0;
 
     public constructor(public readonly uri: vscode.Uri) {
         this.path = getUriPath(uri);
@@ -20,10 +19,6 @@ export class HtmlProjectedDocument implements IProjectedDocument {
 
     public get hostDocumentSyncVersion(): number | null {
         return this.hostDocumentVersion;
-    }
-
-    public get projectedDocumentSyncVersion(): number {
-        return this.projectedDocumentVersion;
     }
 
     public get length(): number {
@@ -63,7 +58,6 @@ export class HtmlProjectedDocument implements IProjectedDocument {
     }
 
     private setContent(content: string) {
-        this.projectedDocumentVersion++;
         this.content = content;
     }
 }

--- a/src/razor/src/html/htmlProjectedDocumentContentProvider.ts
+++ b/src/razor/src/html/htmlProjectedDocumentContentProvider.ts
@@ -46,7 +46,7 @@ export class HtmlProjectedDocumentContentProvider implements vscode.TextDocument
         }
 
         const content = `${razorDocument.htmlDocument.getContent()}
-// ${razorDocument.htmlDocument.projectedDocumentSyncVersion}`;
+// ${razorDocument.htmlDocument.hostDocumentSyncVersion}`;
 
         return content;
     }

--- a/src/razor/src/projection/IProjectedDocument.ts
+++ b/src/razor/src/projection/IProjectedDocument.ts
@@ -9,7 +9,6 @@ export interface IProjectedDocument {
     readonly path: string;
     readonly uri: vscode.Uri;
     readonly hostDocumentSyncVersion: number | null;
-    readonly projectedDocumentSyncVersion: number;
     readonly length: number;
     getContent(): string;
 }

--- a/src/razor/src/projection/projectionResult.ts
+++ b/src/razor/src/projection/projectionResult.ts
@@ -10,4 +10,5 @@ export interface ProjectionResult {
     uri: vscode.Uri;
     position: vscode.Position;
     languageKind: LanguageKind;
+    hostDocumentVersion: number;
 }

--- a/src/razor/src/razorLanguageFeatureBase.ts
+++ b/src/razor/src/razorLanguageFeatureBase.ts
@@ -64,6 +64,7 @@ export class RazorLanguageFeatureBase {
                     uri: projectedUri,
                     position: languageResponse.position,
                     languageKind: languageResponse.kind,
+                    hostDocumentVersion: projectedDocument.hostDocumentSyncVersion,
                 } as ProjectionResult;
             }
             default:


### PR DESCRIPTION
VS Code side of https://github.com/dotnet/razor/pull/10747

The only actual product impact here is that hover and document highlight would throw away responses. The rest of the changes is really just cleaning up unnecessarily confusing logging, and a few unused parameters.

Also bumps Razor to 7ed43a1fe7680e35bb1f81a00478a383065ae58d

https://github.com/dotnet/razor/compare/da79940a3af779e3dc973baa1e4e6ebfa100abe1...7ed43a1fe7680e35bb1f81a00478a383065ae58d?w=1