### PR TITLE
Improve activation telemetry to track down when dropoffs occur

### DIFF
--- a/src/lsptoolshost/roslynLanguageServer.ts
+++ b/src/lsptoolshost/roslynLanguageServer.ts
@@ -76,6 +76,7 @@ import {
 } from '../shared/observers/utils/showMessage';
 import { registerSourceGeneratedFilesContentProvider } from './sourceGeneratedFilesContentProvider';
 import { registerMiscellaneousFileNotifier } from './miscellaneousFileNotifier';
+import { TelemetryEventNames } from '../shared/telemetryEventNames';
 
 let _channel: vscode.LogOutputChannel;
 let _traceChannel: vscode.OutputChannel;
@@ -574,12 +575,13 @@ export class RoslynLanguageServer {
         telemetryReporter: TelemetryReporter,
         additionalExtensionPaths: string[]
     ): Promise<MessageTransports> {
+        telemetryReporter.sendTelemetryEvent(TelemetryEventNames.ClientServerStart);
         const serverPath = getServerPath(platformInfo);
 
         const dotnetInfo = await hostExecutableResolver.getHostExecutableInfo();
         const dotnetExecutablePath = dotnetInfo.path;
-
         _channel.info('Dotnet path: ' + dotnetExecutablePath);
+        telemetryReporter.sendTelemetryEvent(TelemetryEventNames.AcquiredRuntime);
 
         let args: string[] = [];
 
@@ -684,6 +686,8 @@ export class RoslynLanguageServer {
             childProcess = cp.spawn(serverPath, args, cpOptions);
         }
 
+        telemetryReporter.sendTelemetryEvent(TelemetryEventNames.LaunchedServer);
+
         // Record the stdout and stderr streams from the server process.
         childProcess.stdout.on('data', (data: { toString: (arg0: any) => any }) => {
             const result: string = isString(data) ? data : data.toString(RoslynLanguageServer.encoding);
@@ -755,6 +759,8 @@ export class RoslynLanguageServer {
         if (socket === undefined) {
             throw new Error('Timeout. Client cound not connect to server via named pipe');
         }
+
+        telemetryReporter.sendTelemetryEvent(TelemetryEventNames.ClientConnected);
 
         return {
             reader: new SocketMessageReader(socket, RoslynLanguageServer.encoding),
@@ -1071,6 +1077,8 @@ export async function activateRoslynLanguageServer(
     // Create a separate channel for outputting trace logs - these are incredibly verbose and make other logs very difficult to see.
     // The trace channel verbosity is controlled by the _channel verbosity.
     _traceChannel = vscode.window.createOutputChannel('C# LSP Trace Logs');
+
+    reporter.sendTelemetryEvent(TelemetryEventNames.ClientInitialize);
 
     const hostExecutableResolver = new DotnetRuntimeExtensionResolver(
         platformInfo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ import { debugSessionTracker } from './coreclrDebug/provisionalDebugSessionTrack
 import { getComponentFolder } from './lsptoolshost/builtInComponents';
 import { activateOmniSharpLanguageServer, ActivationResult } from './omnisharp/omnisharpLanguageServer';
 import { ActionOption, showErrorMessage } from './shared/observers/utils/showMessage';
+import { TelemetryEventNames } from './shared/telemetryEventNames';
 
 export async function activate(
     context: vscode.ExtensionContext
@@ -218,7 +219,7 @@ export async function activate(
     const activationProperties: { [key: string]: string } = {
         serverKind: useOmnisharpServer ? 'OmniSharp' : 'Roslyn',
     };
-    reporter.sendTelemetryEvent('CSharpActivated', activationProperties);
+    reporter.sendTelemetryEvent(TelemetryEventNames.CSharpActivated, activationProperties);
 
     if (!useOmnisharpServer) {
         debugSessionTracker.initializeDebugSessionHandlers(context);

--- a/src/shared/telemetryEventNames.ts
+++ b/src/shared/telemetryEventNames.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Defines all telemetry event names to ensure we do not have overlapping events.
+ */
+export enum TelemetryEventNames {
+    // Common extension events
+    CSharpActivated = 'CSharpActivated',
+
+    // Events related to the roslyn language server.
+    ClientInitialize = 'roslyn/clientInitialize',
+    ClientServerStart = 'roslyn/clientServerInitialize',
+    AcquiredRuntime = 'roslyn/acquiredRuntime',
+    LaunchedServer = 'roslyn/launchedServer',
+    ClientConnected = 'roslyn/clientConnected',
+}


### PR DESCRIPTION
initial funnel telemetry is showing a dropoff between activation and server start.  This generally isn't expected as the server launch is started as part of activation (even if there are no projects).

Adding additional telemetry to see where the dropoffs occur at