### PR TITLE
Warn in the statusbar when the active file is not part of the open workspace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # Latest
+* Warn when the active file is not part of the open workspace (PR: [#7628](https://github.com/dotnet/vscode-csharp/pull/7628))
+* Update Roslyn to 4.13.0-1.24509.4 (PR: [#7628](https://github.com/dotnet/vscode-csharp/pull/7628))
+  * Add a WorkspaceKind property to ProjectContext. (PR: [#75384](https://github.com/dotnet/roslyn/pull/75384))
+  * Convert more lambda rude edits to runtime rude edits (PR: [#75285](https://github.com/dotnet/roslyn/pull/75285))
+
+# 2.51.x
 * Bumped xamltools to 17.12.35403.211 (PR: [#7629](https://github.com/dotnet/vscode-csharp/pull/7629))
 * Update Roslyn to 4.13.0-1.24503.11 (PR: [#7618](https://github.com/dotnet/vscode-csharp/pull/7618))
   * LSP hover responses escape backticks within inline code (PR: [#75364](https://github.com/dotnet/roslyn/pull/75364))

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "defaults": {
-    "roslyn": "4.13.0-1.24503.11",
+    "roslyn": "4.13.0-1.24509.4",
     "omniSharp": "1.39.11",
     "razor": "9.0.0-preview.24480.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",

--- a/src/lsptoolshost/languageStatusBar.ts
+++ b/src/lsptoolshost/languageStatusBar.ts
@@ -10,7 +10,6 @@ import { languageServerOptions } from '../shared/options';
 import { ServerState } from './serverStateChange';
 import { getCSharpDevKit } from '../utils/getCSharpDevKit';
 import { RazorLanguage } from '../razor/src/razorLanguage';
-import { VSWorkspaceKind } from './roslynProtocol';
 
 let currentServerState: ServerState = ServerState.Stopped;
 
@@ -87,10 +86,9 @@ class ProjectContextStatus {
             // Show a warning when the active file is part of the Miscellaneous File workspace and
             // project initialization is complete.
             if (currentServerState === ServerState.ProjectInitializationComplete) {
-                item.severity =
-                    e.context._vs_workspace_kind === VSWorkspaceKind.MiscellaneousFiles
-                        ? vscode.LanguageStatusSeverity.Warning
-                        : vscode.LanguageStatusSeverity.Information;
+                item.severity = e.context._vs_is_miscellaneous
+                    ? vscode.LanguageStatusSeverity.Warning
+                    : vscode.LanguageStatusSeverity.Information;
             } else {
                 item.severity = vscode.LanguageStatusSeverity.Information;
             }

--- a/src/lsptoolshost/languageStatusBar.ts
+++ b/src/lsptoolshost/languageStatusBar.ts
@@ -10,12 +10,20 @@ import { languageServerOptions } from '../shared/options';
 import { ServerState } from './serverStateChange';
 import { getCSharpDevKit } from '../utils/getCSharpDevKit';
 import { RazorLanguage } from '../razor/src/razorLanguage';
+import { VSWorkspaceKind } from './roslynProtocol';
+
+let currentServerState: ServerState = ServerState.Stopped;
 
 export function registerLanguageStatusItems(
     context: vscode.ExtensionContext,
     languageServer: RoslynLanguageServer,
     languageServerEvents: RoslynLanguageServerEvents
 ) {
+    // Track the current server state.
+    languageServerEvents.onServerStateChange((e) => {
+        currentServerState = e.state;
+    });
+
     // DevKit will provide an equivalent workspace status item.
     if (!getCSharpDevKit()) {
         WorkspaceStatus.createStatusItem(context, languageServerEvents);
@@ -44,6 +52,8 @@ class WorkspaceStatus {
 
         const item = vscode.languages.createLanguageStatusItem('csharp.workspaceStatus', documentSelector);
         item.name = vscode.l10n.t('C# Workspace Status');
+        item.severity = vscode.LanguageStatusSeverity.Error;
+        item.command = openSolutionCommand;
         context.subscriptions.push(item);
 
         languageServerEvents.onServerStateChange((e) => {
@@ -51,7 +61,7 @@ class WorkspaceStatus {
             item.busy = e.state === ServerState.ProjectInitializationStarted;
             item.severity =
                 e.state === ServerState.Stopped
-                    ? vscode.LanguageStatusSeverity.Warning
+                    ? vscode.LanguageStatusSeverity.Error
                     : vscode.LanguageStatusSeverity.Information;
             item.command = e.state === ServerState.Stopped ? restartServerCommand : openSolutionCommand;
         });
@@ -73,6 +83,17 @@ class ProjectContextStatus {
 
         projectContextService.onActiveFileContextChanged((e) => {
             item.text = e.context._vs_label;
+
+            // Show a warning when the active file is part of the Miscellaneous File workspace and
+            // project initialization is complete.
+            if (currentServerState === ServerState.ProjectInitializationComplete) {
+                item.severity =
+                    e.context._vs_workspace_kind === VSWorkspaceKind.MiscellaneousFiles
+                        ? vscode.LanguageStatusSeverity.Warning
+                        : vscode.LanguageStatusSeverity.Information;
+            } else {
+                item.severity = vscode.LanguageStatusSeverity.Information;
+            }
         });
 
         // Trigger a refresh, but don't block creation on the refresh completing.

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -13,10 +13,17 @@ export interface VSProjectContextList {
     _vs_defaultIndex: number;
 }
 
+export enum VSWorkspaceKind {
+    Unknown = 0,
+    Host = 1,
+    MiscellaneousFiles = 2,
+}
+
 export interface VSProjectContext {
     _vs_label: string;
     _vs_id: string;
     _vs_kind: string;
+    _vs_workspace_kind: VSWorkspaceKind;
 }
 
 export interface VSTextDocumentIdentifier extends lsp.TextDocumentIdentifier {

--- a/src/lsptoolshost/roslynProtocol.ts
+++ b/src/lsptoolshost/roslynProtocol.ts
@@ -13,17 +13,11 @@ export interface VSProjectContextList {
     _vs_defaultIndex: number;
 }
 
-export enum VSWorkspaceKind {
-    Unknown = 0,
-    Host = 1,
-    MiscellaneousFiles = 2,
-}
-
 export interface VSProjectContext {
     _vs_label: string;
     _vs_id: string;
     _vs_kind: string;
-    _vs_workspace_kind: VSWorkspaceKind;
+    _vs_is_miscellaneous: boolean;
 }
 
 export interface VSTextDocumentIdentifier extends lsp.TextDocumentIdentifier {

--- a/src/lsptoolshost/services/projectContextService.ts
+++ b/src/lsptoolshost/services/projectContextService.ts
@@ -5,7 +5,12 @@
 
 import * as vscode from 'vscode';
 import { RoslynLanguageServer } from '../roslynLanguageServer';
-import { VSGetProjectContextsRequest, VSProjectContext, VSProjectContextList } from '../roslynProtocol';
+import {
+    VSGetProjectContextsRequest,
+    VSProjectContext,
+    VSProjectContextList,
+    VSWorkspaceKind,
+} from '../roslynProtocol';
 import { TextDocumentIdentifier } from 'vscode-languageserver-protocol';
 import { UriConverter } from '../uriConverter';
 import { LanguageServerEvents } from '../languageServerEvents';
@@ -26,6 +31,7 @@ export class ProjectContextService {
         _vs_id: '',
         _vs_kind: '',
         _vs_label: '',
+        _vs_workspace_kind: VSWorkspaceKind.Unknown,
     };
 
     constructor(private _languageServer: RoslynLanguageServer, _languageServerEvents: LanguageServerEvents) {

--- a/src/lsptoolshost/services/projectContextService.ts
+++ b/src/lsptoolshost/services/projectContextService.ts
@@ -5,12 +5,7 @@
 
 import * as vscode from 'vscode';
 import { RoslynLanguageServer } from '../roslynLanguageServer';
-import {
-    VSGetProjectContextsRequest,
-    VSProjectContext,
-    VSProjectContextList,
-    VSWorkspaceKind,
-} from '../roslynProtocol';
+import { VSGetProjectContextsRequest, VSProjectContext, VSProjectContextList } from '../roslynProtocol';
 import { TextDocumentIdentifier } from 'vscode-languageserver-protocol';
 import { UriConverter } from '../uriConverter';
 import { LanguageServerEvents } from '../languageServerEvents';
@@ -31,7 +26,7 @@ export class ProjectContextService {
         _vs_id: '',
         _vs_kind: '',
         _vs_label: '',
-        _vs_workspace_kind: VSWorkspaceKind.Unknown,
+        _vs_is_miscellaneous: false,
     };
 
     constructor(private _languageServer: RoslynLanguageServer, _languageServerEvents: LanguageServerEvents) {


### PR DESCRIPTION
To help make it more clear when the active file is not part of the open workspace, we will show a warning in the C# language status bar. This change requires a server side change to send the workspace kind as part of the project context. See https://github.com/dotnet/roslyn/pull/75384


https://github.com/user-attachments/assets/9f6a3513-bed5-4d1c-a227-cb78f90ca8b7

