### PR TITLE
install python to fix signing

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -29,9 +29,9 @@ jobs:
       versionNumberOverride: ${{ parameters.versionNumberOverride }}
 
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.11.x'
+    displayName: 'Use Python 3.11'
     inputs:
-      versionSpec: 3.11.x
+      versionSpec: 3.11
 
   # If we're in an official build, install the signing plugin
   - ${{ if eq(parameters.isOfficial, true) }}:
@@ -56,7 +56,6 @@ jobs:
     displayName: 'Build VSIXs'
     env:
       SignType: $(signType)
-      XSIGN_ARGS: --debug
 
   - ${{ if eq(parameters.isOfficial, true) }}:
     - script: gulp signVsix

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -28,6 +28,11 @@ jobs:
     parameters:
       versionNumberOverride: ${{ parameters.versionNumberOverride }}
 
+  - task: UsePythonVersion@0
+    displayName: 'Use Python 3.11.x'
+    inputs:
+      versionSpec: 3.11.x
+
   # If we're in an official build, install the signing plugin
   - ${{ if eq(parameters.isOfficial, true) }}:
     - task: MicroBuildSigningPlugin@4

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -51,6 +51,7 @@ jobs:
     displayName: 'Build VSIXs'
     env:
       SignType: $(signType)
+      XSIGN_ARGS: --debug
 
   - ${{ if eq(parameters.isOfficial, true) }}:
     - script: gulp signVsix


### PR DESCRIPTION
microbuild signing tool has an implict dependency on a specific version of python