### PR TITLE
Configure `jest.runMode` to run `on-demand`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,5 @@
     "editor.formatOnSave": false,
     "eslint.lintTask.enable": true,
     "dotnet.defaultSolution": "disable",
-    "jest.autoRun": "off",
+    "jest.runMode": "on-demand",
 }


### PR DESCRIPTION
In version 6.2 of vscode-jest the `jest.autoRun` setting [was replaced](https://github.com/jest-community/vscode-jest/blob/master/release-notes/release-note-v6.md#new-features-summary:~:text=Replace%20%22autoRun%22%20with%20%22runMode%22) with `jest.runMode`.