### PR TITLE
Increase server start timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1433,7 +1433,7 @@
           "dotnet.server.startTimeout": {
             "type": "number",
             "scope": "machine-overridable",
-            "default": 30000,
+            "default": 120000,
             "description": "%configuration.dotnet.server.startTimeout%"
           },
           "dotnet.server.waitForDebugger": {


### PR DESCRIPTION
I've seen a couple reports of people hitting a timeout during startup, but eventually works.

The logs show 30seconds between starting and timing out, but the server eventually connects ~10 seconds later.

I see no reason to keep the timeout this low - if the server fails to start (process exits) we reject the promise ahead of time