### PR TITLE
Disable all LSP Server toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # Latest
+* Suppress recoverable errors from razor LSP (PR: [#7624](https://github.com/dotnet/vscode-csharp/pull/7624))
+  * NOTE: this can be re-enabled by setting `razor.languageServer.suppressLspErrorToasts = false`
 * Update Roslyn to 4.13.0-1.24501.3 (PR: [#7618](https://github.com/dotnet/vscode-csharp/pull/7618))
   * Fix issue loading analyzers when using EnforceCodeStyleInBuild (PR: [#75250](https://github.com/dotnet/roslyn/pull/75250))
 * Update Razor to 9.0.0-preview.24480.1 (PR: [#7618](https://github.com/dotnet/vscode-csharp/pull/7618))

--- a/package.json
+++ b/package.json
@@ -1536,6 +1536,11 @@
             "default": false,
             "description": "%configuration.razor.languageServer.forceRuntimeCodeGeneration%",
             "order": 90
+          },
+          "razor.languageServer.suppressLspErrorToasts": {
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.razor.languageServer.suppressLspErrorToasts%"
           }
         }
       },

--- a/package.nls.json
+++ b/package.nls.json
@@ -127,6 +127,7 @@
   "configuration.razor.languageServer.debug": "Specifies whether to wait for debug attach when launching the language server.",
   "configuration.razor.server.trace": "Specifies the logging level to use for the Razor server.",
   "configuration.razor.languageServer.forceRuntimeCodeGeneration": "(EXPERIMENTAL) Enable combined design time/runtime code generation for Razor files",
+  "configuration.razor.languageServer.suppressLspErrorToasts": "Suppresses error toasts from showing up if the server encounters a recoverable error.",
   "debuggers.coreclr.configurationSnippets.label.console-local": ".NET: Launch Executable file (Console)",
   "debuggers.coreclr.configurationSnippets.label.web-local": ".NET: Launch Executable file (Web)",
   "debuggers.coreclr.configurationSnippets.label.attach-local": ".NET: Attach to a .NET process",

--- a/src/razor/src/razorLanguageClient.ts
+++ b/src/razor/src/razorLanguageClient.ts
@@ -10,16 +10,21 @@ import {
     MessageSignature,
     ServerOptions,
 } from 'vscode-languageclient/node';
+import { RazorLanguageServerOptions } from './razorLanguageServerOptions';
 
 export class RazorLanguageClient extends LanguageClient {
+    razorOptions: RazorLanguageServerOptions;
+
     constructor(
         id: string,
         name: string,
         serverOptions: ServerOptions,
         clientOptions: LanguageClientOptions,
+        razorOptions: RazorLanguageServerOptions,
         forceDebug?: boolean
     ) {
         super(id, name, serverOptions, clientOptions, forceDebug);
+        this.razorOptions = razorOptions;
     }
 
     override handleFailedRequest<T>(
@@ -27,14 +32,12 @@ export class RazorLanguageClient extends LanguageClient {
         token: CancellationToken | undefined,
         error: any,
         defaultValue: T,
-        _showNotification?: boolean
+        showNotification?: boolean
     ) {
-        // Temporarily suppress toasts until co-hosting. This resolves some
-        // underlying issues like the below list. This should be re-enabled when we have
-        // confidence that users are receiving actionable errors from the language server.
-        // https://github.com/microsoft/vscode-dotnettools/issues/722
-        // https://github.com/dotnet/vscode-csharp/issues/6973
-        // https://github.com/microsoft/vscode-languageserver-node/issues/1449
-        return super.handleFailedRequest(type, token, error, defaultValue, false);
+        if (this.razorOptions.suppressErrorToasts) {
+            return super.handleFailedRequest(type, token, error, defaultValue, false);
+        }
+
+        return super.handleFailedRequest(type, token, error, defaultValue, showNotification);
     }
 }

--- a/src/razor/src/razorLanguageClient.ts
+++ b/src/razor/src/razorLanguageClient.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    CancellationToken,
+    LanguageClient,
+    LanguageClientOptions,
+    MessageSignature,
+    ServerOptions,
+} from 'vscode-languageclient/node';
+
+export class RazorLanguageClient extends LanguageClient {
+    constructor(
+        id: string,
+        name: string,
+        serverOptions: ServerOptions,
+        clientOptions: LanguageClientOptions,
+        forceDebug?: boolean
+    ) {
+        super(id, name, serverOptions, clientOptions, forceDebug);
+    }
+
+    override handleFailedRequest<T>(
+        type: MessageSignature,
+        token: CancellationToken | undefined,
+        error: any,
+        defaultValue: T,
+        _showNotification?: boolean
+    ) {
+        // Temporarily suppress toasts until co-hosting. This resolves some
+        // underlying issues like the below list. This should be re-enabled when we have
+        // confidence that users are receiving actionable errors from the language server.
+        // https://github.com/microsoft/vscode-dotnettools/issues/722
+        // https://github.com/dotnet/vscode-csharp/issues/6973
+        // https://github.com/microsoft/vscode-languageserver-node/issues/1449
+        return super.handleFailedRequest(type, token, error, defaultValue, false);
+    }
+}

--- a/src/razor/src/razorLanguageServerClient.ts
+++ b/src/razor/src/razorLanguageServerClient.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from 'events';
 import * as vscode from 'vscode';
 import { RequestHandler, RequestType } from 'vscode-jsonrpc';
 import { GenericNotificationHandler, InitializeResult, LanguageClientOptions, State } from 'vscode-languageclient';
-import { LanguageClient, ServerOptions } from 'vscode-languageclient/node';
+import { ServerOptions } from 'vscode-languageclient/node';
 import { RazorLanguage } from './razorLanguage';
 import { RazorLanguageServerOptions } from './razorLanguageServerOptions';
 import { resolveRazorLanguageServerOptions } from './razorLanguageServerOptionsResolver';
@@ -18,6 +18,7 @@ import { TelemetryReporter as RazorTelemetryReporter } from './telemetryReporter
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { randomUUID } from 'crypto';
 import { showErrorMessage } from '../../shared/observers/utils/showMessage';
+import { RazorLanguageClient } from './razorLanguageClient';
 
 const events = {
     ServerStop: 'ServerStop',
@@ -26,7 +27,7 @@ const events = {
 export class RazorLanguageServerClient implements vscode.Disposable {
     private clientOptions!: LanguageClientOptions;
     private serverOptions!: ServerOptions;
-    private client!: LanguageClient;
+    private client!: RazorLanguageClient;
     private onStartListeners: Array<() => Promise<any>> = [];
     private onStartedListeners: Array<() => Promise<any>> = [];
     private eventBus: EventEmitter;
@@ -299,7 +300,7 @@ export class RazorLanguageServerClient implements vscode.Disposable {
 
         this.serverOptions = childProcess;
 
-        this.client = new LanguageClient(
+        this.client = new RazorLanguageClient(
             'razorLanguageServer',
             'Razor Language Server',
             this.serverOptions,

--- a/src/razor/src/razorLanguageServerClient.ts
+++ b/src/razor/src/razorLanguageServerClient.ts
@@ -304,7 +304,8 @@ export class RazorLanguageServerClient implements vscode.Disposable {
             'razorLanguageServer',
             'Razor Language Server',
             this.serverOptions,
-            this.clientOptions
+            this.clientOptions,
+            options
         );
     }
 }

--- a/src/razor/src/razorLanguageServerOptions.ts
+++ b/src/razor/src/razorLanguageServerOptions.ts
@@ -13,4 +13,5 @@ export interface RazorLanguageServerOptions {
     logLevel: LogLevel;
     usingOmniSharp: boolean;
     forceRuntimeCodeGeneration: boolean;
+    suppressErrorToasts: boolean;
 }

--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -25,6 +25,7 @@ export function resolveRazorLanguageServerOptions(
     const usingOmniSharp =
         !getCSharpDevKit() && vscodeApi.workspace.getConfiguration().get<boolean>('dotnet.server.useOmnisharp');
     const forceRuntimeCodeGeneration = serverConfig.get<boolean>('forceRuntimeCodeGeneration');
+    const suppressErrorToasts = serverConfig.get<boolean>('suppressLspErrorToasts');
 
     return {
         serverPath: languageServerExecutablePath,
@@ -33,6 +34,7 @@ export function resolveRazorLanguageServerOptions(
         outputChannel: logger.outputChannel,
         usingOmniSharp,
         forceRuntimeCodeGeneration,
+        suppressErrorToasts,
     } as RazorLanguageServerOptions;
 }
 


### PR DESCRIPTION
[DRAFT]

Should we include an option to enable? I believe this should be disabled by default.
Should we filter based on lsp method? 