### PR TITLE
Acquire aspnetcore runtime when using devkit to avoid double acquisition

### DIFF
--- a/src/lsptoolshost/dotnetRuntime/dotnetRuntimeExtensionApi.ts
+++ b/src/lsptoolshost/dotnetRuntime/dotnetRuntimeExtensionApi.ts
@@ -24,7 +24,7 @@ export interface IDotnetFindPathContext {
 /**
  * https://github.com/dotnet/vscode-dotnet-runtime/blob/main/vscode-dotnet-runtime-library/src/IDotnetAcquireContext.ts
  */
-interface IDotnetAcquireContext {
+export interface IDotnetAcquireContext {
     version: string;
     requestingExtensionId?: string;
     errorConfiguration?: AcquireErrorConfiguration;
@@ -49,7 +49,7 @@ enum AcquireErrorConfiguration {
 /**
  * https://github.com/dotnet/vscode-dotnet-runtime/blob/main/vscode-dotnet-runtime-library/src/Acquisition/DotnetInstallMode.ts
  */
-type DotnetInstallMode = 'sdk' | 'runtime' | 'aspnetcore';
+export type DotnetInstallMode = 'sdk' | 'runtime' | 'aspnetcore';
 
 /**
  * https://github.com/dotnet/vscode-dotnet-runtime/blob/main/vscode-dotnet-runtime-library/src/DotnetVersionSpecRequirement.ts


### PR DESCRIPTION
C# Dev Kit requires the aspnetcore runtime, and requests it from the acquisition tool.  If C# requests the regular runtime, the .NET install tool cannot de-duplicate the requests and only download the normal runtime once.  Instead, if using devkit we can just require the aspnetcore runtime.  There should be no change in behavior as devkit already requires it.

Before, you get a download for both the runtime, and the aspnetcore runtime (which includes the normal runtime):
![image](https://github.com/user-attachments/assets/9d92466a-f624-45cc-b58f-4312bb6263eb)

After, you just get a single download for the aspnetcore runtime
![image](https://github.com/user-attachments/assets/bb47b4ee-87ba-4ad0-a055-932c0024d9e7)
