### PR TITLE
Update Razor cohosting to be 'on' by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1560,7 +1560,7 @@
           },
           "razor.languageServer.cohostingEnabled": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "%configuration.razor.languageServer.cohostingEnabled%",
             "tags": [
               "experimental"


### PR DESCRIPTION
Update Razor cohosting to be 'on' by default. 

Tested locally with a multi-project Blazor solution.