### PR TITLE
Add razor completion integration test

### DIFF
--- a/test/razor/razorIntegrationTests/completion.integration.test.ts
+++ b/test/razor/razorIntegrationTests/completion.integration.test.ts
@@ -33,7 +33,7 @@ integrationHelpers.describeIfWindows(`Razor Completion ${testAssetWorkspace.desc
 
         const insertPosition = new vscode.Position(4, 4);
         await insertText(insertPosition, '<te');
-        const completionList = await getCompletionsAsync(new vscode.Position(4, 7), 'e');
+        const completionList = await getCompletionsAsync(new vscode.Position(4, 7), 'e', undefined);
         expect(completionList.items.length).toBeGreaterThan(0);
         const textTagCompletionItem = completionList.items.find((item) => item.label === 'text');
 
@@ -46,9 +46,38 @@ integrationHelpers.describeIfWindows(`Razor Completion ${testAssetWorkspace.desc
         expect(textTagCompletionItem!.insertText).toBe('text');
     });
 
+    test('Div Tag', async () => {
+        if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
+            return;
+        }
+
+        const insertPosition = new vscode.Position(6, 0);
+        await insertText(insertPosition, '<di');
+        const completionList = await getCompletionsAsync(new vscode.Position(6, 3), undefined, 10);
+        expect(completionList.items.length).toBeGreaterThan(0);
+        const divTagCompletionItem = completionList.items.find((item) => item.label === 'div');
+
+        if (!divTagCompletionItem) {
+            throw new Error(completionList.items.reduce((acc, item) => acc + item.label + '\n', ''));
+        }
+
+        expect(divTagCompletionItem).toBeDefined();
+
+        // Reader, you may be wondering why the kind is a Property. To that I say: I don't know.
+        // If you find out please add a detailed explanation. Thank you in advance.
+        expect(divTagCompletionItem!.kind).toEqual(vscode.CompletionItemKind.Property);
+        expect(divTagCompletionItem!.insertText).toBe('div');
+
+        const documentation = divTagCompletionItem!.documentation as vscode.MarkdownString;
+        expect(documentation.value).toBe(
+            'The div element has no special meaning at all. It represents its children. It can be used with the class, lang, and title attributes to mark up semantics common to a group of consecutive elements.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/HTML/Element/div)'
+        );
+    });
+
     async function getCompletionsAsync(
         position: vscode.Position,
-        triggerCharacter: string | undefined
+        triggerCharacter: string | undefined,
+        resolveCount: number | undefined
     ): Promise<vscode.CompletionList> {
         const activeEditor = vscode.window.activeTextEditor;
         if (!activeEditor) {
@@ -59,7 +88,8 @@ integrationHelpers.describeIfWindows(`Razor Completion ${testAssetWorkspace.desc
             'vscode.executeCompletionItemProvider',
             activeEditor.document.uri,
             position,
-            triggerCharacter
+            triggerCharacter,
+            resolveCount
         );
     }
 

--- a/test/razor/razorIntegrationTests/completion.integration.test.ts
+++ b/test/razor/razorIntegrationTests/completion.integration.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { beforeAll, afterAll, test, expect, beforeEach } from '@jest/globals';
+import testAssetWorkspace from './testAssets/testAssetWorkspace';
+import * as integrationHelpers from '../../lsptoolshost/integrationTests/integrationHelpers';
+
+integrationHelpers.describeIfWindows(`Razor Completion ${testAssetWorkspace.description}`, function () {
+    beforeAll(async function () {
+        if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
+            return;
+        }
+
+        await integrationHelpers.activateCSharpExtension();
+    });
+
+    beforeEach(async function () {
+        await integrationHelpers.openFileInWorkspaceAsync(path.join('Pages', 'Completion.razor'));
+    });
+
+    afterAll(async () => {
+        await testAssetWorkspace.cleanupWorkspace();
+    });
+
+    test('Text Tag', async () => {
+        if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
+            return;
+        }
+
+        const completionList = await getCompletionsAsync(new vscode.Position(4, 7), 'e');
+        expect(completionList.items.length).toBeGreaterThan(0);
+        const textTagCompletionItem = completionList.items.find((item) => item.label === 'text');
+
+        if (!textTagCompletionItem) {
+            throw new Error(completionList.items.reduce((acc, item) => acc + item.label + '\n', ''));
+        }
+
+        expect(textTagCompletionItem).toBeDefined();
+        expect(textTagCompletionItem!.kind).toEqual(vscode.CompletionItemKind.Text);
+        expect(textTagCompletionItem!.insertText).toBe('text');
+    });
+
+    async function getCompletionsAsync(
+        position: vscode.Position,
+        triggerCharacter: string | undefined
+    ): Promise<vscode.CompletionList> {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (!activeEditor) {
+            throw new Error('No active editor');
+        }
+
+        return await vscode.commands.executeCommand(
+            'vscode.executeCompletionItemProvider',
+            activeEditor.document.uri,
+            position,
+            triggerCharacter
+        );
+    }
+});

--- a/test/razor/razorIntegrationTests/completion.integration.test.ts
+++ b/test/razor/razorIntegrationTests/completion.integration.test.ts
@@ -31,6 +31,8 @@ integrationHelpers.describeIfWindows(`Razor Completion ${testAssetWorkspace.desc
             return;
         }
 
+        const insertPosition = new vscode.Position(4, 4);
+        await insertText(insertPosition, '<te');
         const completionList = await getCompletionsAsync(new vscode.Position(4, 7), 'e');
         expect(completionList.items.length).toBeGreaterThan(0);
         const textTagCompletionItem = completionList.items.find((item) => item.label === 'text');
@@ -59,5 +61,16 @@ integrationHelpers.describeIfWindows(`Razor Completion ${testAssetWorkspace.desc
             position,
             triggerCharacter
         );
+    }
+
+    async function insertText(position: vscode.Position, text: string): Promise<void> {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (!activeEditor) {
+            throw new Error('No active editor');
+        }
+
+        await activeEditor.edit((builder) => {
+            builder.insert(position, text);
+        });
     }
 });

--- a/test/razor/razorIntegrationTests/testAssets/RazorApp/Pages/Completion.razor
+++ b/test/razor/razorIntegrationTests/testAssets/RazorApp/Pages/Completion.razor
@@ -1,0 +1,10 @@
+@page "/completion"
+
+@* Insert text tag in below using completion *@
+@{
+    <te
+}
+
+@code {
+
+}

--- a/test/razor/razorIntegrationTests/testAssets/RazorApp/Pages/Completion.razor
+++ b/test/razor/razorIntegrationTests/testAssets/RazorApp/Pages/Completion.razor
@@ -2,7 +2,7 @@
 
 @* Insert text tag in below using completion *@
 @{
-    <te
+    
 }
 
 @code {


### PR DESCRIPTION
Completes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1861421 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1861422

Adds a test for `<text>` and `<div>` completion and sets up scaffolding for other completion tests.
