### PR TITLE
Bump Razor to 10.0.0-preview.25377.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.88.x
+* Bump Razor to 10.0.0-preview.25377.4 (PR: [#???](https://github.com/dotnet/vscode-csharp/pull/???))
+  * Cache MEF composition in OOP and VS Code (PR: [#12041](https://github.com/dotnet/razor/pull/12041))
 
 # 2.87.x
 * Bump Roslyn to 5.0.0-2.25371.17 (PR: [#8436](https://github.com/dotnet/vscode-csharp/pull/8436))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.88.x
-* Bump Razor to 10.0.0-preview.25377.4 (PR: [#???](https://github.com/dotnet/vscode-csharp/pull/???))
+* Bump Razor to 10.0.0-preview.25377.4 (PR: [#8459](https://github.com/dotnet/vscode-csharp/pull/8459))
   * Cache MEF composition in OOP and VS Code (PR: [#12041](https://github.com/dotnet/razor/pull/12041))
 
 # 2.87.x

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.0.0-2.25371.17",
     "omniSharp": "1.39.12",
-    "razor": "10.0.0-preview.25368.1",
+    "razor": "10.0.0-preview.25377.4",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.36106.43"
   },


### PR DESCRIPTION
Tiny one this week, but may as well keep it fresh.

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/aa3cf977560b3a21111c7691175043249f908215...2c9fd5dcffadd0271ffe9e6f14caa09c8a2f2d6a?w=1)
* Reduce allocations in WhereAsArray IA/IA.Builder extension methods (PR: [#12051](https://github.com/dotnet/razor/pull/12051))
* Fix wrap with tag under cohosting (PR: [#12049](https://github.com/dotnet/razor/pull/12049))
* Add Version.Details.props (PR: [#12050](https://github.com/dotnet/razor/pull/12050))
* Add override completion test for VS Code (PR: [#12046](https://github.com/dotnet/razor/pull/12046))
* Fix exception in tests (PR: [#12038](https://github.com/dotnet/razor/pull/12038))
* Update Microsoft.VisualStudio.ProjectSystem.Sdk package version (PR: [#12029](https://github.com/dotnet/razor/pull/12029))
* Cache MEF composition in OOP and VS Code (PR: [#12041](https://github.com/dotnet/razor/pull/12041))