### PR TITLE
Use 1ES releaseJob in release.yml

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -67,26 +67,25 @@ jobs:
       env:
         SignType: $(signType)
 
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/vsix'
+      TargetFolder: '$(Build.SourcesDirectory)/Packages/VSIX_$(channel)'
+
+  - task: 1ES.PublishBuildArtifacts@1
+    condition: succeeded()
+    displayName: 'Publish VSIXs'
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)/Packages'
+      ArtifactName: 'Packages'
+
   - ${{ if eq(parameters.isOfficial, true) }}:
-    - task: 1ES.PublishBuildArtifacts@1
-      condition: succeeded()
-      displayName: 'Publish VSIXs'
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/vsix'
-        ArtifactName: 'VSIX_$(channel)'
     - task: 1ES.PublishBuildArtifacts@1
       condition: succeededOrFailed()
       displayName: 'Publish Signing Logs'
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)/out/logs'
         ArtifactName: '${{ parameters.platform }} Signing Logs'
-  - ${{ else }}:
-    - task: PublishBuildArtifacts@1
-      condition: succeeded()
-      displayName: 'Publish VSIXs'
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/vsix'
-        ArtifactName: 'VSIX_$(channel)'
 
   - script: npm run test:artifacts
     displayName: 'Run artifacts tests'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -72,20 +72,27 @@ jobs:
       SourceFolder: '$(Build.SourcesDirectory)/vsix'
       TargetFolder: '$(Build.SourcesDirectory)/Packages/VSIX_$(channel)'
 
-  - task: 1ES.PublishBuildArtifacts@1
-    condition: succeeded()
-    displayName: 'Publish VSIXs'
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)/Packages'
-      ArtifactName: 'Packages'
-
   - ${{ if eq(parameters.isOfficial, true) }}:
+    - task: 1ES.PublishBuildArtifacts@1
+      condition: succeeded()
+      displayName: 'Publish VSIXs'
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/Packages'
+        ArtifactName: 'Packages'
     - task: 1ES.PublishBuildArtifacts@1
       condition: succeededOrFailed()
       displayName: 'Publish Signing Logs'
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)/out/logs'
         ArtifactName: '${{ parameters.platform }} Signing Logs'
+
+  - ${{ else }}:
+    - task: PublishBuildArtifacts@1
+      condition: succeeded()
+      displayName: 'Publish VSIXs'
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/Packages'
+        ArtifactName: 'Packages'
 
   - script: npm run test:artifacts
     displayName: 'Run artifacts tests'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -39,20 +39,17 @@ extends:
           name: netcore1espool-internal
           image: 1es-ubuntu-2204
           os: linux
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            pipeline: officialBuildCI
+            destinationPath: $(Pipeline.Workspace)
         strategy:
           runOnce:
             deploy:
               steps:
-              - download: 'none'
-              - task: DownloadPipelineArtifact@2
-                displayName: '📦 Download artifacts from build pipeline.'
-                inputs:
-                  buildType: 'specific'
-                  project: 'internal'
-                  definition: 1264
-                  buildVersionToDownload: 'specific'
-                  buildId: '$(resources.pipeline.officialBuildCI.runID)'
-                  branchName: '$(resources.pipeline.officialBuildCI.sourceBranch)'
               - template: /azure-pipelines/install-node.yml@self
               - pwsh: |
                   npm install --global @vscode/vsce

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -45,6 +45,7 @@ extends:
           inputs:
           - input: pipelineArtifact
             pipeline: officialBuildCI
+            artifactName: Packages
             destinationPath: $(Pipeline.Workspace)
         strategy:
           runOnce:


### PR DESCRIPTION
Instead of publishing a VSIX_Release or VSIX_Prerelease artifact we will now always publish a Packages artifact containing either a VSIX_Release or VSIX_Prerelease folder.

Test [Build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2619807&view=results) and [Release](https://dev.azure.com/dnceng/internal/_build/results?buildId=2619842&view=results)