### PR TITLE
Only send build only diagnostic ids requests for opening C# files

### DIFF
--- a/src/lsptoolshost/server/roslynLanguageServer.ts
+++ b/src/lsptoolshost/server/roslynLanguageServer.ts
@@ -895,6 +895,9 @@ export class RoslynLanguageServer {
         // When a file is opened process any build diagnostics that may be shown
         this._languageClient.addDisposable(
             vscode.workspace.onDidOpenTextDocument(async (event) => {
+                if (event.languageId !== 'csharp') {
+                    return;
+                }
                 try {
                     const buildIds = await this.getBuildOnlyDiagnosticIds(CancellationToken.None);
                     await this._buildDiagnosticService._onFileOpened(event, buildIds);


### PR DESCRIPTION
Related to https://github.com/dotnet/vscode-csharp/issues/8152 , but not the cause.  Razor is opening thousands of html files, causing us to send thousands of these requests