### PR TITLE
switch to older devkit to avoid .net runtime install error

### DIFF
--- a/azure-pipelines/dotnet-variables.yml
+++ b/azure-pipelines/dotnet-variables.yml
@@ -1,3 +1,3 @@
 variables:
 - name: defaultDotnetVersion
-  value: '9.0.202'
+  value: '8.0.403'

--- a/test/vscodeLauncher.ts
+++ b/test/vscodeLauncher.ts
@@ -32,7 +32,7 @@ export async function prepareVSCodeAndExecuteTests(
     const extensionsToInstall = [
         'ms-dotnettools.vscode-dotnet-runtime',
         'ms-dotnettools.csharp',
-        'ms-dotnettools.csdevkit',
+        'ms-dotnettools.csdevkit@1.16.6',
     ];
 
     await installExtensions(extensionsToInstall, cli, args);


### PR DESCRIPTION
https://github.com/dotnet/vscode-csharp/pull/8105 was wrong - we run devkit tests on machines specifically with only .net8 installed.  