### PR TITLE
Use insiders for CI to workaround crash in vscode

### DIFF
--- a/test/vscodeLauncher.ts
+++ b/test/vscodeLauncher.ts
@@ -15,7 +15,7 @@ export async function prepareVSCodeAndExecuteTests(
     userDataDir: string,
     env: NodeJS.ProcessEnv
 ): Promise<number> {
-    let vscodeVersion = 'stable';
+    let vscodeVersion = 'insiders';
     if (process.env.CODE_VERSION) {
         console.log(`VSCode version overriden to ${process.env.CODE_VERSION}.`);
         vscodeVersion = process.env.CODE_VERSION;
@@ -84,7 +84,7 @@ async function installExtensions(extensionIds: string[], vscodeCli: string, vsco
         shell: true,
     });
     if (result.error || result.status !== 0) {
-        throw new Error(`Failed to install the runtime extension: ${JSON.stringify(result)}`);
+        throw new Error(`Failed to install extensions: ${JSON.stringify(result)}`);
     }
 
     console.log();


### PR DESCRIPTION
Resolves https://github.com/dotnet/vscode-csharp/issues/8446