### PR TITLE
Storage account for Copilot language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -423,6 +423,24 @@
       "integrity": "9944EBD6EE06BD595BCADD3057CD9BEF4105C3A3952DAE03E54F3114E2E6661F"
     },
     {
+      "id": "RoslynCopilotLanguageServer",
+      "description": "Language server for Roslyn Copilot integration (Windows)",
+      "url": "https://roslynomnisharp.blob.core.windows.net/releases/1.39.12/omnisharp-linux-musl-arm64-net6.0-1.39.12.zip",
+      "installPath": ".roslyncopilotlanguageserver",
+      "platforms": [
+        "win32",
+        "linux",
+        "linux-musl",
+        "darwin"
+      ],
+      "architectures": [
+        "x86_64",
+        "arm64"
+      ],
+      "installTestPath": "./.roslyncopilotlanguageserver/Microsoft.VisualStudio.Copilot.Roslyn.LanguageServer.dll",
+      "integrity": "9944EBD6EE06BD595BCADD3057CD9BEF4105C3A3952DAE03E54F3114E2E6661F"
+    },
+    {
       "id": "Debugger",
       "description": ".NET Core Debugger (Windows / x64)",
       "url": "https://vsdebugger-cyg0dxb6czfafzaz.b01.azurefd.net/coreclr-debug-2-81-0/coreclr-debug-win7-x64.zip",

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,9 @@ export async function activate(
     if (useOmnisharpServer) {
         requiredPackageIds.push('OmniSharp');
     }
+    if (csharpDevkitExtension) {
+        requiredPackageIds.push('RoslynCopilotLanguageServer');
+    }
 
     const networkSettingsProvider = vscodeNetworkSettingsProvider(vscode);
     const useFramework = useOmnisharpServer && omnisharpOptions.useModernNet !== true;


### PR DESCRIPTION
This is primarily an implementation of David Barbet's suggestion that helps with our dev innerloop reducing the amount of dependencies across repos. With the roslyn copilot language server coming in from the storage account, changes are no longer required in C# Dev Kit to point to the right language server.