### PR TITLE
mention devkit component in local server path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ In your workspace `settings.json` file, add the following lines:
 "dotnet.server.waitForDebugger": true,
 "dotnet.server.path": "<roslynRepoRoot>/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net9.0/Microsoft.CodeAnalysis.LanguageServer.dll"
 "dotnet.server.componentPaths": {
-    "roslynDevKit": "<roslynRepoRoot>/artifacts/bin/Microsoft.VisualStudio.LanguageServices.DevKit/Debug/net9.0
+    "roslynDevKit": "<roslynRepoRoot>/artifacts/bin/Microsoft.VisualStudio.LanguageServices.DevKit/Debug/net9.0"
 },
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,9 @@ In your workspace `settings.json` file, add the following lines:
 ```json
 "dotnet.server.waitForDebugger": true,
 "dotnet.server.path": "<roslynRepoRoot>/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net9.0/Microsoft.CodeAnalysis.LanguageServer.dll"
+"dotnet.server.componentPaths": {
+    "roslynDevKit": "<roslynRepoRoot>/artifacts/bin/Microsoft.VisualStudio.LanguageServices.DevKit/Debug/net9.0
+},
 ```
 
 Replace <roslynRepoRoot> with the actual path to your Roslyn repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,23 +115,28 @@ This section provides instructions on how to debug locally built Roslyn and Razo
 
 #### Configuring Roslyn Language Server
 
-In your workspace `settings.json` file, add the following lines:
+In your `settings.json` file, add the following lines:
 
 ```json
 "dotnet.server.waitForDebugger": true,
 "dotnet.server.path": "<roslynRepoRoot>/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net9.0/Microsoft.CodeAnalysis.LanguageServer.dll"
+```
+
+Replace <roslynRepoRoot> with the actual path to your Roslyn repository.
+
+If using C# Dev Kit, you can also override the Roslyn DevKit component in your `settings.json`:
+```json
 "dotnet.server.componentPaths": {
     "roslynDevKit": "<roslynRepoRoot>/artifacts/bin/Microsoft.VisualStudio.LanguageServices.DevKit/Debug/net9.0"
 },
 ```
-
-Replace <roslynRepoRoot> with the actual path to your Roslyn repository.
 
 Or, in VSCode settings (`Ctrl+,`):
 
 1. Search for `dotnet server`.
 2. Set `dotnet.server.path` to the path of your Roslyn DLL.
 3. Enable `dotnet.server.waitForDebugger`.
+4. (Optional) - add the component to `dotnet.server.componentPaths` (see above).
 
 #### Configuring Razor Language Server
 


### PR DESCRIPTION
not always required, but ensures devkit components also use the locally built bits.