### PR TITLE
Port the rest of the cohosting endpoints to VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,9 @@
   * Fix some hardcoded values in cohosting (#11817) (PR: [#11817](https://github.com/dotnet/razor/pull/11817))
   * Add new shared SelectXXXAsArray helpers (#11796) (PR: [#11796](https://github.com/dotnet/razor/pull/11796))
 * Bump Roslyn to 5.0.0-1.25255.4 (PR: [#8249](https://github.com/dotnet/vscode-csharp/pull/8249))
-  * Move RestoreUseStaticGraphEvaluation setting inside repo (#78429) (PR: [#78429](https://github.com/dotnet/roslyn/pull/78429))
-  * Adjust LocalBinderFactory.VisitInvocationExpression to handle attributes on extension parameter (#78399) (PR: [#78399](https://github.com/dotnet/roslyn/pull/78399))
-  * Exclude EditorFeatures from rebuild check (#78437) (PR: [#78437](https://github.com/dotnet/roslyn/pull/78437))
   * Ensure hover markdown for supported platforms uses non-breaking spaces for indentation (#78405) (PR: [#78405](https://github.com/dotnet/roslyn/pull/78405))
   * Change O(n) + O(lg n) search in SolutionState.SortedProjectStates to just O(lg n) (#78427) (PR: [#78427](https://github.com/dotnet/roslyn/pull/78427))
   * Fix syntax tree creation when modifying source generated documents (#78343) (PR: [#78343](https://github.com/dotnet/roslyn/pull/78343))
-  * Revert back to scouting queue (#78424) (PR: [#78424](https://github.com/dotnet/roslyn/pull/78424))
-  * Precursor work to merge EditorFeatures.WPF into EditorFeatures. (#78308) (PR: [#78308](https://github.com/dotnet/roslyn/pull/78308))
-  * Implement workaround for missing ValueTuple in remote debugger (#78393) (PR: [#78393](https://github.com/dotnet/roslyn/pull/78393))
 
 # 2.76.x
 * Bump Razor to 10.0.0-preview.25252.1 (PR: [#8239](https://github.com/dotnet/vscode-csharp/pull/8239))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.77.x
+* Bump Razor to 10.0.0-preview.25255.4 (PR: [#8249](https://github.com/dotnet/vscode-csharp/pull/8249))
+  * Port remaining cohosting endpoints to VS Code (#11815) (PR: [#11815](https://github.com/dotnet/razor/pull/11815))
+  * Fix cohost semantic tokens in VS Code (#11816) (PR: [#11816](https://github.com/dotnet/razor/pull/11816))
+  * Fix some hardcoded values in cohosting (#11817) (PR: [#11817](https://github.com/dotnet/razor/pull/11817))
+  * Add new shared SelectXXXAsArray helpers (#11796) (PR: [#11796](https://github.com/dotnet/razor/pull/11796))
+* Bump Roslyn to 5.0.0-1.25255.4 (PR: [#8249](https://github.com/dotnet/vscode-csharp/pull/8249))
+  * Move RestoreUseStaticGraphEvaluation setting inside repo (#78429) (PR: [#78429](https://github.com/dotnet/roslyn/pull/78429))
+  * Adjust LocalBinderFactory.VisitInvocationExpression to handle attributes on extension parameter (#78399) (PR: [#78399](https://github.com/dotnet/roslyn/pull/78399))
+  * Exclude EditorFeatures from rebuild check (#78437) (PR: [#78437](https://github.com/dotnet/roslyn/pull/78437))
+  * Ensure hover markdown for supported platforms uses non-breaking spaces for indentation (#78405) (PR: [#78405](https://github.com/dotnet/roslyn/pull/78405))
+  * Change O(n) + O(lg n) search in SolutionState.SortedProjectStates to just O(lg n) (#78427) (PR: [#78427](https://github.com/dotnet/roslyn/pull/78427))
+  * Fix syntax tree creation when modifying source generated documents (#78343) (PR: [#78343](https://github.com/dotnet/roslyn/pull/78343))
+  * Revert back to scouting queue (#78424) (PR: [#78424](https://github.com/dotnet/roslyn/pull/78424))
+  * Precursor work to merge EditorFeatures.WPF into EditorFeatures. (#78308) (PR: [#78308](https://github.com/dotnet/roslyn/pull/78308))
+  * Implement workaround for missing ValueTuple in remote debugger (#78393) (PR: [#78393](https://github.com/dotnet/roslyn/pull/78393))
 
 # 2.76.x
 * Bump Razor to 10.0.0-preview.25252.1 (PR: [#8239](https://github.com/dotnet/vscode-csharp/pull/8239))

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.0.0-1.25252.3",
+    "roslyn": "5.0.0-1.25255.4",
     "omniSharp": "1.39.12",
-    "razor": "10.0.0-preview.25252.1",
+    "razor": "10.0.0-preview.25255.4",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.36010.33"
   },

--- a/src/lsptoolshost/razor/razorEndpoints.ts
+++ b/src/lsptoolshost/razor/razorEndpoints.ts
@@ -6,43 +6,28 @@
 import * as vscode from 'vscode';
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import {
-    ColorInformation,
-    ColorPresentationParams,
     ColorPresentationRequest,
-    CompletionList,
-    CompletionParams,
     CompletionRequest,
-    DefinitionParams,
     DefinitionRequest,
-    DocumentColorParams,
     DocumentColorRequest,
-    DocumentFormattingParams,
     DocumentFormattingRequest,
     DocumentHighlight,
     DocumentHighlightKind,
-    DocumentHighlightParams,
     DocumentHighlightRequest,
-    DocumentOnTypeFormattingParams,
     DocumentOnTypeFormattingRequest,
-    FoldingRange,
-    FoldingRangeParams,
     FoldingRangeRequest,
     Hover,
-    HoverParams,
     HoverRequest,
-    ImplementationParams,
     ImplementationRequest,
     Location,
     LogMessageParams,
     MarkupKind,
+    MarkupContent,
     NotificationType,
-    ReferenceParams,
     ReferencesRequest,
     RequestType,
     SignatureHelp,
-    SignatureHelpParams,
     SignatureHelpRequest,
-    TextEdit,
 } from 'vscode-languageclient';
 import { RazorLogger } from '../../razor/src/razorLogger';
 import { HtmlUpdateParameters } from './htmlUpdateParameters';
@@ -52,7 +37,6 @@ import { HtmlDocumentManager } from './htmlDocumentManager';
 import { DocumentColorHandler } from '../../razor/src/documentColor/documentColorHandler';
 import { razorOptions } from '../../shared/options';
 import { ColorPresentationHandler } from '../../razor/src/colorPresentation/colorPresentationHandler';
-import { ColorPresentation, MarkupContent } from 'vscode-html-languageservice';
 import { convertRangeToSerializable } from '../../razor/src/rpc/serializableRange';
 import { FoldingRangeHandler } from '../../razor/src/folding/foldingRangeHandler';
 import { CompletionHandler } from '../../razor/src/completion/completionHandler';


### PR DESCRIPTION
This is everything we currently support.

Razor side: https://github.com/dotnet/razor/pull/11815
Part of https://github.com/dotnet/razor/issues/11759

Now including bumps for Roslyn:
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/8b20c85884883c20dd8352805d5ffd6f1fff3827...e57ec163ea3c7ef815214036e1c0169ed2bb65db?w=1)
  * Move RestoreUseStaticGraphEvaluation setting inside repo (#78429) (PR: [#78429](https://github.com/dotnet/roslyn/pull/78429))
  * Adjust LocalBinderFactory.VisitInvocationExpression to handle attributes on extension parameter (#78399) (PR: [#78399](https://github.com/dotnet/roslyn/pull/78399))
  * Exclude EditorFeatures from rebuild check (#78437) (PR: [#78437](https://github.com/dotnet/roslyn/pull/78437))
  * Ensure hover markdown for supported platforms uses non-breaking spaces for indentation (#78405) (PR: [#78405](https://github.com/dotnet/roslyn/pull/78405))
  * Change O(n) + O(lg n) search in SolutionState.SortedProjectStates to just O(lg n) (#78427) (PR: [#78427](https://github.com/dotnet/roslyn/pull/78427))
  * Fix syntax tree creation when modifying source generated documents (#78343) (PR: [#78343](https://github.com/dotnet/roslyn/pull/78343))
  * Revert back to scouting queue (#78424) (PR: [#78424](https://github.com/dotnet/roslyn/pull/78424))
  * Precursor work to merge EditorFeatures.WPF into EditorFeatures. (#78308) (PR: [#78308](https://github.com/dotnet/roslyn/pull/78308))
  * Skip generate analyzer documentation to unblock ci (#78412) (PR: [#78412](https://github.com/dotnet/roslyn/pull/78412))
  * Switch to non-scouting queue to unblock CI (#78407) (PR: [#78407](https://github.com/dotnet/roslyn/pull/78407))
  * Implement workaround for missing ValueTuple in remote debugger (#78393) (PR: [#78393](https://github.com/dotnet/roslyn/pull/78393))

and Razor:
[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/98e74370f0ac419f80d9c2f1a9050fa84f33bce5...9e23fe8b6d1dba3e8f0e76274074c413a588f976?w=1)
  * Port remaining cohosting endpoints to VS Code (#11815) (PR: [#11815](https://github.com/dotnet/razor/pull/11815))
  * Fix cohost semantic tokens in VS Code (#11816) (PR: [#11816](https://github.com/dotnet/razor/pull/11816))
  * Fix some hardcoded values in cohosting (#11817) (PR: [#11817](https://github.com/dotnet/razor/pull/11817))
  * Add new shared SelectXXXAsArray helpers (#11796) (PR: [#11796](https://github.com/dotnet/razor/pull/11796))