### PR TITLE
Require at least version 8.0.10 of the .net runtime

### DIFF
--- a/azure-pipelines/prereqs.yml
+++ b/azure-pipelines/prereqs.yml
@@ -17,9 +17,9 @@ steps:
 # So we avoid installing .NET in those cases.
 - ${{ if eq(parameters.installDotNet, true) }}:
   - task: UseDotNet@2
-    displayName: 'Install .NET Core SDKs'
+    displayName: 'Install .NET SDK'
     inputs:
-      version: '8.x'
+      version: '8.0.403'
 
 - script: dotnet --info
   displayName: Display dotnet info

--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -24,7 +24,6 @@ jobs:
   steps:
   - template: /azure-pipelines/test.yml@self
     parameters:
-      # Prefer the dotnet from the container.
-      installDotNet: false
+      installDotNet: true
       installAdditionalLinuxDependencies: true
       npmCommand: $(npmCommand)

--- a/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
+++ b/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
@@ -16,7 +16,7 @@ import { getDotnetInfo } from '../shared/utils/getDotnetInfo';
 import { readFile } from 'fs/promises';
 import { RuntimeInfo } from '../shared/utils/dotnetInfo';
 
-export const DotNetRuntimeVersion = '8.0';
+export const DotNetRuntimeVersion = '8.0.10';
 
 interface IDotnetAcquireResult {
     dotnetPath: string;
@@ -166,7 +166,7 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
             }
 
             // Verify that the dotnet we found includes a runtime version that is compatible with our requirement.
-            const requiredRuntimeVersion = semver.parse(`${DotNetRuntimeVersion}.0`);
+            const requiredRuntimeVersion = semver.parse(`${DotNetRuntimeVersion}`);
             if (!requiredRuntimeVersion) {
                 throw new Error(`Unable to parse minimum required version ${DotNetRuntimeVersion}`);
             }


### PR DESCRIPTION
With .net 8.0.10 *not* installed
```
Failed to find dotnet info from path, falling back to acquire runtime via ms-dotnettools.vscode-dotnet-runtime
No compatible .NET runtime found. Minimum required version is 8.0.10.
Dotnet path: /home/dibarbet/.config/Code/User/globalStorage/ms-dotnettools.vscode-dotnet-runtime/.dotnet/8.0.10~x64/dotnet
Activating C# + C# Dev Kit + C# IntelliCode...
```

With .net 8.0.10 installed
```
Using dotnet configured on PATH
Dotnet path: C:\Program Files\dotnet\dotnet.exe
Activating C# + C# Dev Kit + C# IntelliCode...
```

Verified runtime version
```
trce: Program[0]
      .NET Runtime Version: .NET 8.0.10
```

Related to https://github.com/microsoft/vscode-dotnettools/issues/1449