### PR TITLE
Fix colors to have more visible contrast ratio

### DIFF
--- a/src/razor/src/csharp/csharpPreviewPanel.ts
+++ b/src/razor/src/csharp/csharpPreviewPanel.ts
@@ -126,6 +126,9 @@ export class CSharpPreviewPanel {
             vertical-align: middle;
             cursor: pointer;
         }
+        button:focus-visible {
+            outline-color: var(--vscode-focusBorder)
+        }
     </style>
 
     <script type="text/javascript">

--- a/src/razor/src/html/htmlPreviewPanel.ts
+++ b/src/razor/src/html/htmlPreviewPanel.ts
@@ -127,6 +127,9 @@ export class HtmlPreviewPanel {
             vertical-align: middle;
             cursor: pointer;
         }
+        button:focus-visible {
+            outline-color: var(--vscode-focusBorder)
+        }
     </style>
 
     <script type="text/javascript">


### PR DESCRIPTION
Fixes internal issue https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2295981 

The default color by the host is `#E49400` which has a ratio of `2.38:1`. 

New color is defined by vs-code (blue by default, them dependent setting) at `#007FD4` getting the ratio to ~`4:1`

<img width="188" alt="image" src="https://github.com/user-attachments/assets/207a5745-111d-4583-804c-46763ac99477">
