### PR TITLE
Report when the client LSP is fully initialized

### DIFF
--- a/src/lsptoolshost/server/roslynLanguageServer.ts
+++ b/src/lsptoolshost/server/roslynLanguageServer.ts
@@ -183,6 +183,7 @@ export class RoslynLanguageServer {
                     state: ServerState.Started,
                     workspaceLabel: this.workspaceDisplayName(),
                 });
+                this._telemetryReporter.sendTelemetryEvent(TelemetryEventNames.ClientServerReady);
             } else if (state.newState === State.Stopped) {
                 this._languageServerEvents.onServerStateChangeEmitter.fire({
                     state: ServerState.Stopped,
@@ -338,7 +339,7 @@ export class RoslynLanguageServer {
      * Returns whether or not the underlying LSP server is running or not.
      */
     public isRunning(): boolean {
-        return this._languageClient.state === State.Running;
+        return this._languageClient.isRunning();
     }
 
     /**

--- a/src/shared/telemetryEventNames.ts
+++ b/src/shared/telemetryEventNames.ts
@@ -11,9 +11,17 @@ export enum TelemetryEventNames {
     CSharpActivated = 'CSharpActivated',
 
     // Events related to the roslyn language server.
+
+    // Roslyn client has started initialization process.
     ClientInitialize = 'roslyn/clientInitialize',
+    // Roslyn client has started the server initialization process.
     ClientServerStart = 'roslyn/clientServerInitialize',
+    // Roslyn client has acquired the runtime needed to start the server.
     AcquiredRuntime = 'roslyn/acquiredRuntime',
+    // Roslyn client has successfully started the server process.
     LaunchedServer = 'roslyn/launchedServer',
+    // Roslyn client has connected to the server process named pipe.
     ClientConnected = 'roslyn/clientConnected',
+    // Roslyn client and server have fully initialized via LSP.
+    ClientServerReady = 'roslyn/clientServerReady',
 }


### PR DESCRIPTION
Seeing a dropoff between the client reporting the server process started, and the server process reporting that it started.  My hypothesis is that there is some issue reporting telemetry on the server side rather than failures to initialize the server.

To verify, report on the client side when full LSP initialization is complete to compare with the server LSP initialization reports.
