### PR TITLE
Workaround issue installing .net runtime in latest extension

### DIFF
--- a/test/vscodeLauncher.ts
+++ b/test/vscodeLauncher.ts
@@ -32,7 +32,7 @@ export async function prepareVSCodeAndExecuteTests(
     const extensionsToInstall = [
         'ms-dotnettools.vscode-dotnet-runtime',
         'ms-dotnettools.csharp',
-        'ms-dotnettools.csdevkit',
+        'ms-dotnettools.csdevkit@1.16.6',
     ];
 
     await installExtensions(extensionsToInstall, cli, args);


### PR DESCRIPTION
for some reason the latest devkit is unable to install the .net runtime on the CI machines (C# works fine).  for now downgrading devkit

```
ms-dotnettools.csdevkit requested to download the .NET ASP.NET Runtime.
Downloading .NET version(s) 9.0.3~x64~aspnetcore ......
Error : (DotnetAcquisitionFinalError)
Failed to download .NET 9.0.3~x64~aspnetcore:
.NET Acquisition Failed: .NET install timed out.
You should change the timeout if you have a slow connection. See: https://github.com/dotnet/vscode-dotnet-runtime/blob/main/Documentation/troubleshooting-runtime.md#install-script-timeouts.
Our CDN may be blocked in China or experience significant slowdown, in which case you should install .NET manually., MESSAGE: Command failed: powershell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy bypass -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; & 'd:\a\_work\1\s\.vscode-test\extensions\ms-dotnettools.vscode-dotnet-runtime-2.3.0\dist\install scripts\dotnet-install.ps1' -InstallDir 'd:\a\_work\1\s\out\userData\[DevKit][slnWithCsproj]_codelens.integration.test.ts\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\9.0.3~x64~aspnetcore' -Version 9.0.3 -Verbose -Runtime aspnetcore -Architecture x64 }"
dotnet-install: Failed to verify the version of installed "ASP.NET Core Runtime".
Installation source: https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/9.0.3/aspnetcore-runtime-9.0.3-win-x64.zip.
Installation location: d:\a\_work\1\s\out\userData\[DevKit][slnWithCsproj]_codelens.integration.test.ts\User\globalStorage\ms-dotnettools.vscode-dotnet-runtime\.dotnet\9.0.3~x64~aspnetcore.
Report the bug at https://github.com/dotnet/install-scripts/issues.
"ASP.NET Core Runtime" with version = 9.0.3 failed to install with an unknown error.
At D:\a\_work\1\s\.vscode-test\extensions\ms-dotnettools.vscode-dotnet-runtime-2.3.0\dist\install 
scripts\dotnet-install.ps1:1375 char:5
+     throw "`"$assetName`" with version = $($DownloadedLink.effectiveV ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: ("ASP.NET Core R... unknown error.:String) [], RuntimeException
    + FullyQualifiedErrorId : "ASP.NET Core Runtime" with version = 9.0.3 failed to install with an unknown error.
 
, CODE: 1, SIGNAL: null, Error: .NET install timed out.

```