### PR TITLE
Expose sourcelink option and update Roslyn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # Latest
+* Bump Roslyn to 4.12.0-2.24461.7 (PR: [#7544](https://github.com/dotnet/vscode-csharp/pull/7544))
+  * Fix crash when closing source link documents (PR: [#75047](https://github.com/dotnet/roslyn/pull/75047))
+  * Add option to disable source link (PR: [#75047](https://github.com/dotnet/roslyn/pull/75047))
+  * Fix issue navigating from source link documents (PR: [#75033](https://github.com/dotnet/roslyn/pull/75033))
+* Fix exception applying fix all code action (PR: [#7537](https://github.com/dotnet/vscode-csharp/pull/7537))
+
+# 2.45.20
 * Fix check for rzls being present (PR: [#7462](https://github.com/dotnet/vscode-csharp/pull/7462))
 * Bump Razor to 9.0.0-preview.24418.1 (PR: [#7456](https://github.com/dotnet/vscode-csharp/pull/7456))
   * Don't add already known documents to the misc files project (#10753) (PR: [#10753](https://github.com/dotnet/razor/pull/10753))

--- a/package.json
+++ b/package.json
@@ -916,6 +916,12 @@
             "description": "%configuration.dotnet.navigation.navigateToDecompiledSources%",
             "order": 60
           },
+          "dotnet.navigation.navigateToSourceLinkAndEmbeddedSources": {
+            "type": "boolean",
+            "default": "true",
+            "description": "%configuration.dotnet.navigation.navigateToSourceLinkAndEmbeddedSources%",
+            "order": 60
+          },
           "dotnet.quickInfo.showRemarksInQuickInfo": {
             "type": "boolean",
             "default": "true",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "defaults": {
-    "roslyn": "4.12.0-2.24422.6",
+    "roslyn": "4.12.0-2.24461.7",
     "omniSharp": "1.39.11",
     "razor": "9.0.0-preview.24418.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",

--- a/package.nls.json
+++ b/package.nls.json
@@ -75,6 +75,7 @@
   "configuration.dotnet.inlayHints.suppressInlayHintsForParametersThatMatchArgumentName": "Suppress hints when argument matches parameter name",
   "configuration.dotnet.inlayHints.suppressInlayHintsForParametersThatMatchMethodIntent": "Suppress hints when parameter name matches the method's intent",
   "configuration.dotnet.navigation.navigateToDecompiledSources": "Enable navigation to decomplied sources.",
+  "configuration.dotnet.navigation.navigateToSourceLinkAndEmbeddedSources": "Enable navigation to source link and embedded sources.",
   "configuration.dotnet.quickInfo.showRemarksInQuickInfo": "Show remarks information when display symbol.",
   "configuration.dotnet.symbolSearch.searchReferenceAssemblies": "Search symbols in reference assemblies. It affects features requires symbol searching, such as add imports.",
   "configuration.dotnet.unitTestDebuggingOptions": "Options to use with the debugger when launching for unit test debugging. (Previously `csharp.unitTestDebuggingOptions`)",


### PR DESCRIPTION
Contains fixes for
https://github.com/dotnet/vscode-csharp/issues/7535
https://github.com/dotnet/vscode-csharp/issues/7532
https://github.com/dotnet/vscode-csharp/issues/7514

And exposes the option to disable source link in case there are further issues.