### PR TITLE
Cherry-pick xaml fix to release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Update Debugger to v2.43.0 (PR: [#7420](https://github.com/dotnet/vscode-csharp/pull/7420))
 * Bump xamltools to 17.12.35223.16 (PR: [#7464](https://github.com/dotnet/vscode-csharp/pull/7464))
 * Added XAML Hot Reload support for x:FactoryMethod and x:Arguments
+* Bump xamltools to 17.12.35304.30 (PR: [#7507](https://github.com/dotnet/vscode-csharp/pull/7508))
 
 # 2.44.x
 * Bump Roslyn to 4.12.0-2.24416.3 (PR: [#7448](https://github.com/dotnet/vscode-csharp/pull/7448))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "omniSharp": "1.39.11",
     "razor": "9.0.0-preview.24418.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
-    "xamlTools": "17.12.35223.16"
+    "xamlTools": "17.12.35304.30"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
Bump xamlTools to 17.12.35304.30