### PR TITLE
Register Copilot `relatedFilesProvider` for C#

### DIFF
--- a/src/lsptoolshost/copilot.ts
+++ b/src/lsptoolshost/copilot.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { CSharpExtensionId } from '../constants/csharpExtensionId';
+import { CopilotRelatedDocumentsReport, CopilotRelatedDocumentsRequest } from './roslynProtocol';
+import { RoslynLanguageServer } from './roslynLanguageServer';
+import { UriConverter } from './uriConverter';
+import { TextDocumentIdentifier } from 'vscode-languageserver-protocol';
+
+export async function registerCopilotExtension(languageServer: RoslynLanguageServer, channel: vscode.OutputChannel) {
+    const ext = vscode.extensions.getExtension('github.copilot');
+    if (!ext) {
+        channel.appendLine('GitHub Copilot extension not installed. Skipping call to `registerRelatedFilesProvider`');
+        return;
+    }
+    await ext.activate();
+    const relatedAPI = ext.exports as
+        | {
+              registerRelatedFilesProvider(
+                  providerId: { extensionId: string; languageId: string },
+                  callback: (
+                      uri: vscode.Uri
+                  ) => Promise<{ entries: vscode.Uri[]; traits?: { name: string; value: string }[] }>
+              ): void;
+          }
+        | undefined;
+    if (!relatedAPI) {
+        channel.appendLine(
+            'Incompatible GitHub Copilot extension installed. Skipping call to `registerRelatedFilesProvider`'
+        );
+        return;
+    }
+    channel.appendLine('registerRelatedFilesProvider succeeded.');
+
+    const id = {
+        extensionId: CSharpExtensionId,
+        languageId: 'csharp',
+    };
+
+    relatedAPI.registerRelatedFilesProvider(id, async (uri) => {
+        const writeOutput = (output: CopilotRelatedDocumentsReport[], builder: vscode.Uri[] | null) => {
+            if (output) {
+                for (const report of output) {
+                    if (report._vs_file_paths) {
+                        for (const filePath of report._vs_file_paths) {
+                            channel.appendLine('found related file: ' + filePath);
+                            builder?.push(vscode.Uri.file(filePath));
+                        }
+                    }
+                }
+            }
+        };
+
+        const relatedFiles: vscode.Uri[] = [];
+        const uriString = UriConverter.serialize(uri);
+        const textDocument = TextDocumentIdentifier.create(uriString);
+        const responsePromise = languageServer.sendRequestWithProgress(
+            CopilotRelatedDocumentsRequest.type,
+            {
+                _vs_textDocument: textDocument,
+                position: {
+                    line: 0,
+                    character: 0,
+                },
+            },
+            async (p) => {
+                writeOutput(p, relatedFiles);
+            }
+        );
+
+        await responsePromise.then(
+            (result) => {
+                writeOutput(result, null);
+                return;
+            },
+            (err) => {
+                channel.appendLine(err);
+                return;
+            }
+        );
+
+        return {
+            entries: relatedFiles,
+        };
+    });
+}

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -68,6 +68,7 @@ import { registerLanguageStatusItems } from './languageStatusBar';
 import { ProjectContextService } from './services/projectContextService';
 import { ProvideDynamicFileResponse } from '../razor/src/dynamicFile/provideDynamicFileResponse';
 import { ProvideDynamicFileParams } from '../razor/src/dynamicFile/provideDynamicFileParams';
+import { registerCopilotExtension } from './copilot';
 
 let _channel: vscode.OutputChannel;
 let _traceChannel: vscode.OutputChannel;
@@ -1036,6 +1037,7 @@ export async function activateRoslynLanguageServer(
     );
 
     registerLanguageStatusItems(context, languageServer, languageServerEvents);
+    await registerCopilotExtension(languageServer, _channel);
 
     // Register any commands that need to be handled by the extension.
     registerCommands(context, languageServer, hostExecutableResolver, _channel);

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -1037,7 +1037,7 @@ export async function activateRoslynLanguageServer(
     );
 
     registerLanguageStatusItems(context, languageServer, languageServerEvents);
-    await registerCopilotExtensionAsync(languageServer, _traceChannel);
+    await registerCopilotExtensionAsync(languageServer, _channel);
 
     // Register any commands that need to be handled by the extension.
     registerCommands(context, languageServer, hostExecutableResolver, _channel);

--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -68,7 +68,7 @@ import { registerLanguageStatusItems } from './languageStatusBar';
 import { ProjectContextService } from './services/projectContextService';
 import { ProvideDynamicFileResponse } from '../razor/src/dynamicFile/provideDynamicFileResponse';
 import { ProvideDynamicFileParams } from '../razor/src/dynamicFile/provideDynamicFileParams';
-import { registerCopilotExtension } from './copilot';
+import { registerCopilotExtensionAsync } from './copilot';
 
 let _channel: vscode.OutputChannel;
 let _traceChannel: vscode.OutputChannel;
@@ -1037,7 +1037,7 @@ export async function activateRoslynLanguageServer(
     );
 
     registerLanguageStatusItems(context, languageServer, languageServerEvents);
-    await registerCopilotExtension(languageServer, _channel);
+    await registerCopilotExtensionAsync(languageServer, _traceChannel);
 
     // Register any commands that need to be handled by the extension.
     registerCommands(context, languageServer, hostExecutableResolver, _channel);

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -221,6 +221,16 @@ export interface ProjectNeedsRestoreName {
     projectFilePaths: string[];
 }
 
+export interface CopilotRelatedDocumentsParams extends lsp.WorkDoneProgressParams, lsp.PartialResultParams {
+    _vs_textDocument: lsp.TextDocumentIdentifier;
+    position: lsp.Position;
+}
+
+export interface CopilotRelatedDocumentsReport {
+    _vs_resultId: string | null;
+    _vs_file_paths: string[] | null;
+}
+
 export namespace WorkspaceDebugConfigurationRequest {
     export const method = 'workspace/debugConfiguration';
     export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
@@ -329,4 +339,16 @@ export namespace ProjectNeedsRestoreRequest {
     export const method = 'workspace/_roslyn_projectNeedsRestore';
     export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.serverToClient;
     export const type = new lsp.RequestType<ProjectNeedsRestoreName, void, void>(method);
+}
+
+export namespace CopilotRelatedDocumentsRequest {
+    export const method = 'copilot/_related_documents';
+    export const messageDirection: lsp.MessageDirection = lsp.MessageDirection.clientToServer;
+    export const type = new lsp.ProtocolRequestType<
+        CopilotRelatedDocumentsParams,
+        CopilotRelatedDocumentsReport[],
+        CopilotRelatedDocumentsReport[],
+        void,
+        void
+    >(method);
 }

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -227,8 +227,7 @@ export interface CopilotRelatedDocumentsParams extends lsp.WorkDoneProgressParam
 }
 
 export interface CopilotRelatedDocumentsReport {
-    _vs_resultId: string | null;
-    _vs_file_paths: string[] | null;
+    _vs_file_paths?: string[];
 }
 
 export namespace WorkspaceDebugConfigurationRequest {


### PR DESCRIPTION
`registerRelatedFilesProvider` is a new method on the copilot extension. `RelatedDocumentsHandler` is implemented [here](https://github.com/CyrusNajmabadi/roslyn/blob/main/src/LanguageServer/Protocol/Handler/RelatedDocuments/RelatedDocumentsHandler.cs) in Roslyn language server.