### PR TITLE
Set extensionKind to "workspace"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
       "supported": false
     }
   },
+  "extensionKind": [
+    "workspace"
+  ],
   "defaults": {
     "roslyn": "5.0.0-1.25204.1",
     "omniSharp": "1.39.12",


### PR DESCRIPTION
The C# extension requires access to the workspace files in order to run design-time builds.

Resolves #8144