### PR TITLE
Bump Razor to 10.0.0-preview.25368.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.87.x
-* Bump Razor to 10.0.0-preview.25368.1 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Bump Razor to 10.0.0-preview.25368.1 (PR: [#8430](https://github.com/dotnet/vscode-csharp/pull/8430))
   * Fixing override completion in VSCode when LSP is enabled (PR: [#12039](https://github.com/dotnet/razor/pull/12039))
   * [Cohost] Fix rename and unskip test (PR: [#11952](https://github.com/dotnet/razor/pull/11952))
   * Ensure unique file paths for non-file Uris (PR: [#12037](https://github.com/dotnet/razor/pull/12037))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.87.x
+* Bump Razor to 10.0.0-preview.25368.1 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Fixing override completion in VSCode when LSP is enabled (PR: [#12039](https://github.com/dotnet/razor/pull/12039))
+  * [Cohost] Fix rename and unskip test (PR: [#11952](https://github.com/dotnet/razor/pull/11952))
+  * Ensure unique file paths for non-file Uris (PR: [#12037](https://github.com/dotnet/razor/pull/12037))
+  * Fix completion of hyphenated items (PR: [#12035](https://github.com/dotnet/razor/pull/12035))
+  * Allow completion items to add using directives (PR: [#12034](https://github.com/dotnet/razor/pull/12034))
 
 # 2.86.x
 * Bump Roslyn to 5.0.0-1.25361.2 (PR: [#8416](https://github.com/dotnet/vscode-csharp/pull/8416))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.0.0-1.25361.2",
     "omniSharp": "1.39.12",
-    "razor": "10.0.0-preview.25360.2",
+    "razor": "10.0.0-preview.25368.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.36106.43"
   },


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/ce330d020d1686e80f5ed4aec2e66f12c4f505b5...aa3cf977560b3a21111c7691175043249f908215?w=1)
  * Fixing override completion in VSCode when LSP is enabled (PR: [#12039](https://github.com/dotnet/razor/pull/12039))
  * Update insertion branches for VS release changes (PR: [#12040](https://github.com/dotnet/razor/pull/12040))
  * [Cohost] Fix rename and unskip test (PR: [#11952](https://github.com/dotnet/razor/pull/11952))
  * Ensure unique file paths for non-file Uris (PR: [#12037](https://github.com/dotnet/razor/pull/12037))
  * Fix completion of hyphenated items (PR: [#12035](https://github.com/dotnet/razor/pull/12035))
  * Allow completion items to add using directives (PR: [#12034](https://github.com/dotnet/razor/pull/12034))
  * Update configs for snap (PR: [#12031](https://github.com/dotnet/razor/pull/12031))