### PR TITLE
Support Html requests in cohosting

### DIFF
--- a/src/lsptoolshost/activate.ts
+++ b/src/lsptoolshost/activate.ts
@@ -86,7 +86,7 @@ export async function activateRoslynLanguageServer(
     registerCodeActionFixAllCommands(context, languageServer, _channel);
 
     registerRazorCommands(context, languageServer);
-    registerRazorEndpoints(context, languageServer, razorLogger);
+    registerRazorEndpoints(context, languageServer, razorLogger, platformInfo);
 
     registerUnitTestingCommands(context, languageServer);
 

--- a/src/lsptoolshost/razor/htmlDocument.ts
+++ b/src/lsptoolshost/razor/htmlDocument.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { getUriPath } from '../../razor/src/uriPaths';
+
+export class HtmlDocument {
+    public readonly path: string;
+    private content = '';
+
+    public constructor(public readonly uri: vscode.Uri) {
+        this.path = getUriPath(uri);
+    }
+
+    public getContent() {
+        return this.content;
+    }
+
+    public setContent(content: string) {
+        this.content = content;
+    }
+}

--- a/src/lsptoolshost/razor/htmlDocumentContentProvider.ts
+++ b/src/lsptoolshost/razor/htmlDocumentContentProvider.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { HtmlDocumentManager } from './htmlDocumentManager';
+import { RazorLogger } from '../../razor/src/razorLogger';
+import { getUriPath } from '../../razor/src/uriPaths';
+
+export class HtmlDocumentContentProvider implements vscode.TextDocumentContentProvider {
+    public static readonly scheme = 'razor-html';
+
+    private readonly onDidChangeEmitter: vscode.EventEmitter<vscode.Uri> = new vscode.EventEmitter<vscode.Uri>();
+
+    constructor(private readonly documentManager: HtmlDocumentManager, private readonly logger: RazorLogger) {}
+
+    public get onDidChange() {
+        return this.onDidChangeEmitter.event;
+    }
+
+    public fireDidChange(uri: vscode.Uri) {
+        this.onDidChangeEmitter.fire(uri);
+    }
+
+    public provideTextDocumentContent(uri: vscode.Uri) {
+        const document = this.findDocument(uri);
+        if (!document) {
+            // Document was removed from the document manager, meaning there's no more content for this
+            // file. Report an empty document.
+            this.logger.logVerbose(
+                `Could not find document '${getUriPath(
+                    uri
+                )}' when updating the HTML buffer. This typically happens when a document is removed.`
+            );
+            return '';
+        }
+
+        return document.getContent();
+    }
+
+    private findDocument(uri: vscode.Uri) {
+        const projectedPath = getUriPath(uri);
+
+        return this.documentManager.documents.find(
+            (document) => document.path.localeCompare(projectedPath, undefined, { sensitivity: 'base' }) === 0
+        );
+    }
+}

--- a/src/lsptoolshost/razor/htmlDocumentManager.ts
+++ b/src/lsptoolshost/razor/htmlDocumentManager.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { RazorLogger } from '../../razor/src/razorLogger';
+import { PlatformInformation } from '../../shared/platform';
+import { getUriPath } from '../../razor/src/uriPaths';
+import { virtualHtmlSuffix } from '../../razor/src/razorConventions';
+import { HtmlDocumentContentProvider } from './htmlDocumentContentProvider';
+import { HtmlDocument } from './htmlDocument';
+
+export class HtmlDocumentManager {
+    private readonly htmlDocuments: { [hostDocumentPath: string]: HtmlDocument } = {};
+    private readonly contentProvider: HtmlDocumentContentProvider;
+
+    constructor(private readonly platformInfo: PlatformInformation, private readonly logger: RazorLogger) {
+        this.contentProvider = new HtmlDocumentContentProvider(this, this.logger);
+    }
+
+    public get documents() {
+        return Object.values(this.htmlDocuments);
+    }
+
+    public register() {
+        const didCloseRegistration = vscode.workspace.onDidCloseTextDocument(async (document) => {
+            if (document.languageId !== 'html') {
+                return;
+            }
+
+            await this.closeDocument(document.uri);
+        });
+
+        const providerRegistration = vscode.workspace.registerTextDocumentContentProvider(
+            HtmlDocumentContentProvider.scheme,
+            this.contentProvider
+        );
+
+        return vscode.Disposable.from(didCloseRegistration, providerRegistration);
+    }
+
+    public async updateDocumentText(uri: vscode.Uri, text: string) {
+        const document = await this.getDocument(uri);
+
+        this.logger.logVerbose(`New content for '${uri}', updating '${document.path}'.`);
+
+        document.setContent(text);
+
+        this.contentProvider.fireDidChange(document.uri);
+    }
+
+    private async closeDocument(uri: vscode.Uri) {
+        const document = await this.getDocument(uri);
+
+        if (document) {
+            this.logger.logVerbose(`Document '${document.uri}' was closed. Removing from the document manager.`);
+
+            delete this.htmlDocuments[document.path];
+        }
+    }
+
+    public async getDocument(uri: vscode.Uri): Promise<HtmlDocument> {
+        let document = this.findDocument(uri);
+
+        // This might happen in the case that a file is opened outside the workspace
+        if (!document) {
+            this.logger.logMessage(
+                `File '${uri}' didn't exist in the Razor document list. This is likely because it's from outside the workspace.`
+            );
+            document = this.addDocument(uri);
+        }
+
+        await vscode.workspace.openTextDocument(document.uri);
+
+        return document!;
+    }
+
+    private addDocument(uri: vscode.Uri): HtmlDocument {
+        let document = this.findDocument(uri);
+        if (document) {
+            this.logger.logMessage(`Skipping document creation for '${document.path}' because it already exists.`);
+            return document;
+        }
+
+        document = this.createDocument(uri);
+        this.htmlDocuments[document.path] = document;
+
+        return document;
+    }
+
+    private findDocument(uri: vscode.Uri): HtmlDocument | undefined {
+        let path = getUriPath(uri);
+
+        // We might be passed a Razor document Uri, but we store and manage Html projected documents.
+        if (uri.scheme !== HtmlDocumentContentProvider.scheme) {
+            path = `${path}${virtualHtmlSuffix}`;
+        }
+
+        if (this.platformInfo.isLinux()) {
+            return this.htmlDocuments[path];
+        }
+
+        return Object.values(this.htmlDocuments).find(
+            (document) => document.path.localeCompare(path, undefined, { sensitivity: 'base' }) === 0
+        );
+    }
+
+    private createDocument(uri: vscode.Uri) {
+        uri = uri.with({
+            scheme: HtmlDocumentContentProvider.scheme,
+            path: `${uri.path}${virtualHtmlSuffix}`,
+        });
+        const projectedDocument = new HtmlDocument(uri);
+
+        return projectedDocument;
+    }
+}

--- a/src/lsptoolshost/razor/htmlUpdateParameters.ts
+++ b/src/lsptoolshost/razor/htmlUpdateParameters.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TextDocumentIdentifier } from 'vscode-languageserver-protocol';
+
+export class HtmlUpdateParameters {
+    constructor(public readonly textDocument: TextDocumentIdentifier, public readonly text: string) {}
+}

--- a/src/lsptoolshost/razor/razorEndpoints.ts
+++ b/src/lsptoolshost/razor/razorEndpoints.ts
@@ -5,13 +5,25 @@
 
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import * as vscode from 'vscode';
-import { LogMessageParams, NotificationType, RequestType } from 'vscode-languageclient';
+import {
+    ColorInformation,
+    ColorPresentationParams,
+    ColorPresentationRequest,
+    DocumentColorParams,
+    DocumentColorRequest,
+    LogMessageParams,
+    NotificationType,
+    RequestType,
+} from 'vscode-languageclient';
 import { RazorLogger } from '../../razor/src/razorLogger';
 import { HtmlUpdateParameters } from './htmlUpdateParameters';
 import { UriConverter } from '../utils/uriConverter';
 import { PlatformInformation } from '../../shared/platform';
 import { HtmlDocumentManager } from './htmlDocumentManager';
+import { DocumentColorHandler } from '../../razor/src/documentColor/documentColorHandler';
 import { razorOptions } from '../../shared/options';
+import { ColorPresentationHandler } from '../../razor/src/colorPresentation/colorPresentationHandler';
+import { ColorPresentation } from 'vscode-html-languageservice';
 
 export function registerRazorEndpoints(
     context: vscode.ExtensionContext,
@@ -35,6 +47,23 @@ export function registerRazorEndpoints(
         const uri = UriConverter.deserialize(params.textDocument.uri);
         await documentManager.updateDocumentText(uri, params.text);
     });
+
+    registerRequestHandler<DocumentColorParams, ColorInformation[]>(DocumentColorRequest.method, async (params) => {
+        const uri = UriConverter.deserialize(params.textDocument.uri);
+        const document = await documentManager.getDocument(uri);
+
+        return await DocumentColorHandler.doDocumentColorRequest(document.uri);
+    });
+
+    registerRequestHandler<ColorPresentationParams, ColorPresentation[]>(
+        ColorPresentationRequest.method,
+        async (params) => {
+            const uri = UriConverter.deserialize(params.textDocument.uri);
+            const document = await documentManager.getDocument(uri);
+
+            return await ColorPresentationHandler.doColorPresentationRequest(document.uri, params);
+        }
+    );
 
     // Helper method that registers a request handler, and logs errors to the Razor logger.
     function registerRequestHandler<Params, Result>(method: string, invocation: (params: Params) => Promise<Result>) {

--- a/src/razor/src/colorPresentation/colorPresentationHandler.ts
+++ b/src/razor/src/colorPresentation/colorPresentationHandler.ts
@@ -54,22 +54,9 @@ export class ColorPresentationHandler {
                 return this.emptyColorInformationResponse;
             }
 
-            const color = new vscode.Color(
-                colorPresentationParams.color.red,
-                colorPresentationParams.color.green,
-                colorPresentationParams.color.blue,
-                colorPresentationParams.color.alpha
-            );
             const virtualHtmlUri = razorDocument.htmlDocument.uri;
 
-            const colorPresentations = await vscode.commands.executeCommand<vscode.ColorPresentation[]>(
-                'vscode.executeColorPresentationProvider',
-                color,
-                new ColorPresentationContext(virtualHtmlUri, colorPresentationParams.range)
-            );
-
-            const serializableColorPresentations = this.SerializeColorPresentations(colorPresentations);
-            return serializableColorPresentations;
+            return await ColorPresentationHandler.doColorPresentationRequest(virtualHtmlUri, colorPresentationParams);
         } catch (error) {
             this.logger.logWarning(`${ColorPresentationHandler.provideHtmlColorPresentation} failed with ${error}`);
         }
@@ -77,7 +64,28 @@ export class ColorPresentationHandler {
         return this.emptyColorInformationResponse;
     }
 
-    private SerializeColorPresentations(colorPresentations: vscode.ColorPresentation[]) {
+    public static async doColorPresentationRequest(
+        virtualHtmlUri: vscode.Uri,
+        colorPresentationParams: SerializableColorPresentationParams
+    ) {
+        const color = new vscode.Color(
+            colorPresentationParams.color.red,
+            colorPresentationParams.color.green,
+            colorPresentationParams.color.blue,
+            colorPresentationParams.color.alpha
+        );
+
+        const colorPresentations = await vscode.commands.executeCommand<vscode.ColorPresentation[]>(
+            'vscode.executeColorPresentationProvider',
+            color,
+            new ColorPresentationContext(virtualHtmlUri, colorPresentationParams.range)
+        );
+
+        const serializableColorPresentations = ColorPresentationHandler.SerializeColorPresentations(colorPresentations);
+        return serializableColorPresentations;
+    }
+
+    private static SerializeColorPresentations(colorPresentations: vscode.ColorPresentation[]) {
         const serializableColorPresentations = new Array<SerializableColorPresentation>();
         for (const colorPresentation of colorPresentations) {
             let serializedTextEdit: any = null;

--- a/src/razor/src/documentColor/documentColorHandler.ts
+++ b/src/razor/src/documentColor/documentColorHandler.ts
@@ -67,24 +67,27 @@ export class DocumentColorHandler {
             }
 
             const virtualHtmlUri = razorDocument.htmlDocument.uri;
-
-            const colorInformation = await vscode.commands.executeCommand<vscode.ColorInformation[]>(
-                'vscode.executeDocumentColorProvider',
-                virtualHtmlUri
-            );
-
-            const serializableColorInformation = new Array<SerializableColorInformation>();
-            for (const color of colorInformation) {
-                const serializableRange = convertRangeToSerializable(color.range);
-                const serializableColor = new SerializableColorInformation(serializableRange, color.color);
-                serializableColorInformation.push(serializableColor);
-            }
-
-            return serializableColorInformation;
+            return await DocumentColorHandler.doDocumentColorRequest(virtualHtmlUri);
         } catch (error) {
             this.logger.logWarning(`${DocumentColorHandler.provideHtmlDocumentColorEndpoint} failed with ${error}`);
         }
 
         return this.emptyColorInformationResponse;
+    }
+
+    public static async doDocumentColorRequest(virtualHtmlUri: vscode.Uri) {
+        const colorInformation = await vscode.commands.executeCommand<vscode.ColorInformation[]>(
+            'vscode.executeDocumentColorProvider',
+            virtualHtmlUri
+        );
+
+        const serializableColorInformation = new Array<SerializableColorInformation>();
+        for (const color of colorInformation) {
+            const serializableRange = convertRangeToSerializable(color.range);
+            const serializableColor = new SerializableColorInformation(serializableRange, color.color);
+            serializableColorInformation.push(serializableColor);
+        }
+
+        return serializableColorInformation;
     }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/11759

This is the guts of how html requests work in cohosting. Relatively simple, most of the work is now on the server. Also adds support for document color and color presentation as the first two test candidates.