### PR TITLE
Added Building step to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,10 @@ Follow these steps to build, run, and test the repository:
 #### Building
 
 1. Run `npm i` - This command installs the project dependencies.
-2. Run `npm i -g gulp` - This command installs Gulp globally.
-3. Run `gulp installDependencies` - This command downloads the various dependencies as specified by the version in the [package.json](package.json) file.
-4. Run `code .` - This command opens the project in Visual Studio Code.
+2. Run `vsts-npm-auth -config .npmrc` - This command will configure your credentials for the next command.
+3. Run `npm i -g gulp` - This command installs Gulp globally.
+4. Run `gulp installDependencies` - This command downloads the various dependencies as specified by the version in the [package.json](package.json) file.
+5. Run `code .` - This command opens the project in Visual Studio Code.
 
 #### Running
 


### PR DESCRIPTION
For new contributors, it may be necessary to run
`vsts-npm-auth -config .npmrc` before `npm i -g gulp`