### PR TITLE
Fix environment name

### DIFF
--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -34,7 +34,7 @@ extends:
       jobs:
       - deployment: PublishToMarketplace
         displayName: PublishToMarketplace
-        environment: vscode-csharp-release
+        environment: vscode-csharp-release-approvals
         pool:
           name: netcore1espool-internal
           image: 1es-ubuntu-2204


### PR DESCRIPTION
the old environment was deleted (no permissions), and the new one was renamed back to the old name.   So now have to update this