### PR TITLE
Ignore preview versions when locating the .NET runtime.

### DIFF
--- a/src/lsptoolshost/dotnetRuntime/dotnetRuntimeExtensionApi.ts
+++ b/src/lsptoolshost/dotnetRuntime/dotnetRuntimeExtensionApi.ts
@@ -5,13 +5,20 @@
 
 // Contains APIs defined by the vscode-dotnet-runtime extension
 
+/**
+ * https://github.com/dotnet/vscode-dotnet-runtime/blob/main/vscode-dotnet-runtime-library/src/IDotnetAcquireResult.ts
+ */
 export interface IDotnetAcquireResult {
     dotnetPath: string;
 }
 
+/**
+ * https://github.com/dotnet/vscode-dotnet-runtime/blob/main/vscode-dotnet-runtime-library/src/IDotnetFindPathContext.ts
+ */
 export interface IDotnetFindPathContext {
     acquireContext: IDotnetAcquireContext;
     versionSpecRequirement: DotnetVersionSpecRequirement;
+    rejectPreviews?: boolean;
 }
 
 /**

--- a/src/lsptoolshost/dotnetRuntime/dotnetRuntimeExtensionResolver.ts
+++ b/src/lsptoolshost/dotnetRuntime/dotnetRuntimeExtensionResolver.ts
@@ -51,6 +51,8 @@ export class DotnetRuntimeExtensionResolver implements IHostExecutableResolver {
                 mode: 'runtime',
             },
             versionSpecRequirement: 'greater_than_or_equal',
+            // Reject previews because we are not setting `DOTNET_ROLL_FORWARD_TO_PRERELEASE` when starting the server.
+            rejectPreviews: true,
         };
         let acquireResult = await vscode.commands.executeCommand<IDotnetAcquireResult | undefined>(
             'dotnet.findPath',


### PR DESCRIPTION
Since we are not launching the Roslyn LSP server with `DOTNET_ROLL_FORWARD_TO_PRERELEASE` then, there is no reason to consider preview runtimes.

Fixes part of https://github.com/dotnet/vscode-csharp/issues/8034