### PR TITLE
Do not remove documents if they are not files

### DIFF
--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -193,11 +193,13 @@ export class RazorDocumentManager implements IRazorDocumentManager {
     private closeDocument(uri: vscode.Uri) {
         const document = this._getDocument(uri);
 
-        // Files outside of the workspace will return undefined from getWorkspaceFolder
-        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-        if (!workspaceFolder) {
-            // Out of workspace files should be removed once they're closed
-            this.removeDocument(uri);
+        // Documents that are files should be removed if they are outside the workspace folder
+        if (uri.scheme === 'file') {
+            // Files outside of the workspace will return undefined from getWorkspaceFolder
+            const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+            if (!workspaceFolder) {
+                this.removeDocument(uri);
+            }
         }
 
         this.notifyDocumentChange(document, RazorDocumentChangeKind.closed);


### PR DESCRIPTION
Fixes [AB#2261836](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2261836)

When the preview changes window closes, it issues a document closed for a document being tracked but with a URI of 'vscode-bulkeditpreview-editor'. This is a valid notification for closing a document but it should not be removed because that will cause the content to be lost making the client and server out of sync for what it thinks the csharp/html code is