### PR TITLE
Delete dotnet.dotnetPath option and migrate to replacement

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,9 @@
     // Set the context to the workspace folder to allow us to copy files from it.
     "context": ".."
   },
+  "mounts": [
+    "type=volume,target=${containerWorkspaceFolder}/node_modules"
+  ],
   "customizations": {
     "vscode": {
       "settings": {
@@ -37,7 +40,8 @@
         "powershell.integratedConsole.showOnStartup": false,
         "powershell.startAutomatically": false,
         // ms-azure-devops.azure-pipelines settings
-        "azure-pipelines.customSchemaFile": ".vscode/dnceng-schema.json"
+        "azure-pipelines.customSchemaFile": ".vscode/dnceng-schema.json",
+        "jest.jestCommandLine": "./node_modules/.bin/jest"
       },
       "extensions": [
         "ms-dotnettools.csharp",
@@ -52,5 +56,5 @@
       ]
     }
   },
-  "postCreateCommand": "npm ci && npx gulp installDependencies"
+  "postCreateCommand": "npm i && npx gulp installDependencies && npm i -g gulp"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,5 +56,5 @@
       ]
     }
   },
-  "postCreateCommand": "npm i && npx gulp installDependencies && npm i -g gulp"
+  "postCreateCommand": "npm ci && npx gulp installDependencies && npm i -g gulp"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,5 @@
     "editor.formatOnSave": false,
     "eslint.lintTask.enable": true,
     "dotnet.defaultSolution": "disable",
-    "jest.autoRun": "off"
+    "jest.autoRun": "off",
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Bump xamltools to 17.13.35521.31 (PR: [#7814](https://github.com/dotnet/vscode-csharp/pull/7814))
 
 # 2.59.x
+* Delete `dotnet.dotnetPath` setting and support automatic migration to replacements (PR: [#7825](https://github.com/dotnet/vscode-csharp/pull/7825))
+  * Existing `dotnet.dotnetPath` values will be migrated to the .NET Install Tool extension's `dotnetAcquisitionExtension.existingDotnetPath` setting.  See [this page](https://github.com/dotnet/vscode-dotnet-runtime/blob/main/vscode-dotnet-runtime-extension/README.md#i-already-have-a-net-runtime-or-sdk-installed-and-i-want-to-use-it) for more details on configuring the .NET Install Tool.
+  * The OmniSharp version of `dotnet.dotnetPath` has been migrated to `omnisharp.dotnetPath`
 
 # 2.58.x
 * Update Razor to 9.0.0-preview.24569.4 (PR: [#7805](https://github.com/dotnet/vscode-csharp/pull/7805))

--- a/package.json
+++ b/package.json
@@ -1405,11 +1405,6 @@
             "default": false,
             "description": "%configuration.dotnet.preferCSharpExtension%"
           },
-          "dotnet.dotnetPath": {
-            "type": "string",
-            "scope": "machine-overridable",
-            "description": "%configuration.dotnet.dotnetPath%"
-          },
           "dotnet.server.path": {
             "type": "string",
             "scope": "machine-overridable",
@@ -1535,6 +1530,11 @@
             "default": false,
             "description": "%configuration.omnisharp.dotnet.server.useOmnisharp%",
             "order": 0
+          },
+          "omnisharp.dotnetPath": {
+            "type": "string",
+            "scope": "machine-overridable",
+            "description": "%configuration.omnisharp.dotnetPath%"
           },
           "csharp.format.enable": {
             "type": "boolean",

--- a/package.nls.json
+++ b/package.nls.json
@@ -24,7 +24,6 @@
   "command.dotnet.test.debugTestsInContext": "Debug Tests in Context",
   "command.dotnet.restartServer": "Restart Language Server",
   "configuration.dotnet.defaultSolution.description": "The path of the default solution to be opened in the workspace, or set to 'disable' to skip it. (Previously `omnisharp.defaultLaunchSolution`)",
-  "configuration.dotnet.dotnetPath": "Specifies the path to a dotnet installation directory to use instead of the default system one. This only influences the dotnet installation to use for hosting the language server itself. Example: \"/home/username/mycustomdotnetdirectory\".",
   "configuration.dotnet.server.path": "Specifies the absolute path to the server (LSP or O#) executable. When left empty the version pinned to the C# Extension is used. (Previously `omnisharp.path`)",
   "configuration.dotnet.server.componentPaths": "Allows overriding the folder path for built in components of the language server (for example, override the .roslynDevKit path in the extension directory to use locally built components)",
   "configuration.dotnet.server.componentPaths.roslynDevKit": "Overrides the folder path for the .roslynDevKit component of the language server",
@@ -86,6 +85,7 @@
     ]
   },
   "configuration.omnisharp.dotnet.server.useOmnisharp": "Switches to use the Omnisharp server for language features when enabled (requires restart). This option will not be honored with C# Dev Kit installed.",
+  "configuration.omnisharp.dotnetPath": "Specifies the path to a dotnet installation directory to use instead of the default system one. This only influences the dotnet installation to use for hosting the OmniSharp server itself. Example: \"/home/username/mycustomdotnetdirectory\".",
   "configuration.omnisharp.csharp.format.enable": "Enable/disable default C# formatter (requires restart).",
   "configuration.omnisharp.csharp.suppressDotnetInstallWarning": "Suppress the warning that the .NET Core SDK is not on the path.",
   "configuration.omnisharp.csharp.suppressDotnetRestoreNotification": "Suppress the notification window to perform a 'dotnet restore' when dependencies can't be resolved.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,8 @@ import { TelemetryEventNames } from './shared/telemetryEventNames';
 export async function activate(
     context: vscode.ExtensionContext
 ): Promise<CSharpExtensionExports | OmnisharpExtensionExports | null> {
+    const csharpChannel = vscode.window.createOutputChannel('C#', { log: true });
+
     await MigrateOptions(vscode);
     const optionStream = createOptionStream(vscode);
 
@@ -67,7 +69,6 @@ export async function activate(
     // ensure it gets properly disposed. Upon disposal the events will be flushed.
     context.subscriptions.push(reporter);
 
-    const csharpChannel = vscode.window.createOutputChannel('C#', { log: true });
     const csharpchannelObserver = new CsharpChannelObserver(csharpChannel);
     const csharpLogObserver = new CsharpLoggerObserver(csharpChannel);
     eventStream.subscribe(csharpchannelObserver.post);

--- a/src/omnisharp/dotnetResolver.ts
+++ b/src/omnisharp/dotnetResolver.ts
@@ -10,7 +10,7 @@ import { promisify } from 'util';
 import { HostExecutableInformation } from '../shared/constants/hostExecutableInformation';
 import { IHostExecutableResolver } from '../shared/constants/IHostExecutableResolver';
 import { PlatformInformation } from '../shared/platform';
-import { commonOptions } from '../shared/options';
+import { omnisharpOptions } from '../shared/options';
 
 export class DotnetResolver implements IHostExecutableResolver {
     private readonly minimumDotnetVersion = '6.0.100';
@@ -21,7 +21,7 @@ export class DotnetResolver implements IHostExecutableResolver {
         const dotnet = this.platformInfo.isWindows() ? 'dotnet.exe' : 'dotnet';
         const env = { ...process.env };
 
-        const dotnetPathOption = commonOptions.dotnetPath;
+        const dotnetPathOption = omnisharpOptions.dotnetPath;
         if (dotnetPathOption.length > 0) {
             env['PATH'] = dotnetPathOption + path.delimiter + env['PATH'];
         }

--- a/src/shared/configurationProvider.ts
+++ b/src/shared/configurationProvider.ts
@@ -16,7 +16,6 @@ import {
 } from '../shared/processPicker';
 import { PlatformInformation } from './platform';
 import { getCSharpDevKit } from '../utils/getCSharpDevKit';
-import { commonOptions } from './options';
 import {
     ActionOption,
     showErrorMessageWithOptions,
@@ -150,7 +149,7 @@ export class BaseVsDbgConfigurationProvider implements vscode.DebugConfiguration
             }
 
             if (debugConfiguration.checkForDevCert) {
-                if (!(await this.checkForDevCerts(commonOptions.dotnetPath))) {
+                if (!(await this.checkForDevCerts())) {
                     return undefined;
                 }
             }
@@ -235,11 +234,11 @@ export class BaseVsDbgConfigurationProvider implements vscode.DebugConfiguration
         }
     }
 
-    private async checkForDevCerts(dotnetPath: string): Promise<boolean> {
+    private async checkForDevCerts(): Promise<boolean> {
         let result: boolean | undefined = undefined;
 
         while (result === undefined) {
-            const returnData = await hasDotnetDevCertsHttps(dotnetPath);
+            const returnData = await hasDotnetDevCertsHttps();
             const errorCode = returnData.error?.code;
             if (
                 errorCode === CertToolStatusCodes.CertificateNotTrusted ||
@@ -261,7 +260,7 @@ export class BaseVsDbgConfigurationProvider implements vscode.DebugConfiguration
                 );
 
                 if (dialogResult === labelYes) {
-                    const returnData = await createSelfSignedCert(dotnetPath);
+                    const returnData = await createSelfSignedCert();
                     if (returnData.error === null) {
                         // if the process returns 0, returnData.error is null, otherwise the return code can be accessed in returnData.error.code
                         const message = errorCode === CertToolStatusCodes.CertificateNotTrusted ? 'trusted' : 'created';

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -8,7 +8,6 @@ import { DocumentSelector } from 'vscode-languageserver-protocol';
 import * as path from 'path';
 
 export interface CommonOptions {
-    readonly dotnetPath: string;
     readonly waitForDebugger: boolean;
     readonly serverPath: string;
     readonly useOmnisharpServer: boolean;
@@ -66,6 +65,7 @@ export interface OmnisharpServerOptions {
     readonly maxProjectFileCountForDiagnosticAnalysis: number;
     readonly suppressDotnetRestoreNotification: boolean;
     readonly enableLspDriver?: boolean | null;
+    readonly dotnetPath: string;
 }
 
 export interface LanguageServerOptions {
@@ -90,9 +90,6 @@ export interface RazorOptions {
 }
 
 class CommonOptionsImpl implements CommonOptions {
-    public get dotnetPath() {
-        return readOption<string>('dotnet.dotnetPath', '', 'omnisharp.dotnetPath');
-    }
     public get waitForDebugger() {
         return readOption<boolean>('dotnet.server.waitForDebugger', false, 'omnisharp.waitForDebugger');
     }
@@ -375,6 +372,9 @@ class OmnisharpOptionsImpl implements OmnisharpServerOptions {
     public get enableLspDriver() {
         return readOption<boolean>('omnisharp.enableLspDriver', false);
     }
+    public get dotnetPath() {
+        return readOption<string>('omnisharp.dotnetPath', '');
+    }
 }
 
 class LanguageServerOptionsImpl implements LanguageServerOptions {
@@ -471,13 +471,13 @@ function readOption<T>(option: string, defaultValue: T, ...backCompatOptionNames
 }
 
 export const CommonOptionsThatTriggerReload: ReadonlyArray<keyof CommonOptions> = [
-    'dotnetPath',
     'waitForDebugger',
     'serverPath',
     'useOmnisharpServer',
 ];
 
 export const OmnisharpOptionsThatTriggerReload: ReadonlyArray<keyof OmnisharpServerOptions> = [
+    'dotnetPath',
     'enableMsBuildLoadProjectsOnDemand',
     'loggingLevel',
     'enableEditorConfigSupport',

--- a/src/utils/dotnetDevCertsHttps.ts
+++ b/src/utils/dotnetDevCertsHttps.ts
@@ -5,23 +5,18 @@
 
 import * as cp from 'child_process';
 import { getExtensionPath } from '../common';
+import { commonOptions, omnisharpOptions } from '../shared/options';
 
 // Will return true if `dotnet dev-certs https --check` succesfully finds a trusted development certificate.
-export async function hasDotnetDevCertsHttps(dotnetPath: string): Promise<ExecReturnData> {
-    return await execChildProcess(
-        `${dotnetPath ? dotnetPath : 'dotnet'} dev-certs https --check --trust`,
-        process.cwd(),
-        process.env
-    );
+export async function hasDotnetDevCertsHttps(): Promise<ExecReturnData> {
+    const dotnetPath = (commonOptions.useOmnisharpServer ? omnisharpOptions.dotnetPath : undefined) ?? 'dotnet';
+    return await execChildProcess(`${dotnetPath} dev-certs https --check --trust`, process.cwd(), process.env);
 }
 
 // Will run `dotnet dev-certs https --trust` to prompt the user to create a trusted self signed certificates. Retruns true if sucessfull.
-export async function createSelfSignedCert(dotnetPath: string): Promise<ExecReturnData> {
-    return await execChildProcess(
-        `${dotnetPath ? dotnetPath : 'dotnet'} dev-certs https --trust`,
-        process.cwd(),
-        process.env
-    );
+export async function createSelfSignedCert(): Promise<ExecReturnData> {
+    const dotnetPath = (commonOptions.useOmnisharpServer ? omnisharpOptions.dotnetPath : undefined) ?? 'dotnet';
+    return await execChildProcess(`${dotnetPath} dev-certs https --trust`, process.cwd(), process.env);
 }
 
 async function execChildProcess(

--- a/src/utils/dotnetDevCertsHttps.ts
+++ b/src/utils/dotnetDevCertsHttps.ts
@@ -9,14 +9,12 @@ import { commonOptions, omnisharpOptions } from '../shared/options';
 
 // Will return true if `dotnet dev-certs https --check` succesfully finds a trusted development certificate.
 export async function hasDotnetDevCertsHttps(): Promise<ExecReturnData> {
-    const dotnetPath = (commonOptions.useOmnisharpServer ? omnisharpOptions.dotnetPath : undefined) ?? 'dotnet';
-    return await execChildProcess(`${dotnetPath} dev-certs https --check --trust`, process.cwd(), process.env);
+    return await execChildProcess(`${getDotnetCommand()} dev-certs https --check --trust`, process.cwd(), process.env);
 }
 
 // Will run `dotnet dev-certs https --trust` to prompt the user to create a trusted self signed certificates. Retruns true if sucessfull.
 export async function createSelfSignedCert(): Promise<ExecReturnData> {
-    const dotnetPath = (commonOptions.useOmnisharpServer ? omnisharpOptions.dotnetPath : undefined) ?? 'dotnet';
-    return await execChildProcess(`${dotnetPath} dev-certs https --trust`, process.cwd(), process.env);
+    return await execChildProcess(`${getDotnetCommand()} dev-certs https --trust`, process.cwd(), process.env);
 }
 
 async function execChildProcess(
@@ -29,6 +27,14 @@ async function execChildProcess(
             resolve({ error, stdout, stderr });
         });
     });
+}
+
+function getDotnetCommand(): string {
+    if (commonOptions.useOmnisharpServer) {
+        return omnisharpOptions.dotnetPath ?? 'dotnet';
+    } else {
+        return 'dotnet';
+    }
 }
 
 interface ExecReturnData {

--- a/test/lsptoolshost/unitTests/migrateOptions.test.ts
+++ b/test/lsptoolshost/unitTests/migrateOptions.test.ts
@@ -3,12 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { readFileSync } from 'fs';
-import { migrateOptions } from '../../../src/shared/migrateOptions';
-import { describe, test, expect } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    dotnetAcquisitionExtensionOption,
+    dotnetPathOption,
+    IDotnetAcquisitionExistingPaths,
+    MigrateOptions,
+    migrateOptions,
+} from '../../../src/shared/migrateOptions';
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { getVSCodeWithConfig } from '../../fakes';
+import { CSharpExtensionId } from '../../../src/constants/csharpExtensionId';
+import { ConfigurationTarget } from '../../../src/vscodeAdapter';
 
-describe('Migrate configuration should in package.json', () => {
-    const packageJson = JSON.parse(readFileSync('package.json').toString());
+describe('Migrate configurations', () => {
+    const packageJson = JSON.parse(fs.readFileSync('package.json').toString());
     const configuration = packageJson.contributes.configuration;
     // Read the "Project", "Text Editor", "Debugger", "LSP Server" sections of the package.json
     const configurations = [
@@ -18,9 +29,160 @@ describe('Migrate configuration should in package.json', () => {
         ...Object.keys(configuration[3].properties),
     ];
 
+    const validDotnetFolder = path.join('csharp', 'dotnet');
+    const validDotnetPath = path.join(validDotnetFolder, `dotnet${process.platform === 'win32' ? '.exe' : ''}`);
+
+    beforeEach(() => {
+        jest.spyOn(fs, 'existsSync').mockImplementation((path) => {
+            if (path.toString().endsWith(validDotnetPath)) {
+                return true;
+            }
+
+            return false;
+        });
+    });
+
     migrateOptions.forEach((data) => {
         test(`Should have ${data.newName} in package.json`, () => {
             expect(configurations).toContain(data.newName);
         });
+    });
+
+    test(`dotnet.dotnetPath should create new dotnetAcquisitionExtension.existingDotnetPath value`, async () => {
+        getVSCodeWithConfig(vscode);
+
+        vscode.workspace.getConfiguration().update(dotnetPathOption, validDotnetFolder);
+
+        await MigrateOptions(vscode);
+
+        const updatedConfigurations = vscode.workspace.getConfiguration();
+        const acquisitionPath = updatedConfigurations.get<IDotnetAcquisitionExistingPaths[] | undefined>(
+            dotnetAcquisitionExtensionOption
+        );
+        expect(acquisitionPath).toBeDefined();
+        expect(acquisitionPath!.length).toEqual(1);
+        expect(acquisitionPath![0].path).toEqual(validDotnetPath);
+        expect(acquisitionPath![0].extensionId).toEqual(CSharpExtensionId);
+        expect(updatedConfigurations.get(dotnetPathOption)).toBeUndefined();
+    });
+
+    test(`dotnet.dotnetPath should not overwrite existing dotnetAcquisitionExtension.existingDotnetPath value`, async () => {
+        getVSCodeWithConfig(vscode);
+
+        // Set both dotnet.dotnetPath and dotnetAcquisitionExtension.existingDotnetPath for the C# extension
+        vscode.workspace.getConfiguration().update(dotnetPathOption, validDotnetFolder);
+        vscode.workspace.getConfiguration().update(dotnetAcquisitionExtensionOption, [
+            {
+                path: 'differentCSharp\\dotnet.exe',
+                extensionId: CSharpExtensionId,
+            },
+        ]);
+
+        await MigrateOptions(vscode);
+
+        // Only dotnet.dotnetPath should be deleted, dotnetAcquisitionExtension.existingDotnetPath should be unchanged.
+        const updatedConfigurations = vscode.workspace.getConfiguration();
+        const acquisitionPath = updatedConfigurations.get<IDotnetAcquisitionExistingPaths[] | undefined>(
+            dotnetAcquisitionExtensionOption
+        );
+        expect(acquisitionPath).toBeDefined();
+        expect(acquisitionPath!.length).toEqual(1);
+        expect(acquisitionPath![0].path).toEqual('differentCSharp\\dotnet.exe');
+        expect(acquisitionPath![0].extensionId).toEqual(CSharpExtensionId);
+        expect(updatedConfigurations.get(dotnetPathOption)).toBeUndefined();
+    });
+
+    test(`dotnet.dotnetPath should not update dotnetAcquisitionExtension.existingDotnetPath if invalid`, async () => {
+        getVSCodeWithConfig(vscode);
+
+        vscode.workspace.getConfiguration().update(dotnetPathOption, 'invalid\\dotnet');
+
+        await MigrateOptions(vscode);
+
+        const updatedConfigurations = vscode.workspace.getConfiguration();
+        const acquisitionPath = updatedConfigurations.get<IDotnetAcquisitionExistingPaths[] | undefined>(
+            dotnetAcquisitionExtensionOption
+        );
+        expect(acquisitionPath).toBeUndefined();
+        expect(updatedConfigurations.get(dotnetPathOption)).toBeUndefined();
+    });
+
+    test(`dotnet.dotnetPath should append to existing dotnetAcquisitionExtension.existingDotnetPath values`, async () => {
+        getVSCodeWithConfig(vscode);
+
+        // Set dotnet.dotnetPath and dotnetAcquisitionExtension.existingDotnetPath for a different extension
+        vscode.workspace.getConfiguration().update(dotnetPathOption, validDotnetFolder);
+        vscode.workspace.getConfiguration().update(dotnetAcquisitionExtensionOption, [
+            {
+                path: 'otherExtension\\dotnet.exe',
+                extensionId: 'some.other.extension',
+            },
+        ]);
+
+        await MigrateOptions(vscode);
+
+        // dotnet.dotnetPath should be removed and the value appended to dotnetAcquisitionExtension.existingDotnetPath.
+        const updatedConfigurations = vscode.workspace.getConfiguration();
+        const acquisitionPath = updatedConfigurations
+            .get<IDotnetAcquisitionExistingPaths[] | undefined>(dotnetAcquisitionExtensionOption)
+            ?.sort((a, b) => a.extensionId.localeCompare(b.extensionId));
+        expect(acquisitionPath).toBeDefined();
+        expect(acquisitionPath!.length).toEqual(2);
+        expect(acquisitionPath![0].path).toEqual(validDotnetPath);
+        expect(acquisitionPath![0].extensionId).toEqual(CSharpExtensionId);
+        expect(updatedConfigurations.get(dotnetPathOption)).toBeUndefined();
+    });
+
+    test(`dotnet.dotnetPath is migrated for all configuration targets`, async () => {
+        getVSCodeWithConfig(vscode);
+
+        // Set dotnet.dotnetPath for all configuration targets
+        vscode.workspace
+            .getConfiguration()
+            .update(dotnetPathOption, 'global' + validDotnetFolder, ConfigurationTarget.Global);
+        vscode.workspace
+            .getConfiguration()
+            .update(dotnetPathOption, 'workspace' + validDotnetFolder, ConfigurationTarget.Workspace);
+        vscode.workspace
+            .getConfiguration()
+            .update(dotnetPathOption, 'workspaceFolder' + validDotnetFolder, ConfigurationTarget.WorkspaceFolder);
+
+        await MigrateOptions(vscode);
+
+        // dotnet.dotnetPath should be removed and the value appended to dotnetAcquisitionExtension.existingDotnetPath for all configuration targets.
+
+        const inspectDotnetPath = vscode.workspace.getConfiguration().inspect(dotnetPathOption);
+        expect(inspectDotnetPath?.globalValue).toBeUndefined();
+        expect(inspectDotnetPath?.workspaceValue).toBeUndefined();
+        expect(inspectDotnetPath?.workspaceFolderValue).toBeUndefined();
+
+        const inspectAcquisitionPath = vscode.workspace
+            .getConfiguration()
+            .inspect<IDotnetAcquisitionExistingPaths[]>(dotnetAcquisitionExtensionOption);
+        expect(inspectAcquisitionPath?.globalValue).toBeDefined();
+        expect(inspectAcquisitionPath!.globalValue![0].path).toEqual('global' + validDotnetPath);
+
+        expect(inspectAcquisitionPath?.workspaceValue).toBeDefined();
+        expect(inspectAcquisitionPath!.workspaceValue![0].path).toEqual('workspace' + validDotnetPath);
+
+        expect(inspectAcquisitionPath?.workspaceFolderValue).toBeDefined();
+        expect(inspectAcquisitionPath!.workspaceFolderValue![0].path).toEqual('workspaceFolder' + validDotnetPath);
+    });
+
+    test(`dotnet.dotnetPath should migrate to omnisharp.dotnetPath when using O#`, async () => {
+        getVSCodeWithConfig(vscode);
+
+        vscode.workspace.getConfiguration().update(dotnetPathOption, validDotnetFolder);
+        vscode.workspace.getConfiguration().update('dotnet.server.useOmnisharp', true);
+
+        await MigrateOptions(vscode);
+
+        const updatedConfigurations = vscode.workspace.getConfiguration();
+        const acquisitionPath = updatedConfigurations.get<IDotnetAcquisitionExistingPaths[] | undefined>(
+            dotnetAcquisitionExtensionOption
+        );
+        expect(acquisitionPath).toBeUndefined();
+        expect(updatedConfigurations.get('omnisharp.dotnetPath')).toEqual(validDotnetFolder);
+        expect(updatedConfigurations.get(dotnetPathOption)).toBeUndefined();
     });
 });


### PR DESCRIPTION
This removes the `dotnet.dotnetPath` option and adds support for migrating it to the replacement setting (defined by the .NET install tool).

Resolves C# side of https://github.com/microsoft/vscode-dotnettools/issues/1243

Prior to this change, both `dotnet.dotnetPath` and the .NET Install Tool's `dotnetAcquisitionExtension.existingDotnetPath` setting both could influence the runtime that the server used.  It is unnecessary to support both of these options at this point, and only causes needless confusion.  

Here we delete `dotnet.dotnetPath` and migrate existing values to `dotnetAcquisitionExtension.existingDotnetPath`.  This should be unnoticeable in terms of behavior.  The migration is slightly more complicated than other settings as `dotnet.dotnetPath` required a folder containing the `dotnet` executable whereas the .NET install tool setting requires the actual executable path.

OmniSharp as not yet fully migrated over to the .NET install tool for .NET discovery, so O# users of `dotnet.dotnetPath` will be migrated to `omnisharp.dotnetPath`.



