### PR TITLE
Add cohost option to Razor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1536,6 +1536,11 @@
             "type": "boolean",
             "default": true,
             "description": "%configuration.razor.languageServer.useNewFormattingEngine%"
+          },
+          "razor.languageServer.cohostingEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "%configuration.razor.languageServer.cohostingEnabled%"
           }
         }
       },

--- a/package.nls.json
+++ b/package.nls.json
@@ -131,6 +131,7 @@
   "configuration.razor.languageServer.forceRuntimeCodeGeneration": "(EXPERIMENTAL) Enable combined design time/runtime code generation for Razor files",
   "configuration.razor.languageServer.suppressLspErrorToasts": "Suppresses error toasts from showing up if the server encounters a recoverable error.",
   "configuration.razor.languageServer.useNewFormattingEngine": "Use the new Razor formatting engine.",
+  "configuration.razor.languageServer.cohostingEnabled": "(EXPERIMENTAL) Enable Razor cohosting.",
   "debuggers.coreclr.configurationSnippets.label.console-local": ".NET: Launch Executable file (Console)",
   "debuggers.coreclr.configurationSnippets.label.web-local": ".NET: Launch Executable file (Web)",
   "debuggers.coreclr.configurationSnippets.label.attach-local": ".NET: Attach to a .NET process",

--- a/src/lsptoolshost/options/optionNameConverter.ts
+++ b/src/lsptoolshost/options/optionNameConverter.ts
@@ -3,16 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import assert from 'node:assert';
-
 export function convertServerOptionNameToClientConfigurationName(section: string): string | null {
     // Server name would be in format {languageName}|{grouping}.{name} or
-    // {grouping}.{name} if this option can be applied to multiple languages.
+    // {grouping}.{name} if this option can be applied to multiple languages or
+    // just {name} if this option is not in a group.
     const languageNameIndex = section.indexOf('|');
     if (languageNameIndex == -1 || section.substring(0, languageNameIndex) == 'csharp') {
         // 1. locate the last dot to find the {name} part.
         const lastDotIndex = section.lastIndexOf('.');
-        assert(lastDotIndex !== -1, `There is no . in ${section}.`);
         const optionName = section.substring(lastDotIndex + 1);
 
         // 2. Get {grouping} part.
@@ -25,7 +23,7 @@ export function convertServerOptionNameToClientConfigurationName(section: string
         // Example:
         // Grouping: implement_type
         // Name: dotnet_insertion_behavior
-        // Expect result is: dotnet.implmentType.insertionBehavior
+        // Expect result is: dotnet.implementType.insertionBehavior
         const prefixes = ['dotnet', 'csharp'];
         const optionNamePrefix = getPrefix(optionName, prefixes);
 
@@ -34,9 +32,11 @@ export function convertServerOptionNameToClientConfigurationName(section: string
         // Finally, convert everything to camel case and put them together.
         const camelCaseGroupName = convertToCamelCase(optionGroupName, '_');
         const camelCaseFeatureName = convertToCamelCase(featureName, '_');
-        return optionNamePrefix == ''
-            ? camelCaseGroupName.concat('.', camelCaseFeatureName)
-            : convertToCamelCase(optionNamePrefix, '_').concat('.', camelCaseGroupName, '.', camelCaseFeatureName);
+        const camelCasePrefixName = convertToCamelCase(optionNamePrefix, '_');
+
+        // Concatenate the three parts together, with dots as separators, but only if they are not empty.
+        const parts = [camelCasePrefixName, camelCaseGroupName, camelCaseFeatureName].filter((part) => part !== '');
+        return parts.join('.');
     }
 
     return null;

--- a/src/razor/src/extension.ts
+++ b/src/razor/src/extension.ts
@@ -78,6 +78,13 @@ export async function activate(
             logger
         );
 
+        if (razorOptions.cohostingEnabled) {
+            // TODO: We still need a document manager for Html, so need to do _some_ of the below, just not sure what yet,
+            // and it needs to be able to take a roslynLanguageServerClient instead of a razorLanguageServerClient I guess.
+
+            return;
+        }
+
         const hostExecutableResolver = new DotnetRuntimeExtensionResolver(
             platformInfo,
             () => razorOptions.serverPath,

--- a/src/razor/src/razorLanguageServerOptions.ts
+++ b/src/razor/src/razorLanguageServerOptions.ts
@@ -13,4 +13,5 @@ export interface RazorLanguageServerOptions {
     forceRuntimeCodeGeneration: boolean;
     suppressErrorToasts: boolean;
     useNewFormattingEngine: boolean;
+    cohostingEnabled: boolean;
 }

--- a/src/razor/src/razorLanguageServerOptionsResolver.ts
+++ b/src/razor/src/razorLanguageServerOptionsResolver.ts
@@ -37,6 +37,7 @@ export function resolveRazorLanguageServerOptions(
 
     const suppressErrorToasts = serverConfig.get<boolean>('suppressLspErrorToasts');
     const useNewFormattingEngine = serverConfig.get<boolean>('useNewFormattingEngine');
+    const cohostingEnabled = serverConfig.get<boolean>('cohostingEnabled');
 
     return {
         serverPath: languageServerExecutablePath,
@@ -46,6 +47,7 @@ export function resolveRazorLanguageServerOptions(
         forceRuntimeCodeGeneration,
         suppressErrorToasts,
         useNewFormattingEngine,
+        cohostingEnabled,
     } as RazorLanguageServerOptions;
 }
 


### PR DESCRIPTION
Goes with [roslyn] and [razor] to enable the start of Razor cohosting in VS Code.

Mainly just adding a new option, and using it to turn off a bunch of things, but also a slight tweak to configuration names which I'll call out.