### PR TITLE
Use older version of VSCode in integration tests to workaround extension install issue

### DIFF
--- a/test/vscodeLauncher.ts
+++ b/test/vscodeLauncher.ts
@@ -17,7 +17,7 @@ function getSln(workspacePath: string): string | undefined {
 
 async function main() {
     try {
-        const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
+        const vscodeExecutablePath = await downloadAndUnzipVSCode('1.92.2');
         const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
 
         console.log('Display: ' + process.env.DISPLAY);


### PR DESCRIPTION
1.93.0 seems to be failing to install the runtime extension on mac
```
starting node /Users/runner/work/1/s/out/test/vscodeLauncher.js --enable-source-maps
Downloading VS Code 1.93.0 from https://update.code.visualstudio.com/1.93.0/darwin/stable
Downloading VS Code (140903760B)
Downloading VS Code [------------------------------] 3%Downloading VS Code [=-----------------------------] 6%Downloading VS Code [==----------------------------] 9%Downloading VS Code [===---------------------------] 12%Downloading VS Code [====--------------------------] 14%Downloading VS Code [=====-------------------------] 18%Downloading VS Code [======------------------------] 21%Downloading VS Code [======------------------------] 23%Downloading VS Code [=======-----------------------] 24%Downloading VS Code [=======-----------------------] 26%Downloading VS Code [=========---------------------] 30%Downloading VS Code [=========---------------------] 30%Downloading VS Code [==========--------------------] 33%Downloading VS Code [==========--------------------] 35%Downloading VS Code [===========-------------------] 37%Downloading VS Code [============------------------] 40%Downloading VS Code [============------------------] 41%Downloading VS Code [=============-----------------] 45%Downloading VS Code [==============----------------] 49%Downloading VS Code [===============---------------] 51%Downloading VS Code [================--------------] 54%Downloading VS Code [================--------------] 56%Downloading VS Code [=================-------------] 58%Downloading VS Code [=================-------------] 59%Downloading VS Code [==================------------] 62%Downloading VS Code [===================-----------] 65%Downloading VS Code [====================----------] 67%Downloading VS Code [====================----------] 69%Downloading VS Code [====================----------] 70%Downloading VS Code [=====================---------] 70%Downloading VS Code [======================--------] 74%Downloading VS Code [======================--------] 75%Downloading VS Code [=======================-------] 78%Downloading VS Code [========================------] 80%Downloading VS Code [========================------] 83%Downloading VS Code [==========================----] 87%Downloading VS Code [===========================---] 91%Downloading VS Code [===========================---] 93%Downloading VS Code [============================--] 95%Downloading VS Code [=============================-] 99%Downloading VS Code [==============================] 100%Downloaded VS Code into /Users/runner/work/1/s/.vscode-test/vscode-darwin-1.93.0
Downloaded VS Code into /Users/runner/work/1/s/.vscode-test/vscode-darwin-1.93.0
Display: :99.0
[
  '--extensions-dir=/Users/runner/work/1/s/.vscode-test/extensions',
  '--user-data-dir=/Users/runner/work/1/s/.vscode-test/user-data',
  '--install-extension',
  'ms-dotnettools.vscode-dotnet-runtime'
]
/bin/sh: /Users/runner/work/1/s/.vscode-test/vscode-darwin-1.93.0/Visual: No such file or directory

```