### PR TITLE
Upgrade to Node v20.17 and update vsce

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Setting up your local development environment for the vscode-csharp repository i
 
 Before you start, make sure you have the following software installed on your machine:
 
-* Node.js v18 ([v18.17.0 LTS](https://nodejs.org/en/blog/release/v18.17.0)).
+* Node.js v18 ([v18.17.0 LTS](https://nodejs.org/en/blog/release/v20.17.0)).
   * Note - Building with higher major versions of Node.js is not advised - it may work but we do not test it.
 * Npm (The version shipped with node is fine)
 * .NET 8.0 SDK (dotnet should be on your path)
@@ -140,6 +140,11 @@ Or, in VSCode settings (`Ctrl+,`):
 2. Set `razor.languageServer.directory` to the path of your Razor DLL.
 3. Enable `razor.languageServer.debug`.
 4. Set `razor.server.trace` to `Debug`. This gives you more detailed log messages in the output window.
+
+### Updating NPM packages
+We use the .NET eng AzDo artifacts feed https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet-public-npm/npm/registry/ with upstreams to the public npm registry.
+Auth is required in order to pull new packages from the upstream.  This can be done by running `vsts-npm-auth -config .npmrc`.
+If you need to renew authorization, you can force it via `vsts-npm-auth -config .npmrc -F`
 
 ## Creating VSIX Packages for the Extension
 

--- a/azure-pipelines/prereqs.yml
+++ b/azure-pipelines/prereqs.yml
@@ -12,9 +12,9 @@ steps:
 - task: NuGetAuthenticate@1
 
 - task: NodeTool@0
-  displayName: 'Install Node.js 18.x'
+  displayName: 'Install Node.js 20.x'
   inputs:
-    versionSpec: '18.x'
+    versionSpec: '20.x'
 
 # Some tests use predefined docker images with a specific version of .NET installed.
 # So we avoid installing .NET in those cases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,9 +58,9 @@
         "@types/yauzl": "2.10.0",
         "@typescript-eslint/eslint-plugin": "^5.61.0",
         "@typescript-eslint/parser": "^5.61.0",
-        "@vscode/l10n-dev": "^0.0.30",
+        "@vscode/l10n-dev": "^0.0.35",
         "@vscode/test-electron": "2.3.8",
-        "@vscode/vsce": "2.21.0",
+        "@vscode/vsce": "3.0.0",
         "archiver": "5.3.0",
         "del": "3.0.0",
         "eslint": "^8.43.0",
@@ -112,6 +112,380 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@azure-rest/ai-translation-text": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure-rest/ai-translation-text/-/ai-translation-text-1.0.0.tgz",
+      "integrity": "sha1-ZmT3YJ2e96FELKS9iyc0h0/qd4w=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^1.1.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure-rest/ai-translation-text/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure-rest/core-client": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure-rest/core-client/-/core-client-1.4.0.tgz",
+      "integrity": "sha1-O+KMAsbCDknepzp/AS2u7aTqy44=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.5.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure-rest/core-client/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure-rest/core-client/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.7.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-auth/-/core-auth-1.7.2.tgz",
+      "integrity": "sha1-VYt8t90SsAvuwHrl31kH103x69k=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.9.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz",
+      "integrity": "sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.9.1",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.16.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
+      "integrity": "sha1-veO8PrrX+IXd2d5q9eWo/CVLKH4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.9.0",
+        "@azure/logger": "^1.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+      "integrity": "sha1-Bl2rTgk/thiZmIoc28gn2a2QtO4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.9.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-util/-/core-util-1.9.2.tgz",
+      "integrity": "sha1-HcN9xbDa40xXi+Ys+YkFunwMr+c=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.4.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/identity/-/identity-4.4.1.tgz",
+      "integrity": "sha1-SQ+irSZ4Yimvo2QRiSu1Pfo0eNM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.5.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.3.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^3.14.0",
+        "@azure/msal-node": "^2.9.2",
+        "events": "^3.0.0",
+        "jws": "^4.0.0",
+        "open": "^8.0.0",
+        "stoppable": "^1.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/logger/-/logger-1.1.4.tgz",
+      "integrity": "sha1-Ijy/K0JN+mZHjOmk9XX1nG83l2g=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/logger/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "3.22.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-3.22.0.tgz",
+      "integrity": "sha1-5MJgX6wSvY8Xdhfld8WdFdEFVRM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.14.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.14.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-14.14.2.tgz",
+      "integrity": "sha1-WDtKycCJlTcY16Xi87jfLU27F/Q=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "2.13.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-node/-/msal-node-2.13.1.tgz",
+      "integrity": "sha1-8UQ3EnW3w8vlZHYrhHcqlzJFekc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.14.2",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3172,14 +3546,18 @@
       }
     },
     "node_modules/@vscode/l10n-dev": {
-      "version": "0.0.30",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/l10n-dev/-/l10n-dev-0.0.30.tgz",
-      "integrity": "sha512-m/5voX3NtGCVQ/UjKajvwW9PPvjjvcuvEKiKRkf7dS8Q/JT+Sa5XJK70JrVuuwbfGwZktrBBhF25Eu9SXv4Q6A==",
+      "version": "0.0.35",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/l10n-dev/-/l10n-dev-0.0.35.tgz",
+      "integrity": "sha1-zdgQala33I/u9i0QxBPW2NlLLVw=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@azure-rest/ai-translation-text": "^1.0.0-beta.1",
         "debug": "^4.3.4",
         "deepmerge-json": "^1.5.0",
         "glob": "^10.0.0",
+        "markdown-it": "^14.0.0",
+        "node-html-markdown": "^1.3.0",
         "pseudo-localization": "^2.4.0",
         "web-tree-sitter": "^0.20.8",
         "xml2js": "^0.5.0",
@@ -3188,6 +3566,13 @@
       "bin": {
         "vscode-l10n-dev": "dist/cli.js"
       }
+    },
+    "node_modules/@vscode/l10n-dev/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/@vscode/l10n-dev/node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -3229,6 +3614,19 @@
         }
       }
     },
+    "node_modules/@vscode/l10n-dev/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/@vscode/l10n-dev/node_modules/glob": {
       "version": "10.3.10",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-10.3.10.tgz",
@@ -3251,6 +3649,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@vscode/l10n-dev/node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha1-nvI4v6bccL2Of5VytS02mvVptCE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/@vscode/l10n-dev/node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha1-PDxZkog8Yz20cUzLTXtZNdmLfUU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/@vscode/l10n-dev/node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha1-gGduwEMwJd0+F+6YPQ/o3loiN+A=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vscode/l10n-dev/node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-9.0.3.tgz",
@@ -3271,6 +3704,13 @@
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/@vscode/l10n-dev/node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha1-+NP30OxMPeo1p+PI76TLi0XJ5+4=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vscode/l10n-dev/node_modules/yargs": {
       "version": "17.7.2",
@@ -3377,16 +3817,21 @@
       "dev": true
     },
     "node_modules/@vscode/vsce": {
-      "version": "2.21.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-2.21.0.tgz",
-      "integrity": "sha512-KuxYqScqUY/duJbkj9eE2tN2X/WJoGAy54hHtxT3ZBkM6IzrOg7H7CXGUPBxNlmqku2w/cAjOUSrgIHlzz0mbA==",
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-3.0.0.tgz",
+      "integrity": "sha1-efpKJj65R31J77KTHUUgTj77y3g=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "azure-devops-node-api": "^11.0.1",
+        "@azure/identity": "^4.1.0",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
         "commander": "^6.2.1",
-        "glob": "^7.0.6",
+        "form-data": "^4.0.0",
+        "glob": "^11.0.0",
         "hosted-git-info": "^4.0.2",
         "jsonc-parser": "^3.2.0",
         "leven": "^3.1.0",
@@ -3396,7 +3841,7 @@
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "semver": "^7.5.2",
-        "tmp": "^0.2.1",
+        "tmp": "^0.2.3",
         "typed-rest-client": "^1.8.4",
         "url-join": "^4.0.1",
         "xml2js": "^0.5.0",
@@ -3407,10 +3852,165 @@
         "vsce": "vsce"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       },
       "optionalDependencies": {
         "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign/-/vsce-sign-2.0.4.tgz",
+      "integrity": "sha1-tL8VXRbypLrcBp34UNyG91YSSEI=",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.2",
+        "@vscode/vsce-sign-alpine-x64": "2.0.2",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.2",
+        "@vscode/vsce-sign-darwin-x64": "2.0.2",
+        "@vscode/vsce-sign-linux-arm": "2.0.2",
+        "@vscode/vsce-sign-linux-arm64": "2.0.2",
+        "@vscode/vsce-sign-linux-x64": "2.0.2",
+        "@vscode/vsce-sign-win32-arm64": "2.0.2",
+        "@vscode/vsce-sign-win32-x64": "2.0.2"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.2.tgz",
+      "integrity": "sha1-SszEheVapv8EsZW0f3IurVfapY4=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.2.tgz",
+      "integrity": "sha1-Skt7UFtMwPWFljlIl8SaC84OVAw=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.2.tgz",
+      "integrity": "sha1-EKpp/rf4Gj3GjCQgOMoD6v8ZwS4=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.2.tgz",
+      "integrity": "sha1-MxVSjz6hAHpkizMgv/NqM6ngeqU=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.2.tgz",
+      "integrity": "sha1-QUL9qD5xMLMa7diqgeTapjNDI8I=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.2.tgz",
+      "integrity": "sha1-zlxc/JnjRUtPt3BAWBK0a9bcqHA=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.2.tgz",
+      "integrity": "sha1-WauT8yLvs89JFm1OLoEnicMRdCg=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.2.tgz",
+      "integrity": "sha1-0JVwShSwQEwLb2lumInppRsxqGw=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.2.tgz",
+      "integrity": "sha1-KU6nK0T+3WlNSfXO9MVb84dtwlc=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@vscode/vsce/node_modules/commander": {
@@ -3420,6 +4020,46 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/glob": {
+      "version": "11.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha1-YDHfDXtl6qHMubKbXO0WzqZY534=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha1-zgUhhWtFPIbiXyxMDQPm/33cRAs=",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@vscode/vsce/node_modules/hosted-git-info": {
@@ -3434,37 +4074,66 @@
         "node": ">=10"
       }
     },
+    "node_modules/@vscode/vsce/node_modules/jackspeak": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jackspeak/-/jackspeak-4.0.1.tgz",
+      "integrity": "sha1-n8pM6WGvYIPiWcN26eNUFDH1KHs=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/@vscode/vsce/node_modules/jsonc-parser": {
       "version": "3.2.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
-    "node_modules/@vscode/vsce/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+    "node_modules/@vscode/vsce/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha1-nwUiifI62L+Tl6KgQl57hhXFhYA=",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^7.1.3"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
-      "bin": {
-        "rimraf": "bin.js"
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@vscode/vsce/node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+    "node_modules/@vscode/vsce/node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-11.0.0.tgz",
+      "integrity": "sha1-Fdk6GW8YkDTXFmyvn+Vec4TJiiE=",
       "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
+      "license": "ISC",
       "engines": {
-        "node": ">=8.17.0"
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha1-63g8wivB6L69BnFHbUbqTrMqea4=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -4042,6 +4711,13 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -4068,10 +4744,11 @@
       "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q=="
     },
     "node_modules/azure-devops-node-api": {
-      "version": "11.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.0.1.tgz",
-      "integrity": "sha512-YMdjAw9l5p/6leiyIloxj3k7VIvYThKjvqgiQn88r3nhT93ENwsoDS3A83CyJ4uTWzCZ5f5jCi6c27rTU5Pz+A==",
+      "version": "12.5.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
         "typed-rest-client": "^1.8.4"
@@ -4913,6 +5590,16 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha1-V1+Te8QECiCuJzUqbQfJxadBmB8=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -4939,6 +5626,19 @@
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -5216,6 +5916,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-properties/-/define-properties-1.2.0.tgz",
@@ -5247,6 +5957,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -5359,16 +6079,17 @@
       }
     },
     "node_modules/domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "version": "2.3.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0=",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
       "version": "4.2.2",
@@ -7124,6 +7845,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -7759,6 +8495,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -8193,6 +8939,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -8473,6 +9235,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -11085,10 +11860,11 @@
       "dev": true
     },
     "node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "version": "7.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha1-k6libOXl5mvU24aEnnUV6SNApwc=",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -11261,6 +12037,119 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/node-html-markdown": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
+      "integrity": "sha1-7wsZo7v8DxqICruf8qDJqmu/8qk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-html-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha1-od95m4PfXGdD/NknQLoUaCCDt+Q=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha1-uOvWVUw2N8zHZoiAStP2pv2uqKY=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha1-+17/z3bx3eosgb36pN5E55uscPQ=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha1-5BuALh7t+fbK4YPOXmIteJ19jlM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha1-zDhff3UfHR/GUMITdIBCVFOMfTE=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha1-xH9VEnjT3EsLGrjLtC11Gm8Ngk4=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/node-html-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -11500,6 +12389,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.2.tgz",
+      "integrity": "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.1.tgz",
@@ -11572,6 +12479,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha1-5QHNMJSyeEletCWNTJ9tWsMBnwA=",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
       "version": "1.0.11",
@@ -12091,6 +13005,16 @@
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha1-a1PlatdViCNOefSv+pCXLH3Yzbc=",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -12882,6 +13806,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
     "node_modules/stream": {
       "version": "0.0.2",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stream/-/stream-0.0.2.tgz",
@@ -13587,8 +14522,9 @@
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -13667,10 +14603,11 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "1.8.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
-      "integrity": "sha512-xcQpTEAJw2DP7GqVNECh4dD+riS+C1qndXLfBCJ3xk0kqprtGN491P5KlmrDbKdtuW8NEcP/5ChxiJI3S9WYTA==",
+      "version": "1.8.11",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
@@ -14820,6 +15757,314 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@azure-rest/ai-translation-text": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure-rest/ai-translation-text/-/ai-translation-text-1.0.0.tgz",
+      "integrity": "sha1-ZmT3YJ2e96FELKS9iyc0h0/qd4w=",
+      "dev": true,
+      "requires": {
+        "@azure-rest/core-client": "^1.1.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure-rest/core-client": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure-rest/core-client/-/core-client-1.4.0.tgz",
+      "integrity": "sha1-O+KMAsbCDknepzp/AS2u7aTqy44=",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.5.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@azure/abort-controller": {
+          "version": "2.1.2",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+          "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/core-auth": {
+      "version": "1.7.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-auth/-/core-auth-1.7.2.tgz",
+      "integrity": "sha1-VYt8t90SsAvuwHrl31kH103x69k=",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@azure/abort-controller": {
+          "version": "2.1.2",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+          "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/core-client": {
+      "version": "1.9.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz",
+      "integrity": "sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q=",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.9.1",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@azure/abort-controller": {
+          "version": "2.1.2",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+          "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/core-rest-pipeline": {
+      "version": "1.16.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
+      "integrity": "sha1-veO8PrrX+IXd2d5q9eWo/CVLKH4=",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.9.0",
+        "@azure/logger": "^1.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@azure/abort-controller": {
+          "version": "2.1.2",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+          "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+      "integrity": "sha1-Bl2rTgk/thiZmIoc28gn2a2QtO4=",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/core-util": {
+      "version": "1.9.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/core-util/-/core-util-1.9.2.tgz",
+      "integrity": "sha1-HcN9xbDa40xXi+Ys+YkFunwMr+c=",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@azure/abort-controller": {
+          "version": "2.1.2",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+          "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/identity": {
+      "version": "4.4.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/identity/-/identity-4.4.1.tgz",
+      "integrity": "sha1-SQ+irSZ4Yimvo2QRiSu1Pfo0eNM=",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.5.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.1.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.3.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^3.14.0",
+        "@azure/msal-node": "^2.9.2",
+        "events": "^3.0.0",
+        "jws": "^4.0.0",
+        "open": "^8.0.0",
+        "stoppable": "^1.1.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "jwa": {
+          "version": "2.0.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jwa/-/jwa-2.0.0.tgz",
+          "integrity": "sha1-p+nD8p2ulAJ+vK9Jl1yTRVk0EPw=",
+          "dev": true,
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha1-LU6M9qMY/6oSYV6d7H6G5slzEPQ=",
+          "dev": true,
+          "requires": {
+            "jwa": "^2.0.0",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/logger": {
+      "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/logger/-/logger-1.1.4.tgz",
+      "integrity": "sha1-Ijy/K0JN+mZHjOmk9XX1nG83l2g=",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.7.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tslib/-/tslib-2.7.0.tgz",
+          "integrity": "sha1-2bQMXECrWehzjyl98wh78aJpDAE=",
+          "dev": true
+        }
+      }
+    },
+    "@azure/msal-browser": {
+      "version": "3.22.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-browser/-/msal-browser-3.22.0.tgz",
+      "integrity": "sha1-5MJgX6wSvY8Xdhfld8WdFdEFVRM=",
+      "dev": true,
+      "requires": {
+        "@azure/msal-common": "14.14.2"
+      }
+    },
+    "@azure/msal-common": {
+      "version": "14.14.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-common/-/msal-common-14.14.2.tgz",
+      "integrity": "sha1-WDtKycCJlTcY16Xi87jfLU27F/Q=",
+      "dev": true
+    },
+    "@azure/msal-node": {
+      "version": "2.13.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@azure/msal-node/-/msal-node-2.13.1.tgz",
+      "integrity": "sha1-8UQ3EnW3w8vlZHYrhHcqlzJFekc=",
+      "dev": true,
+      "requires": {
+        "@azure/msal-common": "14.14.2",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+          "dev": true
+        }
       }
     },
     "@babel/code-frame": {
@@ -17184,20 +18429,29 @@
       }
     },
     "@vscode/l10n-dev": {
-      "version": "0.0.30",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/l10n-dev/-/l10n-dev-0.0.30.tgz",
-      "integrity": "sha512-m/5voX3NtGCVQ/UjKajvwW9PPvjjvcuvEKiKRkf7dS8Q/JT+Sa5XJK70JrVuuwbfGwZktrBBhF25Eu9SXv4Q6A==",
+      "version": "0.0.35",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/l10n-dev/-/l10n-dev-0.0.35.tgz",
+      "integrity": "sha1-zdgQala33I/u9i0QxBPW2NlLLVw=",
       "dev": true,
       "requires": {
+        "@azure-rest/ai-translation-text": "^1.0.0-beta.1",
         "debug": "^4.3.4",
         "deepmerge-json": "^1.5.0",
         "glob": "^10.0.0",
+        "markdown-it": "^14.0.0",
+        "node-html-markdown": "^1.3.0",
         "pseudo-localization": "^2.4.0",
         "web-tree-sitter": "^0.20.8",
         "xml2js": "^0.5.0",
         "yargs": "^17.7.1"
       },
       "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+          "dev": true
+        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -17227,6 +18481,12 @@
             "ms": "2.1.2"
           }
         },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=",
+          "dev": true
+        },
         "glob": {
           "version": "10.3.10",
           "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-10.3.10.tgz",
@@ -17239,6 +18499,35 @@
             "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
             "path-scurry": "^1.10.1"
           }
+        },
+        "linkify-it": {
+          "version": "5.0.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/linkify-it/-/linkify-it-5.0.0.tgz",
+          "integrity": "sha1-nvI4v6bccL2Of5VytS02mvVptCE=",
+          "dev": true,
+          "requires": {
+            "uc.micro": "^2.0.0"
+          }
+        },
+        "markdown-it": {
+          "version": "14.1.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/markdown-it/-/markdown-it-14.1.0.tgz",
+          "integrity": "sha1-PDxZkog8Yz20cUzLTXtZNdmLfUU=",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "^4.4.0",
+            "linkify-it": "^5.0.0",
+            "mdurl": "^2.0.0",
+            "punycode.js": "^2.3.1",
+            "uc.micro": "^2.1.0"
+          }
+        },
+        "mdurl": {
+          "version": "2.0.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/mdurl/-/mdurl-2.0.0.tgz",
+          "integrity": "sha1-gGduwEMwJd0+F+6YPQ/o3loiN+A=",
+          "dev": true
         },
         "minimatch": {
           "version": "9.0.3",
@@ -17253,6 +18542,12 @@
           "version": "2.1.2",
           "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "uc.micro": {
+          "version": "2.1.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/uc.micro/-/uc.micro-2.1.0.tgz",
+          "integrity": "sha1-+NP30OxMPeo1p+PI76TLi0XJ5+4=",
           "dev": true
         },
         "yargs": {
@@ -17338,16 +18633,20 @@
       }
     },
     "@vscode/vsce": {
-      "version": "2.21.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-2.21.0.tgz",
-      "integrity": "sha512-KuxYqScqUY/duJbkj9eE2tN2X/WJoGAy54hHtxT3ZBkM6IzrOg7H7CXGUPBxNlmqku2w/cAjOUSrgIHlzz0mbA==",
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce/-/vsce-3.0.0.tgz",
+      "integrity": "sha1-efpKJj65R31J77KTHUUgTj77y3g=",
       "dev": true,
       "requires": {
-        "azure-devops-node-api": "^11.0.1",
+        "@azure/identity": "^4.1.0",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
         "commander": "^6.2.1",
-        "glob": "^7.0.6",
+        "form-data": "^4.0.0",
+        "glob": "^11.0.0",
         "hosted-git-info": "^4.0.2",
         "jsonc-parser": "^3.2.0",
         "keytar": "^7.7.0",
@@ -17358,7 +18657,7 @@
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "semver": "^7.5.2",
-        "tmp": "^0.2.1",
+        "tmp": "^0.2.3",
         "typed-rest-client": "^1.8.4",
         "url-join": "^4.0.1",
         "xml2js": "^0.5.0",
@@ -17366,11 +18665,45 @@
         "yazl": "^2.2.2"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha1-HtxFng8MVISG7Pn8mfIiE2S5oK4=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/commander/-/commander-6.2.1.tgz",
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
+        },
+        "glob": {
+          "version": "11.0.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/glob/-/glob-11.0.0.tgz",
+          "integrity": "sha1-YDHfDXtl6qHMubKbXO0WzqZY534=",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^4.0.1",
+            "minimatch": "^10.0.0",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^2.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "10.0.1",
+              "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minimatch/-/minimatch-10.0.1.tgz",
+              "integrity": "sha1-zgUhhWtFPIbiXyxMDQPm/33cRAs=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            }
+          }
         },
         "hosted-git-info": {
           "version": "4.1.0",
@@ -17381,31 +18714,127 @@
             "lru-cache": "^6.0.0"
           }
         },
+        "jackspeak": {
+          "version": "4.0.1",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jackspeak/-/jackspeak-4.0.1.tgz",
+          "integrity": "sha1-n8pM6WGvYIPiWcN26eNUFDH1KHs=",
+          "dev": true,
+          "requires": {
+            "@isaacs/cliui": "^8.0.2",
+            "@pkgjs/parseargs": "^0.11.0"
+          }
+        },
         "jsonc-parser": {
           "version": "3.2.0",
           "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
           "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
           "dev": true
         },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+        "path-scurry": {
+          "version": "2.0.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/path-scurry/-/path-scurry-2.0.0.tgz",
+          "integrity": "sha1-nwUiifI62L+Tl6KgQl57hhXFhYA=",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "lru-cache": "^11.0.0",
+            "minipass": "^7.1.2"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "11.0.0",
+              "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/lru-cache/-/lru-cache-11.0.0.tgz",
+              "integrity": "sha1-Fdk6GW8YkDTXFmyvn+Vec4TJiiE=",
+              "dev": true
+            }
           }
         },
         "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "dev": true,
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
+          "version": "0.2.3",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tmp/-/tmp-0.2.3.tgz",
+          "integrity": "sha1-63g8wivB6L69BnFHbUbqTrMqea4=",
+          "dev": true
         }
       }
+    },
+    "@vscode/vsce-sign": {
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign/-/vsce-sign-2.0.4.tgz",
+      "integrity": "sha1-tL8VXRbypLrcBp34UNyG91YSSEI=",
+      "dev": true,
+      "requires": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.2",
+        "@vscode/vsce-sign-alpine-x64": "2.0.2",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.2",
+        "@vscode/vsce-sign-darwin-x64": "2.0.2",
+        "@vscode/vsce-sign-linux-arm": "2.0.2",
+        "@vscode/vsce-sign-linux-arm64": "2.0.2",
+        "@vscode/vsce-sign-linux-x64": "2.0.2",
+        "@vscode/vsce-sign-win32-arm64": "2.0.2",
+        "@vscode/vsce-sign-win32-x64": "2.0.2"
+      }
+    },
+    "@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.2.tgz",
+      "integrity": "sha1-SszEheVapv8EsZW0f3IurVfapY4=",
+      "dev": true,
+      "optional": true
+    },
+    "@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.2.tgz",
+      "integrity": "sha1-Skt7UFtMwPWFljlIl8SaC84OVAw=",
+      "dev": true,
+      "optional": true
+    },
+    "@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.2.tgz",
+      "integrity": "sha1-EKpp/rf4Gj3GjCQgOMoD6v8ZwS4=",
+      "dev": true,
+      "optional": true
+    },
+    "@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.2.tgz",
+      "integrity": "sha1-MxVSjz6hAHpkizMgv/NqM6ngeqU=",
+      "dev": true,
+      "optional": true
+    },
+    "@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.2.tgz",
+      "integrity": "sha1-QUL9qD5xMLMa7diqgeTapjNDI8I=",
+      "dev": true,
+      "optional": true
+    },
+    "@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.2.tgz",
+      "integrity": "sha1-zlxc/JnjRUtPt3BAWBK0a9bcqHA=",
+      "dev": true,
+      "optional": true
+    },
+    "@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.2.tgz",
+      "integrity": "sha1-WauT8yLvs89JFm1OLoEnicMRdCg=",
+      "dev": true,
+      "optional": true
+    },
+    "@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.2.tgz",
+      "integrity": "sha1-0JVwShSwQEwLb2lumInppRsxqGw=",
+      "dev": true,
+      "optional": true
+    },
+    "@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.2.tgz",
+      "integrity": "sha1-KU6nK0T+3WlNSfXO9MVb84dtwlc=",
+      "dev": true,
+      "optional": true
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -17871,6 +19300,12 @@
         "async-done": "^2.0.0"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -17888,9 +19323,9 @@
       "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q=="
     },
     "azure-devops-node-api": {
-      "version": "11.0.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-11.0.1.tgz",
-      "integrity": "sha512-YMdjAw9l5p/6leiyIloxj3k7VIvYThKjvqgiQn88r3nhT93ENwsoDS3A83CyJ4uTWzCZ5f5jCi6c27rTU5Pz+A==",
+      "version": "12.5.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU=",
       "dev": true,
       "requires": {
         "tunnel": "0.0.6",
@@ -18534,6 +19969,12 @@
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
+    "cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha1-V1+Te8QECiCuJzUqbQfJxadBmB8=",
+      "dev": true
+    },
     "collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -18560,6 +20001,15 @@
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.20.3",
@@ -18778,6 +20228,12 @@
       "integrity": "sha512-jZRrDmBKjmGcqMFEUJ14FjMJwm05Qaked+1vxaALRtF0UAl7lPU8OLWXFxvoeg3jbQM249VPFVn8g2znaQkEtA==",
       "dev": true
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/define-properties/-/define-properties-1.2.0.tgz",
@@ -18801,6 +20257,12 @@
         "pify": "^3.0.0",
         "rimraf": "^2.2.8"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -18882,9 +20344,9 @@
       }
     },
     "domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "version": "2.3.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0=",
       "dev": true
     },
     "domhandler": {
@@ -20190,6 +21652,17 @@
         }
       }
     },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -20635,6 +22108,12 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/he/-/he-1.2.0.tgz",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+      "dev": true
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -20944,6 +22423,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -21129,6 +22614,15 @@
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -23106,9 +24600,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "7.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "version": "7.1.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha1-k6libOXl5mvU24aEnnUV6SNApwc=",
       "dev": true
     },
     "mkdirp": {
@@ -23261,6 +24755,83 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "dev": true,
       "optional": true
+    },
+    "node-html-markdown": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
+      "integrity": "sha1-7wsZo7v8DxqICruf8qDJqmu/8qk=",
+      "dev": true,
+      "requires": {
+        "node-html-parser": "^6.1.1"
+      }
+    },
+    "node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha1-od95m4PfXGdD/NknQLoUaCCDt+Q=",
+      "dev": true,
+      "requires": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "5.1.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-select/-/css-select-5.1.0.tgz",
+          "integrity": "sha1-uOvWVUw2N8zHZoiAStP2pv2uqKY=",
+          "dev": true,
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^6.1.0",
+            "domhandler": "^5.0.2",
+            "domutils": "^3.0.1",
+            "nth-check": "^2.0.1"
+          }
+        },
+        "css-what": {
+          "version": "6.1.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/css-what/-/css-what-6.1.0.tgz",
+          "integrity": "sha1-+17/z3bx3eosgb36pN5E55uscPQ=",
+          "dev": true
+        },
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha1-5BuALh7t+fbK4YPOXmIteJ19jlM=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha1-zDhff3UfHR/GUMITdIBCVFOMfTE=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.1.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha1-xH9VEnjT3EsLGrjLtC11Gm8Ngk4=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3"
+          }
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=",
+          "dev": true
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -23443,6 +25014,17 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "open": {
+      "version": "8.4.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/open/-/open-8.4.2.tgz",
+      "integrity": "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=",
+      "dev": true,
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/optionator/-/optionator-0.9.1.tgz",
@@ -23490,6 +25072,12 @@
       "version": "2.2.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha1-5QHNMJSyeEletCWNTJ9tWsMBnwA=",
       "dev": true
     },
     "pako": {
@@ -23884,6 +25472,12 @@
       "version": "2.3.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha1-a1PlatdViCNOefSv+pCXLH3Yzbc=",
       "dev": true
     },
     "pure-rand": {
@@ -24453,6 +26047,12 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
+    "stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha1-MtpWjoPqSIsI5NfqLDvMnXUBXVs=",
+      "dev": true
+    },
     "stream": {
       "version": "0.0.2",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/stream/-/stream-0.0.2.tgz",
@@ -24959,7 +26559,7 @@
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "integrity": "sha1-cvExSzSlsZLbASMk3yzFh8pH+Sw=",
       "dev": true
     },
     "tunnel-agent": {
@@ -25015,9 +26615,9 @@
       }
     },
     "typed-rest-client": {
-      "version": "1.8.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
-      "integrity": "sha512-xcQpTEAJw2DP7GqVNECh4dD+riS+C1qndXLfBCJ3xk0kqprtGN491P5KlmrDbKdtuW8NEcP/5ChxiJI3S9WYTA==",
+      "version": "1.8.11",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
       "dev": true,
       "requires": {
         "qs": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -135,9 +135,9 @@
     "@types/yauzl": "2.10.0",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",
-    "@vscode/l10n-dev": "^0.0.30",
+    "@vscode/l10n-dev": "^0.0.35",
     "@vscode/test-electron": "2.3.8",
-    "@vscode/vsce": "2.21.0",
+    "@vscode/vsce": "3.0.0",
     "archiver": "5.3.0",
     "del": "3.0.0",
     "eslint": "^8.43.0",
@@ -1384,7 +1384,7 @@
           },
           "dotnet.unitTests.runSettingsPath": {
             "type": "string",
-            "markdownDescription": "%configuration.dotnet.unitTests.runSettingsPath.markdownDescription%"
+            "markdownDescription": "%configuration.dotnet.unitTests.runSettingsPath%"
           }
         }
       },


### PR DESCRIPTION
the latest vsce requires node 20 or higher.  we need the latest vsce for MI publishing, so we must upgrade to node v20.