### PR TITLE
Delay server start if nothing opened to avoid blocking devkit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,8 @@ export async function activate(
     const installDependencies: IInstallDependencies = async (dependencies: AbsolutePathPackage[]) =>
         downloadAndInstallPackages(dependencies, networkSettingsProvider, eventStream, isValidDownload);
 
+    // Fine to do this as part of activate as it is always a no-op in Roslyn mode (the debugger and Razor are shipped in-box)
+    // Only actually downloads files in O# mode or local development.
     const runtimeDependenciesExist = await installRuntimeDependencies(
         context.extension.packageJSON,
         context.extension.extensionPath,


### PR DESCRIPTION
Previously, we have attempted to be good citizens of activation by only activating on specific relevant events, and not blocking activation on the server process starting.

However - when Dev Kit is causing us to activate in order to provide the new project command, we end up taking extension host main thread resources away by trying to start the server, delaying the dialog from showing up.  Typically, in the new project scenario we cannot provide anything useful anyway - most often there is no workspace and no open files.  The request is on us to avoid as much work as possible until we detect something actionable.

The change in this PR delays server startup until a workspace is opened or a c# file exists.