### PR TITLE
Bump Razor to 9.0.0-preview.25125.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.68.x
+* Update Razor to 9.0.0-preview.25125.9 (PR: [#8027](https://github.com/dotnet/vscode-csharp/pull/8027))
+  * Don't send invalid ranges for diagnostics if they do not map (#11555) (PR: [#11555](https://github.com/dotnet/razor/pull/11555))
+  * Fix file path service, and integration tests (#11556) (PR: [#11556](https://github.com/dotnet/razor/pull/11556))
+  * Add ParserOptions and CodeGenerationOptions properties to RazorCodeDocument and rationalize options configuration (#11526) (PR: [#11526](https://github.com/dotnet/razor/pull/11526))
+  * Fix parsing of quotes in attribute names (#11543) (PR: [#11543](https://github.com/dotnet/razor/pull/11543))
 
 # 2.67.x
 * Bump xamlTools to 17.14.35821.62 (PR: [#8001](https://github.com/dotnet/vscode-csharp/pull/8001))

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "defaults": {
     "roslyn": "4.14.0-2.25120.5",
     "omniSharp": "1.39.12",
-    "razor": "9.0.0-preview.25121.2",
+    "razor": "9.0.0-preview.25125.9",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.35821.62"
   },


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/82bb05d0f43e11b7068addd9c0762b3372580c1f...0184787f9c22a83848ebd40d9a3bcf5f92943ce6?w=1)

@phil-allen-msft @ryzngard this build doesn't pass symbol check, but I'm working on the assumption that the diagnostics fix is more important, and that the C# extension build pipeline won't complain, but please confirm whether that's the way to go, or if we should wait for the symbol issue to be solved.