### PR TITLE
Add 'Learn more' to miscellaneous files warning.

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -172,6 +172,7 @@
   "C# configuration has changed. Would you like to reload the window to apply your changes?": "C# configuration has changed. Would you like to reload the window to apply your changes?",
   "Nested Code Action": "Nested Code Action",
   "Fix All: ": "Fix All: ",
+  "Learn more": "Learn more",
   "The active document is not part of the open workspace. Not all language features will be available.": "The active document is not part of the open workspace. Not all language features will be available.",
   "Dismiss": "Dismiss",
   "Do not show for this workspace": "Do not show for this workspace",

--- a/src/lsptoolshost/languageStatusBar.ts
+++ b/src/lsptoolshost/languageStatusBar.ts
@@ -10,6 +10,7 @@ import { languageServerOptions } from '../shared/options';
 import { ServerState } from './serverStateChange';
 import { getCSharpDevKit } from '../utils/getCSharpDevKit';
 import { RazorLanguage } from '../razor/src/razorLanguage';
+import { LearnMoreAboutMiscellaneousFilesCommand } from './miscellaneousFileNotifier';
 
 export function registerLanguageStatusItems(
     context: vscode.ExtensionContext,
@@ -91,6 +92,7 @@ class ProjectContextStatus {
                       'The active document is not part of the open workspace. Not all language features will be available.'
                   )
                 : vscode.l10n.t('Active File Context');
+            item.command = e.context._vs_is_miscellaneous ? LearnMoreAboutMiscellaneousFilesCommand : undefined;
         });
 
         // Trigger a refresh, but don't block creation on the refresh completing.

--- a/src/lsptoolshost/miscellaneousFileNotifier.ts
+++ b/src/lsptoolshost/miscellaneousFileNotifier.ts
@@ -13,6 +13,16 @@ import { languageServerOptions } from '../shared/options';
 const SuppressMiscellaneousFilesToastsOption = 'dotnet.server.suppressMiscellaneousFilesToasts';
 const NotifiedDocuments = new Set<string>();
 
+export const LearnMoreAboutMiscellaneousFilesCommand = {
+    command: 'vscode.open',
+    title: vscode.l10n.t('Learn more'),
+    arguments: [
+        vscode.Uri.parse(
+            'https://learn.microsoft.com/en-us/visualstudio/ide/reference/miscellaneous-files?view=vs-2022'
+        ),
+    ],
+};
+
 export function registerMiscellaneousFileNotifier(
     context: vscode.ExtensionContext,
     languageServer: RoslynLanguageServer
@@ -50,7 +60,7 @@ export function registerMiscellaneousFileNotifier(
                 context.workspaceState.update(SuppressMiscellaneousFilesToastsOption, true);
             },
         };
-        showWarningMessage(vscode, message, dismissItem, disableWorkspace);
+        showWarningMessage(vscode, message, dismissItem, disableWorkspace, LearnMoreAboutMiscellaneousFilesCommand);
     });
 }
 


### PR DESCRIPTION
As [suggested](https://github.com/dotnet/vscode-csharp/pull/7652#discussion_r1796219025) at #7652, a "Learn more" link would be used for educating users about miscellaneous files. 

This PR adds a command for opening a VS doc page for Miscellaneous Files. We may want a C# extension centric page for our users instead.

<img width="466" alt="image" src="https://github.com/user-attachments/assets/d79809c7-0b81-4119-869e-daa6bf57df9b">

<img width="527" alt="image" src="https://github.com/user-attachments/assets/cd6017b8-c777-4ac1-8eaa-b120116c2137">
