### PR TITLE
Add mapping endpoints for VS Code

### DIFF
--- a/src/razor/src/document/razorDocumentManager.ts
+++ b/src/razor/src/document/razorDocumentManager.ts
@@ -55,6 +55,22 @@ export class RazorDocumentManager implements IRazorDocumentManager {
         return document;
     }
 
+    public async tryGetDOcumentFromCsharp(csharpUri: vscode.Uri): Promise<IRazorDocument | null> {
+        const isLinux = this.platformInfo.isLinux();
+        const documentPath = getUriPath(csharpUri);
+        const document = Object.values(this.razorDocuments).find((document) => {
+            if (isLinux && document.csharpDocument.path == documentPath) {
+                return document;
+            } else if (
+                document.csharpDocument.path.localeCompare(documentPath, undefined, { sensitivity: 'base' }) === 0
+            ) {
+                return document;
+            }
+        });
+
+        return document ?? null;
+    }
+
     public async getActiveDocument(): Promise<IRazorDocument | null> {
         if (!vscode.window.activeTextEditor) {
             return null;

--- a/src/razor/src/mapping/mapSpanHandler.ts
+++ b/src/razor/src/mapping/mapSpanHandler.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { TextDocumentIdentifier } from 'vscode-languageserver-types';
+import { RazorDocumentManager } from '../document/razorDocumentManager';
+import { RazorLanguageServerClient } from '../razorLanguageServerClient';
+import { razorTextSpan } from '../dynamicFile/razorTextSpan';
+import * as vscode from 'vscode';
+import { RequestType } from 'vscode-jsonrpc';
+import { RazorLogger } from '../razorLogger';
+import { LanguageKind } from '../rpc/languageKind';
+import { razorTextChange } from '../dynamicFile/razorTextChange';
+import { MappingBehavior } from '../rpc/mappingBehavior';
+import { UriConverter } from '../../../lsptoolshost/utils/uriConverter';
+import { RazorMapToDocumentRangesResponse } from '../rpc/razorMapToDocumentRangesResponse';
+import { RazorMapToDocumentEditsParams } from '../rpc/razorMapToDocumentEditsParams';
+import { RazorMapToDocumentEditsResponse } from '../rpc/razorMapToDocumentEditsResponse';
+import { RazorMapToDocumentRangesRequest } from '../rpc/razorMapToDocumentRangesRequest';
+
+export class MapSpanHandler {
+    private static readonly mapSpansEndpoint = 'razor/mapSpans';
+    private static readonly mapTextChangesEndpoint = 'razor/mapTextChanges';
+
+    private mapSpansRequestType: RequestType<MapSpanParams, MapSpansResponse, any> = new RequestType(
+        MapSpanHandler.mapSpansEndpoint
+    );
+
+    private mapTextChangesRequestType: RequestType<MapChangesParams, MapChangesResponse, any> = new RequestType(
+        MapSpanHandler.mapTextChangesEndpoint
+    );
+
+    constructor(
+        private readonly documentManager: RazorDocumentManager,
+        private readonly serverClient: RazorLanguageServerClient,
+        private readonly logger: RazorLogger
+    ) {}
+
+    public async register() {
+        await this.serverClient.onRequestWithParams<MapSpanParams, MapSpansResponse | null, any>(
+            this.mapSpansRequestType,
+            async (request: MapSpanParams, token: vscode.CancellationToken) => this.mapSpans(request, token)
+        );
+
+        await this.serverClient.onRequestWithParams<MapChangesParams, MapChangesResponse | null, any>(
+            this.mapTextChangesRequestType,
+            async (request: MapChangesParams, token: vscode.CancellationToken) => this.mapEdits(request, token)
+        );
+    }
+    private async mapEdits(params: MapChangesParams, _: vscode.CancellationToken): Promise<MapChangesResponse | null> {
+        try {
+            const csharpDocumentUri = vscode.Uri.parse(params.csharpDocument.uri);
+            const document = await this.documentManager.tryGetDOcumentFromCsharp(csharpDocumentUri);
+            if (document === null) {
+                this.logger.logWarning(
+                    `${MapSpanHandler.mapSpansEndpoint} failed to find razor document for ${csharpDocumentUri}`
+                );
+
+                return null;
+            }
+
+            const razorUri = document.uri;
+            const request: RazorMapToDocumentEditsParams = {
+                kind: LanguageKind.CSharp,
+                razorDocumentUri: razorUri,
+                textChanges: params.textChanges,
+            };
+
+            const response = await this.serverClient.sendRequest<RazorMapToDocumentEditsResponse>('', request);
+            if (!response) {
+                return null;
+            }
+
+            return {
+                razorDocument: { uri: razorUri.fsPath },
+                mappedTextChanges: response.textChanges,
+            };
+        } catch (error) {
+            this.logger.logWarning(`${MapSpanHandler.mapSpansEndpoint} failed with ${error}`);
+        }
+
+        return null;
+    }
+    private async mapSpans(request: MapSpanParams, _: vscode.CancellationToken): Promise<MapSpansResponse | null> {
+        try {
+            const csharpDocumentUri = vscode.Uri.parse(request.csharpDocument.uri);
+            const document = await this.documentManager.tryGetDOcumentFromCsharp(csharpDocumentUri);
+            if (document === null) {
+                this.logger.logWarning(
+                    `${MapSpanHandler.mapSpansEndpoint} failed to find razor document for ${csharpDocumentUri}`
+                );
+
+                return null;
+            }
+
+            const razorUri = document.uri;
+            const params = new RazorMapToDocumentRangesRequest(
+                LanguageKind.CSharp,
+                request.ranges,
+                razorUri,
+                MappingBehavior.Strict
+            );
+
+            const response = await this.serverClient.sendRequest<RazorMapToDocumentRangesResponse>(
+                'razor/mapToDocumentRanges',
+                params
+            );
+
+            return {
+                razorDocument: TextDocumentIdentifier.create(UriConverter.serialize(razorUri)),
+                mappedRanges: response.ranges,
+                mappedSpans: response.spans,
+            };
+        } catch (error) {
+            this.logger.logWarning(`${MapSpanHandler.mapSpansEndpoint} failed with ${error}`);
+        }
+
+        return null;
+    }
+}
+
+interface MapSpanParams {
+    csharpDocument: TextDocumentIdentifier;
+    ranges: vscode.Range[];
+}
+
+interface MapSpansResponse {
+    razorDocument: TextDocumentIdentifier;
+    mappedSpans: razorTextSpan[];
+    mappedRanges: vscode.Range[];
+}
+
+interface MapChangesParams {
+    csharpDocument: TextDocumentIdentifier;
+    textChanges: razorTextChange[];
+}
+
+interface MapChangesResponse {
+    razorDocument: TextDocumentIdentifier;
+    mappedTextChanges: razorTextChange[];
+}

--- a/src/razor/src/razorLanguageServiceClient.ts
+++ b/src/razor/src/razorLanguageServiceClient.ts
@@ -11,6 +11,7 @@ import { LanguageQueryResponse } from './rpc/languageQueryResponse';
 import { RazorMapToDocumentRangesRequest } from './rpc/razorMapToDocumentRangesRequest';
 import { RazorMapToDocumentRangesResponse } from './rpc/razorMapToDocumentRangesResponse';
 import { convertRangeFromSerializable, convertRangeToSerializable } from './rpc/serializableRange';
+import { MappingBehavior } from './rpc/mappingBehavior';
 
 export class RazorLanguageServiceClient {
     constructor(private readonly serverClient: RazorLanguageServerClient) {}
@@ -33,7 +34,12 @@ export class RazorLanguageServiceClient {
             serializableRanges.push(serializableRange);
         }
 
-        const request = new RazorMapToDocumentRangesRequest(languageKind, serializableRanges, uri);
+        const request = new RazorMapToDocumentRangesRequest(
+            languageKind,
+            serializableRanges,
+            uri,
+            MappingBehavior.Inclusive
+        );
         const response = await this.serverClient.sendRequest<RazorMapToDocumentRangesResponse>(
             'razor/mapToDocumentRanges',
             request

--- a/src/razor/src/rpc/mappingBehavior.ts
+++ b/src/razor/src/rpc/mappingBehavior.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export enum MappingBehavior {
+    Strict,
+    Inclusive,
+    Inferred,
+}

--- a/src/razor/src/rpc/razorMapToDocumentEditsParams.ts
+++ b/src/razor/src/rpc/razorMapToDocumentEditsParams.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+import { razorTextChange } from '../dynamicFile/razorTextChange';
+import { LanguageKind } from './languageKind';
+
+export interface RazorMapToDocumentEditsParams {
+    kind: LanguageKind;
+    razorDocumentUri: vscode.Uri;
+    textChanges: razorTextChange[];
+}

--- a/src/razor/src/rpc/razorMapToDocumentEditsResponse.ts
+++ b/src/razor/src/rpc/razorMapToDocumentEditsResponse.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { razorTextChange } from '../dynamicFile/razorTextChange';
+
+export interface RazorMapToDocumentEditsResponse {
+    textChanges: razorTextChange[];
+    hostDocumentVersion: number | null;
+}

--- a/src/razor/src/rpc/razorMapToDocumentRangesRequest.ts
+++ b/src/razor/src/rpc/razorMapToDocumentRangesRequest.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { LanguageKind } from './languageKind';
 import { SerializableRange } from './serializableRange';
+import { MappingBehavior } from './mappingBehavior';
 
 export class RazorMapToDocumentRangesRequest {
     public readonly razorDocumentUri: string;
@@ -13,7 +14,8 @@ export class RazorMapToDocumentRangesRequest {
     constructor(
         public readonly kind: LanguageKind,
         public readonly projectedRanges: SerializableRange[],
-        razorDocumentUri: vscode.Uri
+        razorDocumentUri: vscode.Uri,
+        public readonly mappingBehavior: MappingBehavior
     ) {
         this.razorDocumentUri = razorDocumentUri.toString();
     }

--- a/src/razor/src/rpc/razorMapToDocumentRangesResponse.ts
+++ b/src/razor/src/rpc/razorMapToDocumentRangesResponse.ts
@@ -4,8 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { razorTextSpan } from '../dynamicFile/razorTextSpan';
 
 export interface RazorMapToDocumentRangesResponse {
     ranges: vscode.Range[];
-    hostDocumentVersion: number;
+    spans: razorTextSpan[];
+    hostDocumentVersion: number | null;
 }


### PR DESCRIPTION
Hooks up the handlers for mapping spans/changes in generated csharp files. 

Requires https://github.com/dotnet/razor/pull/11673
