### PR TITLE
Lookup Razor file context using its document uri.

### DIFF
--- a/src/lsptoolshost/miscellaneousFileNotifier.ts
+++ b/src/lsptoolshost/miscellaneousFileNotifier.ts
@@ -18,8 +18,12 @@ export function registerMiscellaneousFileNotifier(
     languageServer: RoslynLanguageServer
 ) {
     languageServer._projectContextService.onActiveFileContextChanged((e) => {
-        // Only warn for miscellaneous files when the workspace is fully initialized.
-        if (!e.context._vs_is_miscellaneous || languageServer.state !== ServerState.ProjectInitializationComplete) {
+        // Only warn for C# miscellaneous files when the workspace is fully initialized.
+        if (
+            e.languageId !== 'csharp' ||
+            !e.context._vs_is_miscellaneous ||
+            languageServer.state !== ServerState.ProjectInitializationComplete
+        ) {
             return;
         }
 

--- a/src/lsptoolshost/services/projectContextService.ts
+++ b/src/lsptoolshost/services/projectContextService.ts
@@ -12,6 +12,7 @@ import { LanguageServerEvents } from '../languageServerEvents';
 import { ServerState } from '../serverStateChange';
 
 export interface ProjectContextChangeEvent {
+    languageId: string;
     uri: vscode.Uri;
     context: VSProjectContext;
 }
@@ -57,17 +58,18 @@ export class ProjectContextService {
         const uri = textEditor!.document.uri;
 
         if (!this._languageServer.isRunning()) {
-            this._contextChangeEmitter.fire({ uri, context: this._emptyProjectContext });
+            this._contextChangeEmitter.fire({ languageId, uri, context: this._emptyProjectContext });
             return;
         }
 
         const contextList = await this.getProjectContexts(uri, this._source.token);
         if (!contextList) {
+            this._contextChangeEmitter.fire({ languageId, uri, context: this._emptyProjectContext });
             return;
         }
 
         const context = contextList._vs_projectContexts[contextList._vs_defaultIndex];
-        this._contextChangeEmitter.fire({ uri, context });
+        this._contextChangeEmitter.fire({ languageId, uri, context });
     }
 
     private async getProjectContexts(


### PR DESCRIPTION
Previously we had been looking up Razor document context from its mapped C# file. This is unnecessary as we can look it up directly from the razor file uri.