### PR TITLE
Bump Razor and Roslyn and tweak Razor feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,22 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.63.x
-* Update Roslyn to ...
-* Update Razor to 9.0.0-preview.25064.4
+* Update Roslyn to 4.14.0-1.25065.8 (PR: [#7927](https://github.com/dotnet/vscode-csharp/pull/7927))
+  * Remove explicit recursion in the json detection analyzer (#76764) (PR: [#76764](https://github.com/dotnet/roslyn/pull/76764))
+  * Consider silly cyclic assignment in scoped variance (#76261) (PR: [#76261](https://github.com/dotnet/roslyn/pull/76261))
+  * Fix ordering of 'params' vs 'scoped' in metadata as source (#76745) (PR: [#76745](https://github.com/dotnet/roslyn/pull/76745))
+  * Change partial keyword recommender to better handle partial member syntax (#76744) (PR: [#76744](https://github.com/dotnet/roslyn/pull/76744))
+  * Ensure unconverted elements are converted when on LHS (#76675) (PR: [#76675](https://github.com/dotnet/roslyn/pull/76675))
+  * Proffer CssVisualDiagnosticsService brokered service from C# DevKit to C# Extension (#76737) (PR: [#76737](https://github.com/dotnet/roslyn/pull/76737))
+  * Disable extract class/interface to a new file when unsupported by the workspace. (#76717) (PR: [#76717](https://github.com/dotnet/roslyn/pull/76717))
+  * Fix issue parsing regex category (#76735) (PR: [#76735](https://github.com/dotnet/roslyn/pull/76735))
+  * Properly simplify pattern when converting to pattern matching (#76734) (PR: [#76734](https://github.com/dotnet/roslyn/pull/76734))
+  * Do not lift type parameters in extract method declared within the selected region (#76724) (PR: [#76724](https://github.com/dotnet/roslyn/pull/76724))
+  * Always use .OriginalDefinition uniformly in the unread-members analyzer (#76698) (PR: [#76698](https://github.com/dotnet/roslyn/pull/76698))
+  * Adding checks for mutable structs. (#76711) (PR: [#76711](https://github.com/dotnet/roslyn/pull/76711))
+  * Stash and restore original culture in CultureNormalizer (#76713) (PR: [#76713](https://github.com/dotnet/roslyn/pull/76713))
+  * Add option for choosing stdio as the LSP communication channel (#76437) (PR: [#76437](https://github.com/dotnet/roslyn/pull/76437))
+* Update Razor to 9.0.0-preview.25064.4 (PR: [#7927](https://github.com/dotnet/vscode-csharp/pull/7927))
   * Wire up the UseRoslynTokenizer feature properly (#11386) (PR: [#11386](https://github.com/dotnet/razor/pull/11386))
   * New Razor document formatting engine (#11364) (PR: [#11364](https://github.com/dotnet/razor/pull/11364))
   * Fix a couple of exceptions encountered when formatting documents with preprocessor directives (#11373) (PR: [#11373](https://github.com/dotnet/razor/pull/11373))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.63.x
+* Update Roslyn to ...
+* Update Razor to 9.0.0-preview.25064.4
+  * Wire up the UseRoslynTokenizer feature properly (#11386) (PR: [#11386](https://github.com/dotnet/razor/pull/11386))
+  * New Razor document formatting engine (#11364) (PR: [#11364](https://github.com/dotnet/razor/pull/11364))
+  * Fix a couple of exceptions encountered when formatting documents with preprocessor directives (#11373) (PR: [#11373](https://github.com/dotnet/razor/pull/11373))
+  * Allow RazorProjectEngine.Process to be cancelled (#11334) (PR: [#11334](https://github.com/dotnet/razor/pull/11334))
+  * Further refactoring of Razor tooling project system (#11320) (PR: [#11320](https://github.com/dotnet/razor/pull/11320))
 
 # 2.62.x
 * Update Roslyn to 4.14.0-1.25060.2 (PR: [#7916](https://github.com/dotnet/vscode-csharp/pull/7916))

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "defaults": {
-    "roslyn": "4.14.0-1.25060.2",
+    "roslyn": "4.14.0-1.25065.8",
     "omniSharp": "1.39.12",
     "razor": "9.0.0-preview.25064.4",
     "razorOmnisharp": "7.0.0-preview.23363.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "defaults": {
     "roslyn": "4.14.0-1.25060.2",
     "omniSharp": "1.39.12",
-    "razor": "9.0.0-preview.25052.3",
+    "razor": "9.0.0-preview.25064.4",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.13.35709.178"
   },

--- a/package.json
+++ b/package.json
@@ -1513,17 +1513,15 @@
             "description": "%configuration.razor.languageServer.forceRuntimeCodeGeneration%",
             "order": 90
           },
-          "razor.languageServer.useRoslynTokenizer": {
-            "type": "boolean",
-            "scope": "machine-overridable",
-            "default": false,
-            "markdownDescription": "%configuration.razor.languageServer.useRoslynTokenizer%",
-            "order": 90
-          },
           "razor.languageServer.suppressLspErrorToasts": {
             "type": "boolean",
             "default": true,
             "description": "%configuration.razor.languageServer.suppressLspErrorToasts%"
+          },
+          "razor.languageServer.useNewFormattingEngine": {
+            "type": "boolean",
+            "default": true,
+            "description": "%configuration.razor.languageServer.useNewFormattingEngine%"
           }
         }
       },

--- a/package.nls.json
+++ b/package.nls.json
@@ -128,13 +128,8 @@
   "configuration.razor.languageServer.debug": "Specifies whether to wait for debug attach when launching the language server.",
   "configuration.razor.server.trace": "Specifies the logging level to use for the Razor server.",
   "configuration.razor.languageServer.forceRuntimeCodeGeneration": "(EXPERIMENTAL) Enable combined design time/runtime code generation for Razor files",
-  "configuration.razor.languageServer.useRoslynTokenizer": {
-    "message": "(EXPERIMENTAL) Use the C# tokenizer for Razor files in the IDE. Enables some new C# features, like interpolated and raw strings, in Razor files opened in Visual Studio Code. This matches using `<features>use-roslyn-tokenizer</feature>` in a `.csproj` file for command line builds, and may result in inconsistencies if this option and your project files do not match.",
-    "comment": [
-      "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
-    ]
-  },
   "configuration.razor.languageServer.suppressLspErrorToasts": "Suppresses error toasts from showing up if the server encounters a recoverable error.",
+  "configuration.razor.languageServer.useNewFormattingEngine": "Use the new Razor formatting engine.",
   "debuggers.coreclr.configurationSnippets.label.console-local": ".NET: Launch Executable file (Console)",
   "debuggers.coreclr.configurationSnippets.label.web-local": ".NET: Launch Executable file (Web)",
   "debuggers.coreclr.configurationSnippets.label.attach-local": ".NET: Attach to a .NET process",

--- a/src/razor/src/razorLanguageServerClient.ts
+++ b/src/razor/src/razorLanguageServerClient.ts
@@ -267,8 +267,8 @@ export class RazorLanguageServerClient implements vscode.Disposable {
                 args.push('true');
             }
 
-            if (options.useRoslynTokenizer) {
-                args.push('--UseRoslynTokenizer');
+            if (options.useNewFormattingEngine) {
+                args.push('--UseNewFormattingEngine');
                 args.push('true');
             }
 

--- a/src/razor/src/razorLanguageServerOptions.ts
+++ b/src/razor/src/razorLanguageServerOptions.ts
@@ -11,6 +11,6 @@ export interface RazorLanguageServerOptions {
     debug?: boolean;
     usingOmniSharp: boolean;
     forceRuntimeCodeGeneration: boolean;
-    useRoslynTokenizer: boolean;
     suppressErrorToasts: boolean;
+    useNewFormattingEngine: boolean;
 }

--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -35,8 +35,8 @@ export function resolveRazorLanguageServerOptions(
         forceRuntimeCodeGeneration = hotReload;
     }
 
-    const useRoslynTokenizer = serverConfig.get<boolean>('useRoslynTokenizer');
     const suppressErrorToasts = serverConfig.get<boolean>('suppressLspErrorToasts');
+    const useNewFormattingEngine = serverConfig.get<boolean>('useNewFormattingEngine');
 
     return {
         serverPath: languageServerExecutablePath,
@@ -44,8 +44,8 @@ export function resolveRazorLanguageServerOptions(
         outputChannel: logger.outputChannel,
         usingOmniSharp,
         forceRuntimeCodeGeneration,
-        useRoslynTokenizer,
         suppressErrorToasts,
+        useNewFormattingEngine,
     } as RazorLanguageServerOptions;
 }
 


### PR DESCRIPTION
Hi,

This PR bumps Razor because of a serialization change (from https://github.com/dotnet/razor/pull/11386), bumps Roslyn to carry that serialization change (from https://github.com/dotnet/roslyn/pull/76755) and tweaks some feature flags in Razor.

Enjoy!

Thanks,
Dave

Razor changes: [View Complete Diff of Changes](https://github.com/dotnet/razor/compare/dd64bf78c16a7e8fa1900da060100e9338383dea...e076a7b300ad846caa80d5d4533c2afdf121ecd1?w=1)