### PR TITLE
update razor and fuse on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.69.x
-* Bump razor to 9.0.0-preview.25156.2 (PR: []())
+* Bump razor to 9.0.0-preview.25156.2 (PR: [#8047](https://github.com/dotnet/vscode-csharp/pull/8047))
   * Enable FUSE by default
   * Improve solution load performance (#11591) (PR: [#11591](https://github.com/dotnet/razor/pull/11591))
   * Make logging fall into the pit of success (#11581) (PR: [#11581](https://github.com/dotnet/razor/pull/11581))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
   * Enable FUSE by default
   * Improve solution load performance (#11591) (PR: [#11591](https://github.com/dotnet/razor/pull/11591))
   * Make logging fall into the pit of success (#11581) (PR: [#11581](https://github.com/dotnet/razor/pull/11581))
-  * Fix code actions appearing for the wrong context when invoked from light bulb (#11537) (PR: [#11537](https://github.com/dotnet/razor/pull/11537))
 * Bump xamlTools to 17.14.35904.287 (PR: [#8042](https://github.com/dotnet/vscode-csharp/pull/8042))
 
 # 2.68.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.69.x
+* Bump razor to 9.0.0-preview.25156.2 (PR: []())
+  * Enable FUSE by default
+  * Improve solution load performance (#11591) (PR: [#11591](https://github.com/dotnet/razor/pull/11591))
+  * Make logging fall into the pit of success (#11581) (PR: [#11581](https://github.com/dotnet/razor/pull/11581))
+  * Fix code actions appearing for the wrong context when invoked from light bulb (#11537) (PR: [#11537](https://github.com/dotnet/razor/pull/11537))
 * Bump xamlTools to 17.14.35904.287 (PR: [#8042](https://github.com/dotnet/vscode-csharp/pull/8042))
 
 # 2.68.x

--- a/package.json
+++ b/package.json
@@ -1519,7 +1519,7 @@
           "razor.languageServer.forceRuntimeCodeGeneration": {
             "type": "boolean",
             "scope": "machine-overridable",
-            "default": null,
+            "default": true,
             "description": "%configuration.razor.languageServer.forceRuntimeCodeGeneration%",
             "order": 90
           },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "defaults": {
     "roslyn": "4.14.0-2.25120.5",
     "omniSharp": "1.39.12",
-    "razor": "9.0.0-preview.25125.9",
+    "razor": "9.0.0-preview.25156.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.35904.287"
   },

--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -23,17 +23,7 @@ export function resolveRazorLanguageServerOptions(
     const usingOmniSharp =
         !getCSharpDevKit() && vscodeApi.workspace.getConfiguration().get<boolean>('dotnet.server.useOmnisharp');
 
-    const hotReload = vscodeApi.workspace.getConfiguration('csharp.experimental.debug').get<boolean>('hotReload');
-
-    let forceRuntimeCodeGeneration = serverConfig.get<boolean | null>('forceRuntimeCodeGeneration');
-
-    if (forceRuntimeCodeGeneration === null && hotReload) {
-        logger.logMessage(
-            'Hot Reload is enabled so treating "razor.languageServer.forceRuntimeCodeGeneration" as true. To override this set "razor.languageServer.forceRuntimeCodeGeneration" to true or false.'
-        );
-
-        forceRuntimeCodeGeneration = hotReload;
-    }
+    const forceRuntimeCodeGeneration = serverConfig.get<boolean>('forceRuntimeCodeGeneration');
 
     const suppressErrorToasts = serverConfig.get<boolean>('suppressLspErrorToasts');
     const useNewFormattingEngine = serverConfig.get<boolean>('useNewFormattingEngine');


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/0184787f9c22a83848ebd40d9a3bcf5f92943ce6...2798396c3481573aa49f9c792179ebbb5e183dca?w=1)
  * Improve solution load performance (#11591) (PR: [#11591](https://github.com/dotnet/razor/pull/11591))
  * Remove some Newtonsoft.Json references and conversions (#11593) (PR: [#11593](https://github.com/dotnet/razor/pull/11593))
  * Change symbol publishing for more reliable builds (#11585) (PR: [#11585](https://github.com/dotnet/razor/pull/11585))
  * Remove references to old xliff-tasks repo from Version.Details.xml (#11586) (PR: [#11586](https://github.com/dotnet/razor/pull/11586))
  * Add override completion integration test (#11584) (PR: [#11584](https://github.com/dotnet/razor/pull/11584))
  * Simply cohosting generated document Uri code (#11583) (PR: [#11583](https://github.com/dotnet/razor/pull/11583))
  * Remove unnecessary assert (#11582) (PR: [#11582](https://github.com/dotnet/razor/pull/11582))
  * Make logging fall into the pit of success (#11581) (PR: [#11581](https://github.com/dotnet/razor/pull/11581))
  * Show TODO Razor comments in the Task List in VS (#11540) (PR: [#11540](https://github.com/dotnet/razor/pull/11540))
  * [main] Update dependencies from dotnet/source-build-reference-packages (#11579) (PR: [#11579](https://github.com/dotnet/razor/pull/11579))
  * Update document mapping to work with the source generator (#11558) (PR: [#11558](https://github.com/dotnet/razor/pull/11558))
  * Update PublishData.json after VS Snap (#11576) (PR: [#11576](https://github.com/dotnet/razor/pull/11576))
  * Revert symbol related changes (for now) (#11568) (PR: [#11568](https://github.com/dotnet/razor/pull/11568))
  * Move cohost options to explicit class (#11564) (PR: [#11564](https://github.com/dotnet/razor/pull/11564))
  * Fix code actions appearing for the wrong context when invoked from light bulb (#11537) (PR: [#11537](https://github.com/dotnet/razor/pull/11537))
  * Produce more symbols (#11563) (PR: [#11563](https://github.com/dotnet/razor/pull/11563))