### PR TITLE
exclude some debugger binaries from codesign validation

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -50,6 +50,10 @@ extends:
       tsa:
         enabled: true
         configFile: '$(Build.SourcesDirectory)/.config/guardian/TSAConfig.gdntsa'
+      codeSignValidation:
+        # VCTools dlls are signed with the Phone cert, which isn't accepted by the CodeSign policy.
+        # Can be removed once https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2093995 is fixed.
+        additionalTargetsGlobPattern: '-|**\msdia140.dll;-|**\msvc*.dll;-|**\vcruntime*.dll'
     customBuildTags:
     - ES365AIMigrationTooling
     stages:


### PR DESCRIPTION
valided on https://dnceng.visualstudio.com/internal/_build/results?buildId=2547412&view=logs&j=c391917a-80b7-5fa3-49f0-8d08008adb47&t=ad7dda54-9feb-5e4e-5dfd-cdbdda454fc2