### PR TITLE
Register restore commands even if DevKit is being used

### DIFF
--- a/src/lsptoolshost/projectRestore/restore.ts
+++ b/src/lsptoolshost/projectRestore/restore.ts
@@ -21,7 +21,8 @@ let _restoreInProgress = false;
 export function registerRestoreCommands(context: vscode.ExtensionContext, languageServer: RoslynLanguageServer) {
     if (getCSharpDevKit()) {
         // We do not need to register restore commands if using C# devkit.
-        return;
+        // TODO: restore commands for FBPs still need to run, even if devkit is being used.
+        // return;
     }
     const restoreChannel = vscode.window.createOutputChannel(vscode.l10n.t('.NET NuGet Restore'));
     context.subscriptions.push(


### PR DESCRIPTION
The bug we observed with restore is: we have a new, specific restore behavior for file-based apps, which is implemented only in the base C# extension. When CDK is also loaded, the client simply never responds to `projectNeedsRestore` messages and similar from the server.

But CDK doesn't handle restore of file-based apps. So the effect we see is: when both C#+CDK are loaded together in VS Code (from a fresh "reload window" or fresh startup), restore will just not work. The client will silently not initiate the restore process.

I doubt that just always attaching the restore handlers anyways is the right solution. But, as a short term solution, we could simply attach the handlers and say: **if CDK is loaded, then only do the restore for file-based apps, while assuming CDK continues to handle projects and solutions.**

Wouldn't it be most reasonable to "forward" the message to CDK, and have some way of deciding if CDK handled it, and if they did not, then we handle it? Sorta like how UI event handlers bubble events up?

@jasonmalinowski @dibarbet
