### PR TITLE
Ensure the fix all resolve request reads an existing field

### DIFF
--- a/src/lsptoolshost/fixAllCodeAction.ts
+++ b/src/lsptoolshost/fixAllCodeAction.ts
@@ -24,10 +24,14 @@ export function registerCodeActionFixAllCommands(
 }
 
 export async function getFixAllResponse(
-    data: LSPAny,
+    data: RoslynProtocol.CodeActionResolveData,
     languageServer: RoslynLanguageServer,
     outputChannel: vscode.OutputChannel
 ) {
+    if (!data.FixAllFlavors) {
+        throw new Error(`FixAllFlavors is missing from data ${JSON.stringify(data)}`);
+    }
+
     const result = await vscode.window.showQuickPick(data.FixAllFlavors, {
         placeHolder: vscode.l10n.t('Pick a fix all scope'),
     });
@@ -41,7 +45,7 @@ export async function getFixAllResponse(
         async (_, token) => {
             if (result) {
                 const fixAllCodeAction: RoslynProtocol.RoslynFixAllCodeAction = {
-                    title: data.title,
+                    title: data.UniqueIdentifier,
                     data: data,
                     scope: result,
                 };
@@ -71,7 +75,7 @@ export async function getFixAllResponse(
 
 async function registerFixAllResolveCodeAction(
     languageServer: RoslynLanguageServer,
-    codeActionData: any,
+    codeActionData: RoslynProtocol.CodeActionResolveData,
     outputChannel: vscode.OutputChannel
 ) {
     if (codeActionData) {

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -188,6 +188,15 @@ export interface RoslynFixAllCodeAction extends CodeAction {
     scope: string;
 }
 
+/**
+ * Should match the definition on the server side, but only the properties we require on the client side.
+ * https://github.com/dotnet/roslyn/blob/bd5c00e5e09de8564093f42d87fe49d4971f2e84/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveData.cs#L16C20-L16C41
+ */
+export interface CodeActionResolveData {
+    UniqueIdentifier: string;
+    FixAllFlavors?: string[];
+}
+
 export interface NamedPipeInformation {
     pipeName: string;
 }


### PR DESCRIPTION
The title property never existed on the data object we get from the server.  A server side change made it required for all code action requests (per LSP spec), so started throwing when we passed null.

This changes the client side to pass a value that is always provided in the data - https://github.com/dotnet/roslyn/blob/bd5c00e5e09de8564093f42d87fe49d4971f2e84/src/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveData.cs#L26

Resolves https://github.com/dotnet/vscode-csharp/issues/7535