### PR TITLE
Sync whitespace options even when detectIndentation is on

### DIFF
--- a/src/lsptoolshost/universalEditorConfigProvider.ts
+++ b/src/lsptoolshost/universalEditorConfigProvider.ts
@@ -29,11 +29,11 @@ export function readEquivalentVsCodeConfiguration(serverSideOptionName: string):
 }
 
 function readTabSize(configuration: WorkspaceConfiguration): string {
-    return readValueIfDetectIndentationIsOff(configuration, 'editor.tabSize', '4');
+    return readVsCodeConfigurations<string>(configuration, 'editor.tabSize');
 }
 
 function readIndentSize(configuration: WorkspaceConfiguration): string {
-    const indentSize = readValueIfDetectIndentationIsOff<string>(configuration, 'editor.indentSize', '4');
+    const indentSize = readVsCodeConfigurations<string>(configuration, 'editor.indentSize');
     // indent size could be a number or 'tabSize'. If it is 'tabSize', read the 'tabSize' section from config.
     if (indentSize == 'tabSize') {
         return readTabSize(configuration);
@@ -43,7 +43,7 @@ function readIndentSize(configuration: WorkspaceConfiguration): string {
 }
 
 function readInsertSpaces(configuration: WorkspaceConfiguration): string {
-    const insertSpace = readValueIfDetectIndentationIsOff<boolean>(configuration, 'editor.insertSpaces', true);
+    const insertSpace = readVsCodeConfigurations<boolean>(configuration, 'editor.insertSpaces');
     return insertSpace ? 'space' : 'tab';
 }
 
@@ -60,21 +60,6 @@ function readEol(configuration: WorkspaceConfiguration): string {
 
 function readInsertFinalNewline(configuration: WorkspaceConfiguration): string {
     return readVsCodeConfigurations<string>(configuration, 'files.insertFinalNewline');
-}
-
-function readValueIfDetectIndentationIsOff<T>(
-    configuration: WorkspaceConfiguration,
-    vscodeConfigName: string,
-    defaultValue: T
-): T {
-    // If detectIndentation is on, tabSize, indentSize and insertSpaces would be overridden by vscode based on the file's content.
-    // The values in settings become meaningless, so ask the server to fall back to default value.
-    // TODO: Both 'editor.detectIndentation' and.editorconfig provided the same functions here, we need to find a graceful way to handle them.
-    if (configuration.get<boolean>('editor.detectIndentation')) {
-        return defaultValue;
-    }
-
-    return readVsCodeConfigurations(configuration, vscodeConfigName);
 }
 
 function readVsCodeConfigurations<T>(configuration: WorkspaceConfiguration, vscodeConfigName: string): T {


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/7963
Resolves https://github.com/dotnet/vscode-csharp/issues/6244
Resolves https://github.com/microsoft/vscode-dotnettools/issues/1651

Previously, we would completely ignore the values of tabSize/indentSize/insertSpaces when `editor.detectIndentation` was enabled (which it is by default).  Instead, a hardcoded value would be sent to the server.

Normally this isn't super noticeable - features like formatting pass the settings specific to that document (based on the detection) when invoking the language server.  However some features like code actions do not specify these options, and so the code would only ever be generated with the hardcoded defaults.

This PR updates it so that we now use the user's settings instead of a hardcoded default even when `editor.detectIndentation` is enabled.  (Note - .editorconfig values still override the user setting as normal).

There is still a caveat here however - we are not using the real detected indentation.  So it is still possible that we generate code that does not match the rest of the document's formatting (because the detected indentation does not match the user's setting). 
 At some point I need to investigate if it is possible to sync the detected per document formatting settings over to the server (so code actions use the detected indentation).

![spaces_with_detect_indentation](https://github.com/user-attachments/assets/809de614-f018-4473-9b8e-257a31783bc7)
