### PR TITLE
Set the BuildNumber in the release pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ pr:
     exclude:
     - ./*.md 
     - .github/*
+    - azure-pipelines/release.yml
 
 # Run a scheduled build every night on main to run tests against insiders VSCode.
 # The variable testVSCodeVersion is set to insiders based on the build reason.

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -113,6 +113,35 @@ extends:
                       Write-Host "##[command]vsce $publishArgs"
                       vsce @publishArgs
                     }
+
+    - stage: 'SetBuildNumber'
+      displayName: 'Set BuildNumbder'
+      jobs:
+      - job: 'Set'
+        pool:
+          name: netcore1espool-internal
+          image: 1es-ubuntu-2204
+          os: linux
+        steps:
+        - checkout: none
+        - pwsh: |
+            $buildNumberName = "$(resources.pipeline.officialBuildCI.sourceBranch) build $(resources.pipeline.officialBuildCI.runName)"
+            if ('${{ parameters.test }}' -eq 'true') {
+              $buildNumberName = "# Test publishing " + $buildNumberName
+            }
+            else {
+              $buildNumberName = "# Publishing " + $buildNumberName
+            }
+            $buildNumberName = $buildNumberName -replace '["/:<>\|?@*]','_'
+            # Maximum buildnumber length is 255 chars and we are going to append to the end to ensure we have space.
+            if ($buildNumberName.Length -GT 253) {
+              $buildNumberName = $buildNumberName.Substring(0, 253)
+            }
+            # Avoid ever ending the BuildNumber with a `.` by always appending to it.
+            $buildNumberName += ' #'
+            Write-Host "##vso[task.setvariable variable=BuildNumber;isoutput=true;isreadonly=true]$buildNumberName"
+          displayName: Setting BuildNumber
+
     - stage: 'TagRelease'
       displayName: 'Tag release of vscode-csharp'
       dependsOn: 'PublishStage'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -52,24 +52,24 @@ extends:
             deploy:
               steps:
               - pwsh: |
+                  $artifactVersion = '$(resources.pipeline.officialBuildCI.runName)'
+                  $artifactBranchName = '$(resources.pipeline.officialBuildCI.sourceBranch)' -replace 'refs/heads/',''
+                  
                   # Set the BuildNumber in the form `# Publish prerelease v2.69.22 #` to improve readability in AzDO
-                  $buildNumberName = "$(resources.pipeline.officialBuildCI.sourceBranch) $(resources.pipeline.officialBuildCI.runName)"
+                  $buildNumberName = 'Publish $(artifactBranchName) $(artifactBranchName)'
                   if ('${{ parameters.test }}' -eq 'true') {
-                    $buildNumberName = "Test publish " + $buildNumberName
-                  }
-                  else {
-                    $buildNumberName = "Publish " + $buildNumberName
+                    $buildNumberName = 'Test ' + $buildNumberName
                   }
 
                   # Replace invalid characters
                   $buildNumberName = $buildNumberName -replace '["/:<>\|?@*]','_'
                   # Maximum buildnumber length is 255 chars and we are going to add a prefix and suffix so ensure we have space.
-                  if ($buildNumberName.Length -GT 251) {
-                    $buildNumberName = $buildNumberName.Substring(0, 251)
+                  if ($buildNumberName.Length -GT 252) {
+                    $buildNumberName = $buildNumberName.Substring(0, 252)
                   }
                   # Avoid ever ending the BuildNumber with a `.` by always appending to it.
-                  $buildNumberName = '# ' + $buildNumberName + ' #'
-                  
+                  $buildNumberName = ' ' + $buildNumberName + ' #'
+
                   Write-Host "##vso[build.updatebuildnumber]$buildNumberName"
                 displayName: Set BuildNumber
               - template: /azure-pipelines/install-node.yml@self

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -10,12 +10,6 @@ variables:
 # This is expected to provide pat to tag release.
 - group: DncEng-Partners-Tokens
 
-- name: NamePrefix
-  ${{ if eq(parameters.test, true) }}:
-    value: 'Test publish'
-  ${{ else }}:
-    value: 'Publish'
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -26,9 +20,6 @@ resources:
   - pipeline: officialBuildCI
     source: dotnet-vscode-csharp
     branch: main
-
-name: '$(NamePrefix) $(resources.pipeline.officialBuildCI.sourceBranch) build $(resources.pipeline.officialBuildCI.runName)'
-
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
@@ -60,6 +51,23 @@ extends:
           runOnce:
             deploy:
               steps:
+              - pwsh: |
+                  $buildNumberName = "$(resources.pipeline.officialBuildCI.sourceBranch) build $(resources.pipeline.officialBuildCI.runName)"
+                  if ('${{ parameters.test }}' -eq 'true') {
+                    $buildNumberName = "# Test publishing " + $buildNumberName
+                  }
+                  else {
+                    $buildNumberName = "# Publishing " + $buildNumberName
+                  }
+                  $buildNumberName = $buildNumberName -replace '["/:<>\|?@*]','_'
+                  # Maximum buildnumber length is 255 chars and we are going to append to the end to ensure we have space.
+                  if ($buildNumberName.Length -GT 253) {
+                    $buildNumberName = $buildNumberName.Substring(0, 253)
+                  }
+                  # Avoid ever ending the BuildNumber with a `.` by always appending to it.
+                  $buildNumberName += ' #'
+                  Write-Host "##vso[task.setvariable variable=BuildNumber;isoutput=true;isreadonly=true]$buildNumberName"
+                displayName: Setting BuildNumber
               - template: /azure-pipelines/install-node.yml@self
               - pwsh: |
                   npm install --global @vscode/vsce
@@ -122,6 +130,7 @@ extends:
                       Write-Host "##[command]vsce $publishArgs"
                       vsce @publishArgs
                     }
+
     - stage: 'TagRelease'
       displayName: 'Tag release of vscode-csharp'
       dependsOn: 'PublishStage'

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -56,7 +56,7 @@ extends:
                   $artifactBranchName = '$(resources.pipeline.officialBuildCI.sourceBranch)' -replace 'refs/heads/',''
                   
                   # Set the BuildNumber in the form `# Publish prerelease v2.69.22 #` to improve readability in AzDO
-                  $buildNumberName = 'Publish $(artifactBranchName) $(artifactBranchName)'
+                  $buildNumberName = "Publish $artifactBranchName $artifactBranchName"
                   if ('${{ parameters.test }}' -eq 'true') {
                     $buildNumberName = 'Test ' + $buildNumberName
                   }

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -16,8 +16,6 @@ variables:
   ${{ else }}:
     value: 'Publish'
 
-name: '$(NamePrefix) $(resources.pipeline.officialBuildCI.sourceBranch) build $(resources.pipeline.officialBuildCI.runName)'
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -28,6 +26,9 @@ resources:
   - pipeline: officialBuildCI
     source: dotnet-vscode-csharp
     branch: main
+
+name: '$(NamePrefix) $(resources.pipeline.officialBuildCI.sourceBranch) build $(resources.pipeline.officialBuildCI.runName)'
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -52,22 +52,26 @@ extends:
             deploy:
               steps:
               - pwsh: |
-                  $buildNumberName = "$(resources.pipeline.officialBuildCI.sourceBranch) build $(resources.pipeline.officialBuildCI.runName)"
+                  # Set the BuildNumber in the form `# Publish prerelease v2.69.22 #` to improve readability in AzDO
+                  $buildNumberName = "$(resources.pipeline.officialBuildCI.sourceBranch) $(resources.pipeline.officialBuildCI.runName)"
                   if ('${{ parameters.test }}' -eq 'true') {
-                    $buildNumberName = "# Test publishing " + $buildNumberName
+                    $buildNumberName = "Test publish " + $buildNumberName
                   }
                   else {
-                    $buildNumberName = "# Publishing " + $buildNumberName
+                    $buildNumberName = "Publish " + $buildNumberName
                   }
+
+                  # Replace invalid characters
                   $buildNumberName = $buildNumberName -replace '["/:<>\|?@*]','_'
-                  # Maximum buildnumber length is 255 chars and we are going to append to the end to ensure we have space.
-                  if ($buildNumberName.Length -GT 253) {
-                    $buildNumberName = $buildNumberName.Substring(0, 253)
+                  # Maximum buildnumber length is 255 chars and we are going to add a prefix and suffix so ensure we have space.
+                  if ($buildNumberName.Length -GT 251) {
+                    $buildNumberName = $buildNumberName.Substring(0, 251)
                   }
                   # Avoid ever ending the BuildNumber with a `.` by always appending to it.
-                  $buildNumberName += ' #'
-                  Write-Host "##vso[task.setvariable variable=BuildNumber;isoutput=true;isreadonly=true]$buildNumberName"
-                displayName: Setting BuildNumber
+                  $buildNumberName = '# ' + $buildNumberName + ' #'
+                  
+                  Write-Host "##vso[build.updatebuildnumber]$buildNumberName"
+                displayName: Set BuildNumber
               - template: /azure-pipelines/install-node.yml@self
               - pwsh: |
                   npm install --global @vscode/vsce

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -56,7 +56,7 @@ extends:
                   $artifactBranchName = '$(resources.pipeline.officialBuildCI.sourceBranch)' -replace 'refs/heads/',''
                   
                   # Set the BuildNumber in the form `# Publish prerelease v2.69.22 #` to improve readability in AzDO
-                  $buildNumberName = "Publish $artifactBranchName $artifactBranchName"
+                  $buildNumberName = "Publish $artifactBranchName $artifactVersion"
                   if ('${{ parameters.test }}' -eq 'true') {
                     $buildNumberName = 'Test ' + $buildNumberName
                   }

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -10,6 +10,14 @@ variables:
 # This is expected to provide pat to tag release.
 - group: DncEng-Partners-Tokens
 
+- name: NamePrefix
+  ${{ if eq(parameters.test, true) }}:
+    value: 'Test publish'
+  ${{ else }}:
+    value: 'Publish'
+
+name: '$(NamePrefix) $(resources.pipeline.officialBuildCI.sourceBranch) build $(resources.pipeline.officialBuildCI.runName)'
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -113,35 +121,6 @@ extends:
                       Write-Host "##[command]vsce $publishArgs"
                       vsce @publishArgs
                     }
-
-    - stage: 'SetBuildNumber'
-      displayName: 'Set BuildNumbder'
-      jobs:
-      - job: 'Set'
-        pool:
-          name: netcore1espool-internal
-          image: 1es-ubuntu-2204
-          os: linux
-        steps:
-        - checkout: none
-        - pwsh: |
-            $buildNumberName = "$(resources.pipeline.officialBuildCI.sourceBranch) build $(resources.pipeline.officialBuildCI.runName)"
-            if ('${{ parameters.test }}' -eq 'true') {
-              $buildNumberName = "# Test publishing " + $buildNumberName
-            }
-            else {
-              $buildNumberName = "# Publishing " + $buildNumberName
-            }
-            $buildNumberName = $buildNumberName -replace '["/:<>\|?@*]','_'
-            # Maximum buildnumber length is 255 chars and we are going to append to the end to ensure we have space.
-            if ($buildNumberName.Length -GT 253) {
-              $buildNumberName = $buildNumberName.Substring(0, 253)
-            }
-            # Avoid ever ending the BuildNumber with a `.` by always appending to it.
-            $buildNumberName += ' #'
-            Write-Host "##vso[task.setvariable variable=BuildNumber;isoutput=true;isreadonly=true]$buildNumberName"
-          displayName: Setting BuildNumber
-
     - stage: 'TagRelease'
       displayName: 'Tag release of vscode-csharp'
       dependsOn: 'PublishStage'


### PR DESCRIPTION
Sets the BuildNumber in the release pipeline to easily identify what build was being published.

- Set the BuildNumber in the form `# (Test)? Publish $(branch) $(version) #`
  - ex. `# Publish prerelease 2.69.22 #`

[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2662783&view=results)