### PR TITLE
Update the debugger to 2.66.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -423,7 +423,7 @@
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-win7-x64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-win7-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "win32"
@@ -433,12 +433,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui.exe",
-      "integrity": "BFA8E3298DAFE59213BA2FD9938031B7A41A354415274E8238BB49D9E9381E66"
+      "integrity": "5338B2FE4D94D834EEC9765A0AAB108ED6F4E122993FF08F1050251EF8C08B97"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-win10-arm64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-win10-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "win32"
@@ -447,12 +447,12 @@
         "arm64"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui.exe",
-      "integrity": "299DA0ABD00CD61AA1A6293A3C103CCF3070844E4B667C2811A3AAC16D7E6E44"
+      "integrity": "10C6BEF03C9EE4BE2DD5BB7D318E36E4008AD09EA72865AB3C539BD8F97E1DD3"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-osx-x64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-osx-x64.zip",
       "installPath": ".debugger/x86_64",
       "platforms": [
         "darwin"
@@ -466,12 +466,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/x86_64/vsdbg-ui",
-      "integrity": "5DF02935DFFD453E8C947AFC7567F4199D4BD83F582EBB20ECD23C054F8A43E2"
+      "integrity": "38EBE099481ECBACE220A9F775D5E069DAF99B1469F25AC64FFB3CCA4A2537B3"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (macOS / arm64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-osx-arm64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-osx-arm64.zip",
       "installPath": ".debugger/arm64",
       "platforms": [
         "darwin"
@@ -484,12 +484,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/arm64/vsdbg-ui",
-      "integrity": "1CBC75E00B7CE32DBD2617AC59EE10A4FE1DBB5AEA6E6A94224F50DEC3C96D3E"
+      "integrity": "2F332163AEE26B4081F362CFF1F543F57FB2923E578952F0DD69CF827E03BE70"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-linux-arm.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-linux-arm.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -502,12 +502,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "AE7B3967783B87448BAC4C78074B1D6F6AD4B70981FBB202CC9150A46405D287"
+      "integrity": "44B74BE4995A5AD31293BB9EC578799268E4409EBBFB7424A1A58FEE7E6A2283"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-linux-arm64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-linux-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -520,12 +520,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "468C4577B8E131E47CE83C7A290DA41580C6D327B43308CA8B206D068057CCD0"
+      "integrity": "0A9A32E2E14BFF90B80EC98BA631D27E8B1847C5BF79E8E9A7206439D68D970B"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-linux-musl-x64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-linux-musl-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -538,12 +538,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "B097E8D5C87B445399829DCDC32C387121E81F6F79001715645B620FC8EFD087"
+      "integrity": "423E27BDE8D2DE97261B893CD7B0C78FED94EBF352A672F56BFA2E09D598BEF0"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux musl / ARM64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-linux-musl-arm64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-linux-musl-arm64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux-musl"
@@ -556,12 +556,12 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "02CBCBD53377ECDFD68671D216A7CD2631CF22C60CFA66F5361A919F915D0B19"
+      "integrity": "684B77F7B0A38D2AC7F24DA2682AF53435EC6EA252F694D830D86A47688DE26F"
     },
     {
       "id": "Debugger",
       "description": ".NET Core Debugger (linux / x64)",
-      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-60-0/coreclr-debug-linux-x64.zip",
+      "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-66-0/coreclr-debug-linux-x64.zip",
       "installPath": ".debugger",
       "platforms": [
         "linux"
@@ -574,7 +574,7 @@
         "./vsdbg"
       ],
       "installTestPath": "./.debugger/vsdbg-ui",
-      "integrity": "1710E20F9A7BD4F10A126B86D8F3F9F6C2859B7A7EA2E6BACCE7029ACDA57DFB"
+      "integrity": "BFBBB9BCBB7804963C6698B757942C484744CE2DBE5B2610DC7FA69D216B6E98"
     },
     {
       "id": "RazorOmnisharp",


### PR DESCRIPTION
This PR updates the debugger to the 2.66.0 release, which includes various bug fixes that shipped with Visual Studio 2022 version 17.13.