### PR TITLE
Don't show duplicate toast if C# Dev Kit fails to activate

### DIFF
--- a/src/lsptoolshost/server/roslynLanguageServer.ts
+++ b/src/lsptoolshost/server/roslynLanguageServer.ts
@@ -255,6 +255,11 @@ export class RoslynLanguageServer {
         channel: vscode.LogOutputChannel,
         traceChannel: vscode.OutputChannel
     ): Promise<RoslynLanguageServer> {
+        const devKit = getCSharpDevKit();
+        if (devKit) {
+            await devKit.activate();
+        }
+
         const serverOptions: ServerOptions = async () => {
             return await this.startServer(
                 platformInfo,


### PR DESCRIPTION
came up in another discussion - currently the vscode lsp client displays a toast if server startup fails.  In server startup we're awaiting devkit activation - so if devkit activation fails we get two overlapping toasts.

This change moves us to await devkit activation outside of the server startup path.  If devkit fails, we rely on them to display an error.