### PR TITLE
Fix promptForDevKitDebugConfigurations without CDK installed

### DIFF
--- a/src/lsptoolshost/debugger/debugger.ts
+++ b/src/lsptoolshost/debugger/debugger.ts
@@ -105,5 +105,5 @@ async function promptForDevKitDebugConfigurations(): Promise<boolean> {
         return result;
     }
 
-    return false;
+    return true;
 }


### PR DESCRIPTION
This PR fixes the boolean value that is returned when C# Dev Kit isnt installed. Returning true will continue to generate assets while false will dismiss the whole command.

Fixes https://github.com/dotnet/vscode-csharp/issues/8389