### PR TITLE
Update debugger to 2.52.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -420,7 +420,7 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-win7-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-win7-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "win32"
@@ -430,12 +430,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui.exe",
-      "integrity": "AFA82E9A8C244FA614A3ACDABCF5B7C9703811393D18E2125C2018E32D08FD6F"
+      "integrity": "65431717FC1BF1F3CDA4E2ABE4E42A67564C4F6A4A0A7A38D0EC2120AB3E53E4"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / ARM64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-win10-arm64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-win10-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "win32"
@@ -444,12 +444,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui.exe",
-      "integrity": "73D9ACB6697CC483F3FBDA562EA434316ED2DD876BCD8E313624CD20F2DE808B"
+      "integrity": "F2D3A2E45A749D714EA165EF939C955E4BE3B99C7A82919B2563E38733F2C135"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-osx-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-osx-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "darwin"
@@ -463,12 +463,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui",
-      "integrity": "49BBC3A34AD5B993BA2A10735785F709E7C3DFE3A434BE88917959211F03E501"
+      "integrity": "417C7D0477B0ABC04F5AD296100BDDA754B0BB513329206BA096A568CA9A846B"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / arm64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-osx-arm64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-osx-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "darwin"
@@ -481,12 +481,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui",
-      "integrity": "5007BB60158E593C1C559CFDCDAF93CCC4BB84D7971656494B301263D822BD04"
+      "integrity": "84A4DAA9420B9734585845317CC920CD75AAFF4C740ED4619870D1EFD9375498"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-linux-arm.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-linux-arm.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -499,12 +499,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "2D68C4C2D2EDB7BC7B27F542E3021B0F813445C9DE268BA2A316F02107233167"
+      "integrity": "EDF8B6D14FE42C4732ADFA0794A550D0BE71B6F5CD18D4636132B4DFED76B7DA"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-linux-arm64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-linux-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -517,12 +517,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "0F8782168C76C939135A0FB14B682A582170B0A1606242D44BD1A37E6ACCE936"
+      "integrity": "381D1496318B854BB6C3544D7D0D51C9356618D6BEF33438EB26F13FA4DB8AF4"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-linux-musl-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-linux-musl-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -535,12 +535,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "CB7ADA2C813F1008282534150967E379767477C1BFD63C21419E0A02F59FD71D"
+      "integrity": "C7D9B3FCB947798540F24C3784604367CA51C2D52AE69C515525DD7DCA5C1C17"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / ARM64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-linux-musl-arm64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-linux-musl-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -553,12 +553,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "24C70056FAC4F87396BCE795A2CB8BB10CCB0F652CEFAAF0B63CF05360E90192"
+      "integrity": "6D69141D92DF968755D36FABB73C34F8232108E0B563D3B20A59CFD1FF1BBDD2"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / x64)",
-      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-50-0/coreclr-debug-linux-x64.zip",
+      "url": "https://vsdebugger.azureedge.net/coreclr-debug-2-52-0/coreclr-debug-linux-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -571,7 +571,7 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "FFBDE7002BA9C1532989BB0145333DBD6527173395D58D389302968B72849214"
+      "integrity": "A35AB54ED50822DBB98BA10A1065FEF9EA7BE49406291DFE6D74E116EBECF177"
     },
     {
       "id": "RazorOmnisharp",


### PR DESCRIPTION
This PR updates the debugger to the 2.52.0 version. Two highlights:

1. Make a fix to the async user-unhandled exception feature so that the debugger will not stop when a non-user async method implicitly catches and rethrows an exception.
2. Update the debugger to run on top of the 8.0.10 version of the .NET Runtime.