### PR TITLE
Ignore updates with no changes for csharp files

### DIFF
--- a/src/razor/src/document/IRazorDocumentChangeEvent.ts
+++ b/src/razor/src/document/IRazorDocumentChangeEvent.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ServerTextChange } from '../rpc/serverTextChange';
 import { IRazorDocument } from './IRazorDocument';
 import { RazorDocumentChangeKind } from './razorDocumentChangeKind';
 
 export interface IRazorDocumentChangeEvent {
     readonly document: IRazorDocument;
     readonly kind: RazorDocumentChangeKind;
+    readonly changes: ServerTextChange[];
 }

--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -237,6 +237,16 @@ export class RazorDocumentManager implements IRazorDocumentManager {
             );
         }
 
+        if (updateBufferRequest.changes.length === 0 && !updateBufferRequest.previousWasEmpty) {
+            if (this.logger.verboseEnabled) {
+                this.logger.logVerbose(
+                    `Update for '${updateBufferRequest.hostDocumentFilePath}' was empty. This shouldn't happen because it means the language server is doing extra work.`
+                );
+            }
+
+            return;
+        }
+
         const hostDocumentUri = vscode.Uri.file(updateBufferRequest.hostDocumentFilePath);
         const document = this._getDocument(hostDocumentUri);
         const projectedDocument = document.csharpDocument;

--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -20,6 +20,7 @@ import { createDocument } from './razorDocumentFactory';
 import { razorInitializeCommand } from '../../../lsptoolshost/razor/razorCommands';
 import { PlatformInformation } from '../../../shared/platform';
 import { v4 as uuidv4 } from 'uuid';
+import { ServerTextChange } from '../rpc/serverTextChange';
 
 export class RazorDocumentManager implements IRazorDocumentManager {
     public roslynActivated = false;
@@ -158,7 +159,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
 
         const document = this._getDocument(uri);
 
-        this.notifyDocumentChange(document, RazorDocumentChangeKind.opened);
+        this.notifyDocumentChange(document, RazorDocumentChangeKind.opened, []);
     }
 
     public async ensureRazorInitialized() {
@@ -189,7 +190,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
             }
         }
 
-        this.notifyDocumentChange(document, RazorDocumentChangeKind.closed);
+        this.notifyDocumentChange(document, RazorDocumentChangeKind.closed, []);
     }
 
     private addDocument(uri: vscode.Uri): IRazorDocument {
@@ -203,7 +204,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         document = createDocument(uri);
         this.razorDocuments[document.path] = document;
 
-        this.notifyDocumentChange(document, RazorDocumentChangeKind.added);
+        this.notifyDocumentChange(document, RazorDocumentChangeKind.added, []);
 
         return document;
     }
@@ -212,7 +213,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         const document = this._getDocument(uri);
         delete this.razorDocuments[document.path];
 
-        this.notifyDocumentChange(document, RazorDocumentChangeKind.removed);
+        this.notifyDocumentChange(document, RazorDocumentChangeKind.removed, []);
     }
 
     private findDocument(path: string) {
@@ -235,16 +236,6 @@ export class RazorDocumentManager implements IRazorDocumentManager {
                 `Updating the C# document for Razor file '${updateBufferRequest.hostDocumentFilePath}' ` +
                     `(${updateBufferRequest.hostDocumentVersion})`
             );
-        }
-
-        if (updateBufferRequest.changes.length === 0 && !updateBufferRequest.previousWasEmpty) {
-            if (this.logger.verboseEnabled) {
-                this.logger.logVerbose(
-                    `Update for '${updateBufferRequest.hostDocumentFilePath}' was empty. This shouldn't happen because it means the language server is doing extra work.`
-                );
-            }
-
-            return;
         }
 
         const hostDocumentUri = vscode.Uri.file(updateBufferRequest.hostDocumentFilePath);
@@ -277,7 +268,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
                 updateBufferRequest.encodingCodePage
             );
 
-            this.notifyDocumentChange(document, RazorDocumentChangeKind.csharpChanged);
+            this.notifyDocumentChange(document, RazorDocumentChangeKind.csharpChanged, updateBufferRequest.changes);
         } else {
             this.logger.logWarning(
                 'Failed to update the C# document buffer. This is unexpected and may result in incorrect C# interactions.'
@@ -320,7 +311,7 @@ export class RazorDocumentManager implements IRazorDocumentManager {
 
             htmlProjectedDocument.update(updateBufferRequest.changes, updateBufferRequest.hostDocumentVersion);
 
-            this.notifyDocumentChange(document, RazorDocumentChangeKind.htmlChanged);
+            this.notifyDocumentChange(document, RazorDocumentChangeKind.htmlChanged, updateBufferRequest.changes);
         } else {
             this.logger.logWarning(
                 'Failed to update the HTML document buffer. This is unexpected and may result in incorrect HTML interactions.'
@@ -328,16 +319,19 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         }
     }
 
-    private notifyDocumentChange(document: IRazorDocument, kind: RazorDocumentChangeKind) {
+    private notifyDocumentChange(document: IRazorDocument, kind: RazorDocumentChangeKind, changes: ServerTextChange[]) {
         if (this.logger.verboseEnabled) {
             this.logger.logVerbose(
-                `Notifying document '${getUriPath(document.uri)}' changed '${RazorDocumentChangeKind[kind]}'`
+                `Notifying document '${getUriPath(document.uri)}' changed '${RazorDocumentChangeKind[kind]}' with '${
+                    changes.length
+                }' changes.`
             );
         }
 
         const args: IRazorDocumentChangeEvent = {
             document,
             kind,
+            changes,
         };
 
         this.onChangeEmitter.fire(args);

--- a/src/razor/src/dynamicFile/dynamicFileInfoHandler.ts
+++ b/src/razor/src/dynamicFile/dynamicFileInfoHandler.ts
@@ -40,7 +40,7 @@ export class DynamicFileInfoHandler {
             }
         );
         this.documentManager.onChange(async (e) => {
-            if (e.kind == RazorDocumentChangeKind.csharpChanged && !e.document.isOpen) {
+            if (e.kind == RazorDocumentChangeKind.csharpChanged && !e.document.isOpen && e.changes.length > 0) {
                 const uriString = UriConverter.serialize(e.document.uri);
                 const identifier = TextDocumentIdentifier.create(uriString);
                 await vscode.commands.executeCommand(

--- a/src/razor/src/dynamicFile/dynamicFileInfoHandler.ts
+++ b/src/razor/src/dynamicFile/dynamicFileInfoHandler.ts
@@ -40,6 +40,8 @@ export class DynamicFileInfoHandler {
             }
         );
         this.documentManager.onChange(async (e) => {
+            // Ignore any updates without text changes. This is important for perf since sending an update to roslyn does
+            // a round trip for producing nothing new and causes a lot of churn in solution updates.
             if (e.kind == RazorDocumentChangeKind.csharpChanged && !e.document.isOpen && e.changes.length > 0) {
                 const uriString = UriConverter.serialize(e.document.uri);
                 const identifier = TextDocumentIdentifier.create(uriString);


### PR DESCRIPTION
Before https://github.com/dotnet/vscode-csharp/pull/7826 razor would use textdocument/{open, changed, closed} for csharp changes. That would mean that if the text didn't actually change vs code wouldn't notify roslyn. After that change the notification is handled for closed files by the razorDocumentManager. This causes a loop where csharp generated -> workspace changed for generated csharp -> workspace listeners notifies change -> generation is queued -> change is reported -> workspace changed for csharp -> ....

This is a quicker fix to hopefully unblock while I investigate a more comprehensive fix on the razor side
