### PR TITLE
Require .NET install value to always be passed

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -27,6 +27,9 @@ parameters:
   - auto
   default: auto
 
+variables:
+  defaultDotnetVersion: '8.0.403'
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -63,3 +66,4 @@ extends:
         isOfficial: true
         channel: ${{ parameters.channel }}
         signType: ${{ parameters.signType }}
+        dotnetVersion: $(defaultDotnetVersion)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,11 +18,15 @@ pr:
     exclude:
     - ./*.md
 
+variables:
+  defaultDotnetVersion: '8.0.403'
+
 stages:
 - template: azure-pipelines/build-all.yml
   parameters:
     isOfficial: false
     signType: test
+    dotnetVersion: $(defaultDotnetVersion)
 
 - stage:
   displayName: Test Linux (.NET 6)
@@ -31,7 +35,7 @@ stages:
   - template: azure-pipelines/test-matrix.yml
     parameters:
       # Prefer the dotnet from the container.
-      installDotNet: false
+      dotnetVersion: ''
       installAdditionalLinuxDependencies: true
       pool:
         name: NetCore-Public
@@ -45,7 +49,7 @@ stages:
   - template: azure-pipelines/test-matrix.yml
     parameters:
       # Prefer the dotnet from the container.
-      installDotNet: false
+      dotnetVersion: ''
       installAdditionalLinuxDependencies: true
       pool:
         name: NetCore-Public
@@ -58,7 +62,7 @@ stages:
   jobs:
   - template: azure-pipelines/test-matrix.yml
     parameters:
-      installDotNet: true
+      dotnetVersion: $(defaultDotnetVersion)
       pool:
         name: NetCore-Public
         demands: ImageOverride -equals 1es-windows-2022-open
@@ -69,7 +73,7 @@ stages:
   jobs:
   - template: azure-pipelines/test-matrix.yml
     parameters:
-      installDotNet: true
+      dotnetVersion: $(defaultDotnetVersion)
       pool:
         name: Azure Pipelines
         vmImage: macOS-13
@@ -90,3 +94,5 @@ stages:
       demands: ImageOverride -equals $(demandsName)
     steps:
     - template: azure-pipelines/test-omnisharp.yml
+      parameters:
+        dotnetVersion: $(defaultDotnetVersion)

--- a/azure-pipelines/build-all.yml
+++ b/azure-pipelines/build-all.yml
@@ -4,6 +4,8 @@ parameters:
   default: 'default'
 - name: isOfficial
   type: boolean
+- name: dotnetVersion
+  type: string
 - name: channel
   values:
   - release
@@ -96,6 +98,7 @@ stages:
       versionNumberOverride: ${{ parameters.versionNumberOverride }}
       platform: linux
       isOfficial: ${{ parameters.isOfficial }}
+      dotnetVersion: ${{ parameters.dotnetVersion }}
       pool:
         ${{ if eq(parameters.isOfficial, true) }}:
           name: netcore1espool-internal
@@ -109,6 +112,7 @@ stages:
       versionNumberOverride: ${{ parameters.versionNumberOverride }}
       platform: windows
       isOfficial: ${{ parameters.isOfficial }}
+      dotnetVersion: ${{ parameters.dotnetVersion }}
       pool:
         ${{ if eq(parameters.isOfficial, true) }}:
           name: netcore1espool-internal
@@ -122,6 +126,7 @@ stages:
       versionNumberOverride: ${{ parameters.versionNumberOverride }}
       platform: darwin
       isOfficial: ${{ parameters.isOfficial }}
+      dotnetVersion: ${{ parameters.dotnetVersion }}
       pool:
         name: Azure Pipelines
         ${{ if eq(parameters.isOfficial, true) }}:

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -8,6 +8,8 @@ parameters:
   type: object
 - name: isOfficial
   type: boolean
+- name: dotnetVersion
+  type: string
 
 jobs:
 - job: 'Build_${{ parameters.platform }}_vsixs'
@@ -27,6 +29,7 @@ jobs:
   - template: /azure-pipelines/prereqs.yml@self
     parameters:
       versionNumberOverride: ${{ parameters.versionNumberOverride }}
+      dotnetVersion: ${{ parameters.dotnetVersion}}
 
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.11'

--- a/azure-pipelines/prereqs.yml
+++ b/azure-pipelines/prereqs.yml
@@ -2,9 +2,8 @@ parameters:
   - name: versionNumberOverride
     type: string
     default: 'default'
-  - name: installDotNet
-    type: boolean
-    default: true
+  - name: dotnetVersion
+    type: string
 
 steps:
 
@@ -15,11 +14,11 @@ steps:
 
 # Some tests use predefined docker images with a specific version of .NET installed.
 # So we avoid installing .NET in those cases.
-- ${{ if eq(parameters.installDotNet, true) }}:
+- ${{ if parameters.dotnetVersion }}:
   - task: UseDotNet@2
     displayName: 'Install .NET SDK'
     inputs:
-      version: '8.0.403'
+      version: ${{ parameters.dotnetVersion }}
 
 - script: dotnet --info
   displayName: Display dotnet info

--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -4,8 +4,8 @@ parameters:
   - name: containerName
     type: string
     default: ''
-  - name: installDotNet
-    type: boolean
+  - name: dotnetVersion
+    type: string
   - name: installAdditionalLinuxDependencies
     type: boolean
     default: false
@@ -24,6 +24,6 @@ jobs:
   steps:
   - template: /azure-pipelines/test.yml@self
     parameters:
-      installDotNet: true
+      dotnetVersion: ${{ parameters.dotnetVersion }}
       installAdditionalLinuxDependencies: true
       npmCommand: $(npmCommand)

--- a/azure-pipelines/test-omnisharp.yml
+++ b/azure-pipelines/test-omnisharp.yml
@@ -1,3 +1,7 @@
+parameters:
+  - name: dotnetVersion
+    type: string
+
 steps:
 - checkout: self
   clean: true
@@ -6,6 +10,8 @@ steps:
   fetchDepth: 1
 
 - template: prereqs.yml
+  parameters:
+    dotnetVersion: ${{ parameters.dotnetVersion }}
 
 - template: test-prereqs.yml
 

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -1,6 +1,6 @@
 parameters:
-  - name: installDotNet
-    type: boolean
+  - name: dotnetVersion
+    type: string
   - name: installAdditionalLinuxDependencies
     type: boolean
     default: false
@@ -16,7 +16,7 @@ steps:
 
 - template: prereqs.yml
   parameters:
-    installDotNet: ${{ parameters.installDotNet }}
+    dotnetVersion: ${{ parameters.dotnetVersion }}
 
 - ${{ if eq(parameters.installAdditionalLinuxDependencies, true) }}:
   - template: test-linux-docker-prereqs.yml


### PR DESCRIPTION
integration tests on .net6 were accidentally installing .net8 because one layer in the templates passed 'true' instead of the actual parameter value for 'installDotnet'.

Instead of having a boolean parameter, I switched this to require a string - and all layers of the templates now require the string to be passed, and only the top layer defines the value passed.

From the .NET 6 test run
```
.NET SDKs installed:
  6.0.428 [/usr/share/dotnet/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 6.0.36 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 6.0.36 [/usr/share/dotnet/shared/Microsoft.NETCore.App]
```