### PR TITLE
Disable server restart command with devkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1898,7 +1898,7 @@
         "command": "dotnet.restartServer",
         "title": "%command.dotnet.restartServer%",
         "category": ".NET",
-        "enablement": "dotnet.server.activationContext != 'OmniSharp'"
+        "enablement": "dotnet.server.activationContext == 'Roslyn'"
       }
     ],
     "keybindings": [


### PR DESCRIPTION
This gets people into trouble since restarting the server means project information is lost when using devkit.  See https://github.com/dotnet/vscode-csharp/issues/5882

So disable this command when devkit is enabled