### PR TITLE
respect csharp.debug.console in all cases

### DIFF
--- a/src/razor/src/blazorDebug/blazorDebugConfigurationProvider.ts
+++ b/src/razor/src/blazorDebug/blazorDebugConfigurationProvider.ts
@@ -80,6 +80,7 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
         const program = configuration.hosted ? configuration.program : 'dotnet';
         const cwd = configuration.cwd || '${workspaceFolder}';
         const args = configuration.hosted ? [] : ['run'];
+        const console = configuration.console;
 
         const app = {
             name: SERVER_APP_NAME,
@@ -96,6 +97,7 @@ export class BlazorDebugConfigurationProvider implements vscode.DebugConfigurati
             launchBrowser: {
                 enabled: false,
             },
+            console: console,
             ...configuration.dotNetConfig,
         };
 

--- a/src/shared/assets.ts
+++ b/src/shared/assets.ts
@@ -173,7 +173,7 @@ export class AssetGenerator {
                     }
 
                     // Override console option with user option.
-                    if (forDotnetConfiguration && programLaunchType === ProgramLaunchType.Console && key == 'console') {
+                    if (forDotnetConfiguration && key == 'console') {
                         const consoleOption: string | undefined = AssetGenerator.getConsoleDebugOption();
                         if (consoleOption) {
                             configuration.console = consoleOption;
@@ -370,6 +370,7 @@ export function createWebLaunchConfiguration(programPath: string, workingDirecto
         program: `${util.convertNativePathToPosix(programPath)}`,
         args: Array(0),
         cwd: `${util.convertNativePathToPosix(workingDirectory)}`,
+        console: 'internalConsole',
         stopAtEntry: false,
         'OS-COMMENT5': vscode.l10n.t(
             'Enable launching a web browser when ASP.NET Core starts. For more information: {0}',
@@ -402,6 +403,7 @@ export function createBlazorWebAssemblyHostedLaunchConfiguration(
         'OS-COMMENT1': vscode.l10n.t('If you have changed target frameworks, make sure to update the program path.'),
         program: `${util.convertNativePathToPosix(programPath)}`,
         cwd: `${util.convertNativePathToPosix(workingDirectory)}`,
+        console: 'internalConsole',
     };
 
     return JSON.stringify(configuration);
@@ -413,6 +415,7 @@ export function createBlazorWebAssemblyStandaloneLaunchConfiguration(workingDire
         type: 'blazorwasm',
         request: 'launch',
         cwd: `${util.convertNativePathToPosix(workingDirectory)}`,
+        console: 'internalConsole',
     };
 
     return JSON.stringify(configuration);


### PR DESCRIPTION
Please see issue https://github.com/microsoft/vscode-dotnettools/issues/1473 for more info.

The [documentation](https://code.visualstudio.com/docs/csharp/debugger-settings#_console-terminal-window) doesn't say that `"csharp.debug.console": "externalTerminal"` is only valid for Console Apps.

I've created this PR to fix the issue of `"csharp.debug.console": "externalTerminal"` being silently ignored in many cases when combined with `"type":"dotnet"`.

This was previously working as expected with  `"type": "coreclr"`.  