### PR TITLE
Fix the regular expression to read RID value.

### DIFF
--- a/src/shared/utils/getDotnetInfo.ts
+++ b/src/shared/utils/getDotnetInfo.ts
@@ -62,7 +62,7 @@ async function parseDotnetInfo(dotnetInfo: string, dotnetExecutablePath: string 
             let match: RegExpMatchArray | null;
             if ((match = /^\s*Version:\s*([^\s].*)$/.exec(line))) {
                 version = match[1];
-            } else if ((match = /^ RID:\s*([\w\-.]+)$/.exec(line))) {
+            } else if ((match = /^\s*RID:\s*([\w\-.]+)$/.exec(line))) {
                 runtimeId = match[1];
             } else if ((match = /^\s*Architecture:\s*(.*)/.exec(line))) {
                 architecture = match[1];


### PR DESCRIPTION
The dotnet --info may have a single or double space character at the beginning of the RID information line. The current regular expression fails in one of them.

It matches how Version/Architecture is extracted.