### PR TITLE
[Cherry-Pick] Make sure named pipe awaits server start (#7645)

### DIFF
--- a/src/razor/src/razorLanguageServerClient.ts
+++ b/src/razor/src/razorLanguageServerClient.ts
@@ -222,7 +222,7 @@ export class RazorLanguageServerClient implements vscode.Disposable {
     }
 
     public async connectNamedPipe(pipeName: string): Promise<void> {
-        await this.startHandle;
+        await this.start();
 
         // Params must match https://github.com/dotnet/razor/blob/92005deac54f3e9d1a4d1d8f04389379cccfa354/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/RazorNamedPipeConnectParams.cs#L9
         await this.sendNotification('razor/namedPipeConnect', { pipeName: pipeName });


### PR DESCRIPTION
In cases where the workspace does not contain a razor or cshtml file startup is delayed for razor.
This helps make sure we don't initialize when not needed. That also means that if a user opens a solution that contains a reference
to a project outside of the workspace then startup will be delayed. This is generally fine because it will be
initialized when needed, but there was an issue where the named pipe setup was trying to wait the startup task
that had not been created yet. An await on undefined immediately returns and the project system will never get
information about the project through the named pipe.