### PR TITLE
[prerelease] Revert xamlTools for this week's prerelease update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.72.x
-* Bump xamlTools to 17.14.35927.264 (PR: [#8100](https://github.com/dotnet/vscode-csharp/pull/8100))
+* Revert xamlTools to 17.14.35913.250 (PR: [#8100](https://github.com/dotnet/vscode-csharp/pull/8100))
 * Update Roslyn to 4.14.0-3.25178.1 (PR: [#8103](https://github.com/dotnet/vscode-csharp/pull/8103))
   * Merge `null conditional assignment` to main (PR: [#77867](https://github.com/dotnet/roslyn/pull/77867))
   * Merge `features/extensions` into `main` (PR: [#77851](https://github.com/dotnet/roslyn/pull/77851))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.72.x
-* Revert xamlTools to 17.14.35913.250 (PR: [#8100](https://github.com/dotnet/vscode-csharp/pull/8100))
+* Revert xamlTools to 17.14.35913.250 (PR: [#8121](https://github.com/dotnet/vscode-csharp/pull/8121))
 * Update Roslyn to 4.14.0-3.25178.1 (PR: [#8103](https://github.com/dotnet/vscode-csharp/pull/8103))
   * Merge `null conditional assignment` to main (PR: [#77867](https://github.com/dotnet/roslyn/pull/77867))
   * Merge `features/extensions` into `main` (PR: [#77851](https://github.com/dotnet/roslyn/pull/77851))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "omniSharp": "1.39.12",
     "razor": "9.0.0-preview.25177.4",
     "razorOmnisharp": "7.0.0-preview.23363.1",
-    "xamlTools": "17.14.35927.264"
+    "xamlTools": "17.14.35913.250"
   },
   "main": "./dist/extension",
   "l10n": "./l10n",


### PR DESCRIPTION
Revert xamlTools to what it was 2 weeks ago, to avoid the problem in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2429317, with references to the wrong version of Microsoft.VisualStudio.Threading.

A proper fix will go to main, but for this week's prerelease update we're just reverting to the xamlTools version currently shipping in prerelease. There aren't any important fixes getting missed, so revert isn't a problem.