### PR TITLE
Only publish cpuprofile logs for integration tests.

### DIFF
--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -34,4 +34,4 @@ jobs:
       installAdditionalLinuxDependencies: ${{ parameters.installAdditionalLinuxDependencies }}
       npmCommand: $(npmCommand)
       testVSCodeVersion: ${{ parameters.testVSCodeVersion }}
-      isIntegrationTest: $[ eq(startsWith(variables.npmCommand, 'test:integration'), true) ]
+      isIntegrationTest: ${{ startsWith(variables.npmCommand, 'test:integration') }}

--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -31,6 +31,7 @@ jobs:
   - template: /azure-pipelines/test.yml@self
     parameters:
       dotnetVersion: ${{ parameters.dotnetVersion }}
-      installAdditionalLinuxDependencies: true
+      installAdditionalLinuxDependencies: ${{ parameters.installAdditionalLinuxDependencies }}
       npmCommand: $(npmCommand)
       testVSCodeVersion: ${{ parameters.testVSCodeVersion }}
+      isIntegrationTest: $[ startsWith(variables.npmCommand, 'test:integration') ]

--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -18,12 +18,16 @@ jobs:
     matrix:
       UnitTests:
         npmCommand: test:unit
+        integration: false
       CSharpIntegrationTests:
         npmCommand: test:integration:csharp
+        integration: true
       DevKitTests:
         npmCommand: test:integration:devkit
+        integration: true
       RazorTests:
         npmCommand: test:integration:razor
+        integration: true
   pool: ${{ parameters.pool }}
   ${{ if parameters.containerName }}:
     container: ${{ parameters.containerName }}
@@ -34,4 +38,4 @@ jobs:
       installAdditionalLinuxDependencies: ${{ parameters.installAdditionalLinuxDependencies }}
       npmCommand: $(npmCommand)
       testVSCodeVersion: ${{ parameters.testVSCodeVersion }}
-      isIntegrationTest: ${{ startsWith(variables.npmCommand, 'test:integration') }}
+      isIntegrationTest: ${{ eq(variables.integration, 'true') }}

--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -34,4 +34,4 @@ jobs:
       installAdditionalLinuxDependencies: ${{ parameters.installAdditionalLinuxDependencies }}
       npmCommand: $(npmCommand)
       testVSCodeVersion: ${{ parameters.testVSCodeVersion }}
-      isIntegrationTest: $[ startsWith(variables.npmCommand, 'test:integration') ]
+      isIntegrationTest: $[ eq(startsWith(variables.npmCommand, 'test:integration'), true) ]

--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -18,16 +18,16 @@ jobs:
     matrix:
       UnitTests:
         npmCommand: test:unit
-        integration: false
+        isIntegration: false
       CSharpIntegrationTests:
         npmCommand: test:integration:csharp
-        integration: true
+        isIntegration: true
       DevKitTests:
         npmCommand: test:integration:devkit
-        integration: true
+        isIntegration: true
       RazorTests:
         npmCommand: test:integration:razor
-        integration: true
+        isIntegration: true
   pool: ${{ parameters.pool }}
   ${{ if parameters.containerName }}:
     container: ${{ parameters.containerName }}
@@ -38,4 +38,4 @@ jobs:
       installAdditionalLinuxDependencies: ${{ parameters.installAdditionalLinuxDependencies }}
       npmCommand: $(npmCommand)
       testVSCodeVersion: ${{ parameters.testVSCodeVersion }}
-      isIntegrationTest: ${{ eq(variables.integration, 'true') }}
+      isIntegration: $(isIntegration)

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -46,25 +46,24 @@ steps:
     mergeTestResults: true
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
-- ${{ if eq(parameters.isIntegration, 'true') }}:
-  - powershell: |
-      $tempPath = [System.IO.Path]::GetTempPath()
-      echo "Temp Path: $tempPath"
-      Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
-    displayName: 'Copy .cpuprofile files to out/logs'
-    condition: succeededOrFailed()
+- powershell: |
+    $tempPath = [System.IO.Path]::GetTempPath()
+    echo "Temp Path: $tempPath"
+    Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
+  displayName: 'Copy .cpuprofile files to out/logs'
+  condition: eq(parameters.isIntegration, 'true')
 
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - task: 1ES.PublishPipelineArtifact@1
-      condition: succeededOrFailed()
-      displayName: 'Upload integration test logs'
-      inputs:
-        path: '$(Build.SourcesDirectory)/out/logs'
-        artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
-  - ${{ else }}: 
-    - task: PublishPipelineArtifact@1
-      condition: succeededOrFailed()
-      displayName: 'Upload integration test logs'
-      inputs:
-        targetPath: '$(Build.SourcesDirectory)/out/logs'
-        artifactName: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - task: 1ES.PublishPipelineArtifact@1
+    condition: eq(parameters.isIntegration, 'true')
+    displayName: 'Upload integration test logs'
+    inputs:
+      path: '$(Build.SourcesDirectory)/out/logs'
+      artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
+- ${{ else }}: 
+  - task: PublishPipelineArtifact@1
+    condition: eq(parameters.isIntegration, 'true')
+    displayName: 'Upload integration test logs'
+    inputs:
+      targetPath: '$(Build.SourcesDirectory)/out/logs'
+      artifactName: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -47,25 +47,25 @@ steps:
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
 - powershell: |
-    Write-Host "##vso[task.setvariable variable=isIntegration;]${{ parameters.isIntegration }}"
+    Write-Host "##vso[task.setvariable variable=isIntegrationVar;]${{ parameters.isIntegration }}"
     
 - powershell: |
     $tempPath = [System.IO.Path]::GetTempPath()
     echo "Temp Path: $tempPath"
     Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
   displayName: 'Copy .cpuprofile files to out/logs'
-  condition: eq(variables.isIntegration, true)
+  condition: eq(variables.isIntegrationVar, true)
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - task: 1ES.PublishPipelineArtifact@1
-    condition: eq(variables.isIntegration, true)
+    condition: eq(variables.isIntegrationVar, true)
     displayName: 'Upload integration test logs'
     inputs:
       path: '$(Build.SourcesDirectory)/out/logs'
       artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
 - ${{ else }}: 
   - task: PublishPipelineArtifact@1
-    condition: eq(variables.isIntegration, true)
+    condition: eq(variables.isIntegrationVar, true)
     displayName: 'Upload integration test logs'
     inputs:
       targetPath: '$(Build.SourcesDirectory)/out/logs'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -46,7 +46,7 @@ steps:
     mergeTestResults: true
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
-- ${{ if parameters.isIntegration }}:
+- ${{ if eq(parameters.isIntegration, true) }}:
   - powershell: |
       $tempPath = [System.IO.Path]::GetTempPath()
       echo "Temp Path: $tempPath"

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -46,25 +46,24 @@ steps:
     mergeTestResults: true
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
-- ${{ if eq(parameters.isIntegration, true) }}:
-  - powershell: |
-      $tempPath = [System.IO.Path]::GetTempPath()
-      echo "Temp Path: $tempPath"
-      Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
-    displayName: 'Copy .cpuprofile files to out/logs'
-    condition: succeededOrFailed()
+- powershell: |
+    $tempPath = [System.IO.Path]::GetTempPath()
+    echo "Temp Path: $tempPath"
+    Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
+  displayName: 'Copy .cpuprofile files to out/logs'
+  condition: eq(${{ parameters.isIntegration }}, true)
 
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - task: 1ES.PublishPipelineArtifact@1
-      condition: succeededOrFailed()
-      displayName: 'Upload integration test logs'
-      inputs:
-        path: '$(Build.SourcesDirectory)/out/logs'
-        artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
-  - ${{ else }}: 
-    - task: PublishPipelineArtifact@1
-      condition: succeededOrFailed()
-      displayName: 'Upload integration test logs'
-      inputs:
-        targetPath: '$(Build.SourcesDirectory)/out/logs'
-        artifactName: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - task: 1ES.PublishPipelineArtifact@1
+    condition: eq(${{ parameters.isIntegration }}, true)
+    displayName: 'Upload integration test logs'
+    inputs:
+      path: '$(Build.SourcesDirectory)/out/logs'
+      artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
+- ${{ else }}: 
+  - task: PublishPipelineArtifact@1
+    condition: eq(${{ parameters.isIntegration }}, true)
+    displayName: 'Upload integration test logs'
+    inputs:
+      targetPath: '$(Build.SourcesDirectory)/out/logs'
+      artifactName: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -51,18 +51,18 @@ steps:
     echo "Temp Path: $tempPath"
     Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
   displayName: 'Copy .cpuprofile files to out/logs'
-  condition: eq(parameters.isIntegration, 'true')
+  condition: ${{ eq(parameters.isIntegration, 'true') }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - task: 1ES.PublishPipelineArtifact@1
-    condition: eq(parameters.isIntegration, 'true')
+    condition: ${{ eq(parameters.isIntegration, 'true') }}
     displayName: 'Upload integration test logs'
     inputs:
       path: '$(Build.SourcesDirectory)/out/logs'
       artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
 - ${{ else }}: 
   - task: PublishPipelineArtifact@1
-    condition: eq(parameters.isIntegration, 'true')
+    condition: ${{ eq(parameters.isIntegration, 'true') }}
     displayName: 'Upload integration test logs'
     inputs:
       targetPath: '$(Build.SourcesDirectory)/out/logs'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -9,7 +9,7 @@ parameters:
   - name: testVSCodeVersion
     type: string
   - name: isIntegration
-    type: string
+    type: boolean
 
 steps:
 - checkout: self
@@ -17,8 +17,6 @@ steps:
   submodules: true
   fetchTags: false
   fetchDepth: 1
-
-- script: echo eq(${{ parameters.isIntegration }}, 'true') evaluates to ${{ eq(parameters.isIntegration, 'true') }}
 
 - template: prereqs.yml
   parameters:
@@ -48,24 +46,25 @@ steps:
     mergeTestResults: true
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
-- powershell: |
-    $tempPath = [System.IO.Path]::GetTempPath()
-    echo "Temp Path: $tempPath"
-    Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
-  displayName: 'Copy .cpuprofile files to out/logs'
-  condition: ${{ eq(parameters.isIntegration, 'true') }}
+- ${{ if parameters.isIntegration }}:
+  - powershell: |
+      $tempPath = [System.IO.Path]::GetTempPath()
+      echo "Temp Path: $tempPath"
+      Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
+    displayName: 'Copy .cpuprofile files to out/logs'
+    condition: succeededOrFailed()
 
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - task: 1ES.PublishPipelineArtifact@1
-    condition: ${{ eq(parameters.isIntegration, 'true') }}
-    displayName: 'Upload integration test logs'
-    inputs:
-      path: '$(Build.SourcesDirectory)/out/logs'
-      artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
-- ${{ else }}: 
-  - task: PublishPipelineArtifact@1
-    condition: ${{ eq(parameters.isIntegration, 'true') }}
-    displayName: 'Upload integration test logs'
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/out/logs'
-      artifactName: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - task: 1ES.PublishPipelineArtifact@1
+      condition: succeededOrFailed()
+      displayName: 'Upload integration test logs'
+      inputs:
+        path: '$(Build.SourcesDirectory)/out/logs'
+        artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
+  - ${{ else }}: 
+    - task: PublishPipelineArtifact@1
+      condition: succeededOrFailed()
+      displayName: 'Upload integration test logs'
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/out/logs'
+        artifactName: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -33,12 +33,13 @@ steps:
     DISPLAY: :99.0
     CODE_VERSION: ${{ parameters.testVSCodeVersion }}
 
-- powershell: |
-    $tempPath = [System.IO.Path]::GetTempPath()
-    echo "Temp Path: $tempPath"
-    Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
-  displayName: 'Copy .cpuprofile files to out/logs'
-  condition: succeededOrFailed()
+- ${{ if contains(parameters.npmCommand, ':integration') }}:
+  - powershell: |
+      $tempPath = [System.IO.Path]::GetTempPath()
+      echo "Temp Path: $tempPath"
+      Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
+    displayName: 'Copy .cpuprofile files to out/logs'
+    condition: succeededOrFailed()
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -18,7 +18,7 @@ steps:
   fetchTags: false
   fetchDepth: 1
 
-- script: echo eq(${{ parameters.isIntegration }}, 'true') evaluates to ${{ eq(parameters.isIntegration, 'true)' }}
+- script: echo eq(${{ parameters.isIntegration }}, 'true') evaluates to ${{ eq(parameters.isIntegration, 'true') }}
 
 - template: prereqs.yml
   parameters:

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -11,15 +11,14 @@ parameters:
   - name: isIntegration
     type: string
 
-variables:
-  isIntegration: ${{ parameters.isIntegration }}
-
 steps:
 - checkout: self
   clean: true
   submodules: true
   fetchTags: false
   fetchDepth: 1
+
+- script: echo eq(${{ parameters.isIntegration }}, 'true') evaluates to ${{ eq(parameters.isIntegration, 'true)' }}
 
 - template: prereqs.yml
   parameters:
@@ -54,18 +53,18 @@ steps:
     echo "Temp Path: $tempPath"
     Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
   displayName: 'Copy .cpuprofile files to out/logs'
-  condition: eq(variables['isIntegration'], 'true')
+  condition: ${{ eq(parameters.isIntegration, 'true') }}
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - task: 1ES.PublishPipelineArtifact@1
-    condition: eq(variables['isIntegration'], 'true')
+    condition: ${{ eq(parameters.isIntegration, 'true') }}
     displayName: 'Upload integration test logs'
     inputs:
       path: '$(Build.SourcesDirectory)/out/logs'
       artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
 - ${{ else }}: 
   - task: PublishPipelineArtifact@1
-    condition: eq(variables['isIntegration'], 'true')
+    condition: ${{ eq(parameters.isIntegration, 'true') }}
     displayName: 'Upload integration test logs'
     inputs:
       targetPath: '$(Build.SourcesDirectory)/out/logs'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -8,6 +8,8 @@ parameters:
     type: string
   - name: testVSCodeVersion
     type: string
+  - name: isIntegrationTest
+    type: boolean
 
 steps:
 - checkout: self
@@ -44,7 +46,7 @@ steps:
     mergeTestResults: true
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
-- ${{ if contains(parameters.npmCommand, ':integration') }}:
+- ${{ if eq(parameters.isIntegrationTest, true) }}:
   - powershell: |
       $tempPath = [System.IO.Path]::GetTempPath()
       echo "Temp Path: $tempPath"

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -33,14 +33,6 @@ steps:
     DISPLAY: :99.0
     CODE_VERSION: ${{ parameters.testVSCodeVersion }}
 
-- ${{ if contains(parameters.npmCommand, ':integration') }}:
-  - powershell: |
-      $tempPath = [System.IO.Path]::GetTempPath()
-      echo "Temp Path: $tempPath"
-      Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
-    displayName: 'Copy .cpuprofile files to out/logs'
-    condition: succeededOrFailed()
-
 - task: PublishTestResults@2
   condition: succeededOrFailed()
   displayName: 'Publish Test Results'
@@ -52,17 +44,25 @@ steps:
     mergeTestResults: true
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - task: 1ES.PublishPipelineArtifact@1
+- ${{ if contains(parameters.npmCommand, ':integration') }}:
+  - powershell: |
+      $tempPath = [System.IO.Path]::GetTempPath()
+      echo "Temp Path: $tempPath"
+      Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
+    displayName: 'Copy .cpuprofile files to out/logs'
     condition: succeededOrFailed()
-    displayName: 'Upload integration test logs'
-    inputs:
-      path: '$(Build.SourcesDirectory)/out/logs'
-      artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
-- ${{ else }}: 
-  - task: PublishPipelineArtifact@1
-    condition: succeededOrFailed()
-    displayName: 'Upload integration test logs'
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/out/logs'
-      artifactName: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
+
+  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    - task: 1ES.PublishPipelineArtifact@1
+      condition: succeededOrFailed()
+      displayName: 'Upload integration test logs'
+      inputs:
+        path: '$(Build.SourcesDirectory)/out/logs'
+        artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
+  - ${{ else }}: 
+    - task: PublishPipelineArtifact@1
+      condition: succeededOrFailed()
+      displayName: 'Upload integration test logs'
+      inputs:
+        targetPath: '$(Build.SourcesDirectory)/out/logs'
+        artifactName: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -8,8 +8,8 @@ parameters:
     type: string
   - name: testVSCodeVersion
     type: string
-  - name: isIntegrationTest
-    type: boolean
+  - name: isIntegration
+    type: string
 
 steps:
 - checkout: self
@@ -46,7 +46,7 @@ steps:
     mergeTestResults: true
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
-- ${{ if eq(parameters.isIntegrationTest, true) }}:
+- ${{ if eq(parameters.isIntegration, 'true') }}:
   - powershell: |
       $tempPath = [System.IO.Path]::GetTempPath()
       echo "Temp Path: $tempPath"

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -47,22 +47,25 @@ steps:
     testRunTitle: $(System.StageDisplayName) $(Agent.JobName) (Attempt $(System.JobAttempt))
 
 - powershell: |
+    Write-Host "##vso[task.setvariable variable=isIntegration;]${{ parameters.isIntegration }}"
+    
+- powershell: |
     $tempPath = [System.IO.Path]::GetTempPath()
     echo "Temp Path: $tempPath"
     Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
   displayName: 'Copy .cpuprofile files to out/logs'
-  condition: eq( ${{ parameters.isIntegration }}, 'true')
+  condition: eq(variables.isIntegration, true)
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - task: 1ES.PublishPipelineArtifact@1
-    condition: eq( ${{ parameters.isIntegration }}, 'true')
+    condition: eq(variables.isIntegration, true)
     displayName: 'Upload integration test logs'
     inputs:
       path: '$(Build.SourcesDirectory)/out/logs'
       artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
 - ${{ else }}: 
   - task: PublishPipelineArtifact@1
-    condition: eq( ${{ parameters.isIntegration }}, 'true')
+    condition: eq(variables.isIntegration, true)
     displayName: 'Upload integration test logs'
     inputs:
       targetPath: '$(Build.SourcesDirectory)/out/logs'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -51,18 +51,18 @@ steps:
     echo "Temp Path: $tempPath"
     Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
   displayName: 'Copy .cpuprofile files to out/logs'
-  condition: eq({{ parameters.isIntegration }}, true)
+  condition: eq( ${{ parameters.isIntegration }}, 'true')
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - task: 1ES.PublishPipelineArtifact@1
-    condition: eq({{ parameters.isIntegration }}, true)
+    condition: eq( ${{ parameters.isIntegration }}, 'true')
     displayName: 'Upload integration test logs'
     inputs:
       path: '$(Build.SourcesDirectory)/out/logs'
       artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
 - ${{ else }}: 
   - task: PublishPipelineArtifact@1
-    condition: eq({{ parameters.isIntegration }}, true)
+    condition: eq( ${{ parameters.isIntegration }}, 'true')
     displayName: 'Upload integration test logs'
     inputs:
       targetPath: '$(Build.SourcesDirectory)/out/logs'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -11,6 +11,9 @@ parameters:
   - name: isIntegration
     type: string
 
+variables:
+  isIntegration: ${{ parameters.isIntegration }}
+
 steps:
 - checkout: self
   clean: true
@@ -51,18 +54,18 @@ steps:
     echo "Temp Path: $tempPath"
     Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
   displayName: 'Copy .cpuprofile files to out/logs'
-  condition: ${{ eq(parameters.isIntegration, 'true') }}
+  condition: eq(variables['isIntegration'], 'true')
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - task: 1ES.PublishPipelineArtifact@1
-    condition: ${{ eq(parameters.isIntegration, 'true') }}
+    condition: eq(variables['isIntegration'], 'true')
     displayName: 'Upload integration test logs'
     inputs:
       path: '$(Build.SourcesDirectory)/out/logs'
       artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
 - ${{ else }}: 
   - task: PublishPipelineArtifact@1
-    condition: ${{ eq(parameters.isIntegration, 'true') }}
+    condition: eq(variables['isIntegration'], 'true')
     displayName: 'Upload integration test logs'
     inputs:
       targetPath: '$(Build.SourcesDirectory)/out/logs'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -48,6 +48,8 @@ steps:
 
 - powershell: |
     Write-Host "##vso[task.setvariable variable=isIntegrationVar;]${{ parameters.isIntegration }}"
+  displayName: 'Set IsIntegration Variable'
+  condition: succeededOrFailed()
     
 - powershell: |
     $tempPath = [System.IO.Path]::GetTempPath()

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -51,18 +51,18 @@ steps:
     echo "Temp Path: $tempPath"
     Get-ChildItem -Path $tempPath -Filter *.cpuprofile | Copy-Item -Destination "$(Build.SourcesDirectory)/out/logs"
   displayName: 'Copy .cpuprofile files to out/logs'
-  condition: eq(${{ parameters.isIntegration }}, true)
+  condition: eq({{ parameters.isIntegration }}, true)
 
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - task: 1ES.PublishPipelineArtifact@1
-    condition: eq(${{ parameters.isIntegration }}, true)
+    condition: eq({{ parameters.isIntegration }}, true)
     displayName: 'Upload integration test logs'
     inputs:
       path: '$(Build.SourcesDirectory)/out/logs'
       artifact: 'Test Logs ($(System.StageDisplayName)-$(Agent.JobName)-$(System.JobAttempt))'
 - ${{ else }}: 
   - task: PublishPipelineArtifact@1
-    condition: eq(${{ parameters.isIntegration }}, true)
+    condition: eq({{ parameters.isIntegration }}, true)
     displayName: 'Upload integration test logs'
     inputs:
       targetPath: '$(Build.SourcesDirectory)/out/logs'

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -9,7 +9,7 @@ parameters:
   - name: testVSCodeVersion
     type: string
   - name: isIntegration
-    type: boolean
+    type: string
 
 steps:
 - checkout: self


### PR DESCRIPTION
Since unit tests do not start a VSCode instance there is no log folder to copy into. This was causing CI to always fail.

So, I had to do this a wonky way. Apparently my new `isIntegration` test.yml template parameter couldn't be used for template conditions because it is being sourced from the `isIntegration` variable in the test-matrix.yml. It would be evaluated to `$(isIntegration)` when used in `${{ if }}` statements. It was usable from within scripts as that replacement seems to be made at runtime. So I use a script to set a variable that can then be used from conditions in order to conditionally publish integration test logs.