### PR TITLE
Fix overly aggressive html completion

### DIFF
--- a/src/razor/src/completion/completionHandler.ts
+++ b/src/razor/src/completion/completionHandler.ts
@@ -377,7 +377,7 @@ export class CompletionHandler {
         projectedPosition: Position,
         triggerCharacter: string | undefined
     ) {
-        // The following characters are defnied as trigger characters in Razor language server,
+        // The following characters are defined as trigger characters in Razor language server,
         // but are not normally trigger characters for VS Code HTML language server. We will
         // explicitely ignore them to avoid unexpected completion coming up. VS HTML language server
         // simply returns nothign when completion is not appropriate. VS Code HTML completion is much

--- a/src/razor/src/completion/completionHandler.ts
+++ b/src/razor/src/completion/completionHandler.ts
@@ -377,6 +377,36 @@ export class CompletionHandler {
         projectedPosition: Position,
         triggerCharacter: string | undefined
     ) {
+        // The following characters are defnied as trigger characters in Razor language server,
+        // but are not normally trigger characters for VS Code HTML language server. We will
+        // explicitely ignore them to avoid unexpected completion coming up. VS HTML language server
+        // simply returns nothign when completion is not appropriate. VS Code HTML completion is much
+        // more aggressive and will always put "someting" (e.g. all words in the document) into the
+        // completion list whenever asked for one.
+        const ignorableTriggerCharacters = new Set<string>([
+            ' ',
+            '(',
+            '=',
+            '[',
+            '{',
+            '"',
+            '/',
+            '\\',
+            ':',
+            '~',
+            '*',
+            ',',
+            '-',
+            '&',
+            "'",
+            '"',
+            '`',
+        ]);
+
+        if (triggerCharacter && ignorableTriggerCharacters.has(triggerCharacter)) {
+            return CompletionHandler.emptyCompletionList;
+        }
+
         const completions = await vscode.commands.executeCommand<vscode.CompletionList | vscode.CompletionItem[]>(
             'vscode.executeCompletionItemProvider',
             virtualDocumentUri,


### PR DESCRIPTION
After we switched to the new Razor completion endpoint, we made a larger set of trigger characters available in VS Code Razor pages. They are needed in VS to maintain VS HTML completion trigger behavior, but they cause unnecessary completion lists with unfiltered entries (e.g. all words in the document) pop-up whenever those trigger characters are typed anywhere in the document.

In this PR I'm adding a simple fix to suppress those characters in VS Code HTML context (while leaving them enabled for C#). This should eliminate overly aggressive completion list behavior on typing.

There will be a separate fix for the case when wrong completion entries could get inserted (e.g. ```@...``` could get inserted when ```/``` is typed). 

Fixes:
https://github.com/dotnet/vscode-csharp/issues/7678
https://github.com/dotnet/vscode-csharp/issues/7871