### PR TITLE
Don't use 8.0.10

### DIFF
--- a/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
+++ b/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts
@@ -16,7 +16,7 @@ import { getDotnetInfo } from '../shared/utils/getDotnetInfo';
 import { readFile } from 'fs/promises';
 import { RuntimeInfo } from '../shared/utils/dotnetInfo';
 
-export const DotNetRuntimeVersion = '8.0.10';
+export const DotNetRuntimeVersion = '8.0';
 
 interface IDotnetAcquireResult {
     dotnetPath: string;


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-dotnet-runtime/issues/2021

# ❗ This should be released as a high sev hot-fix release :fire:

This is a bug in the C# Extension.
Here is the line of code causing this problem: https://github.com/dotnet/vscode-csharp/blob/eb38986a52a8be7221d0e466f7a25c98dcbd7825/src/lsptoolshost/dotnetRuntimeExtensionResolver.ts#L19

It looks like this is exactly it. It passes 8.0.10 to our Runtime Acquisition API, but the way the runtime API is designed is to only support major.minor versions. The SDK API accepts many different formats, and the findPath API is going to support patch versions, but not the acquire runtime API. This is documented here, but it should probably be documented better: https://github.com/dotnet/vscode-dotnet-runtime/blob/99112a0d6689b1bc01ff9dcf117368ea79c943b5/vscode-dotnet-runtime-library/src/IDotnetAcquireContext.ts#L15


The acquire API will always acquire the 'latest' 8.0 runtime, so I would revert back to that change, as latest is always gonna be 8.0.10 or higher now. 

Our line of code is here: https://github.com/dotnet/vscode-dotnet-runtime/blob/99112a0d6689b1bc01ff9dcf117368ea79c943b5/vscode-dotnet-runtime-library/src/Acquisition/VersionResolver.ts#L146 Where it rejects the request if its not of the form Major.Minor.  Our data mechanisms show 98.8+ Success Rate for detecting this fault did not get triggered because it counted this as an invalid request.