### PR TITLE
Do not auto surround `<`, `[` and `(` in XAML.

### DIFF
--- a/src/xaml/language-configuration.json
+++ b/src/xaml/language-configuration.json
@@ -40,10 +40,7 @@
 	"surroundingPairs": [
 		{ "open": "'", "close": "'" },
 		{ "open": "\"", "close": "\"" },
-		{ "open": "{", "close": "}"},
-		{ "open": "[", "close": "]"},
-		{ "open": "(", "close": ")" },
-		{ "open": "<", "close": ">" }
+		{ "open": "{", "close": "}"}
 	],
 	"colorizedBracketPairs": [
 	],


### PR DESCRIPTION
Do not auto surround `<`, `[` and `(` in XAML.