### PR TITLE
fix: set default value for enableFileBasedPrograms to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1509,7 +1509,7 @@
           },
           "dotnet.projects.enableFileBasedPrograms": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "%configuration.dotnet.projects.enableFileBasedPrograms%",
             "tags": [
               "preview"


### PR DESCRIPTION
This pull request includes a single change to the `package.json` file, updating the default value for the `dotnet.projects.enableFileBasedPrograms` configuration setting from `true` to `false`.

This is meant to address issue #8314 