### PR TITLE
Use .NET8 and .NET9 for CI tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,21 +45,6 @@ stages:
     dotnetVersion: $(defaultDotnetVersion)
 
 - stage:
-  displayName: Test Linux (.NET 6)
-  dependsOn: []
-  jobs:
-  - template: azure-pipelines/test-matrix.yml
-    parameters:
-      # Prefer the dotnet from the container.
-      dotnetVersion: ''
-      testVSCodeVersion: $(testVSCodeVersion)
-      installAdditionalLinuxDependencies: true
-      pool:
-        name: NetCore-Public
-        demands: ImageOverride -equals 1es-ubuntu-2004-open
-      containerName: mcr.microsoft.com/dotnet/sdk:6.0
-
-- stage:
   displayName: Test Linux (.NET 8)
   dependsOn: []
   jobs:
@@ -73,6 +58,21 @@ stages:
         name: NetCore-Public
         demands: ImageOverride -equals 1es-ubuntu-2004-open
       containerName: mcr.microsoft.com/dotnet/sdk:8.0
+
+- stage:
+  displayName: Test Linux (.NET 9)
+  dependsOn: []
+  jobs:
+  - template: azure-pipelines/test-matrix.yml
+    parameters:
+      # Prefer the dotnet from the container.
+      dotnetVersion: ''
+      testVSCodeVersion: $(testVSCodeVersion)
+      installAdditionalLinuxDependencies: true
+      pool:
+        name: NetCore-Public
+        demands: ImageOverride -equals 1es-ubuntu-2004-open
+      containerName: mcr.microsoft.com/dotnet/sdk:9.0
 
 - stage: Test_Windows_Stage
   displayName: Test Windows


### PR DESCRIPTION
.NET6 is out of support