### PR TITLE
Disable the Razor project context status bar.

### DIFF
--- a/src/lsptoolshost/languageStatusBar.ts
+++ b/src/lsptoolshost/languageStatusBar.ts
@@ -29,10 +29,7 @@ function combineDocumentSelectors(...selectors: vscode.DocumentSelector[]): vsco
 
 class WorkspaceStatus {
     static createStatusItem(context: vscode.ExtensionContext, languageServerEvents: RoslynLanguageServerEvents) {
-        const documentSelector = combineDocumentSelectors(
-            languageServerOptions.documentSelector,
-            RazorLanguage.documentSelector
-        );
+        const documentSelector = combineDocumentSelectors(languageServerOptions.documentSelector);
         const openSolutionCommand = {
             command: 'dotnet.openSolution',
             title: vscode.l10n.t('Open solution'),

--- a/src/lsptoolshost/services/projectContextService.ts
+++ b/src/lsptoolshost/services/projectContextService.ts
@@ -47,7 +47,7 @@ export class ProjectContextService {
     public async refresh() {
         const textEditor = vscode.window.activeTextEditor;
         const languageId = textEditor?.document?.languageId;
-        if (languageId !== 'csharp' && languageId !== 'aspnetcorerazor') {
+        if (languageId !== 'csharp') {
             return;
         }
 


### PR DESCRIPTION
We need to properly call the rzls endpoint to get project contexts. Will reenable as part of that work.