### PR TITLE
Bump Razor to 10.0.0-preview.25408.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.89.x
+* Bump Razor to 10.0.0-preview.25408.2 (PR: [#8512](https://github.com/dotnet/vscode-csharp/pull/8512))
+  * Fix cohost override setting (PR: [#12082](https://github.com/dotnet/razor/pull/12082))
+  * Cohost span mapping (PR: [#12055](https://github.com/dotnet/razor/pull/12055))
+  * Explicitly deny certain Roslyn formatting options (PR: [#12064](https://github.com/dotnet/razor/pull/12064))
+  * Don't use `requestContext` in document closed endpoint (PR: [#12080](https://github.com/dotnet/razor/pull/12080))
 
 # 2.88.x
 * Enable Razor Cohosting "on" by default (PR: [#8469](https://github.com/dotnet/vscode-csharp/pull/8469))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.0.0-2.25405.5",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25403.1",
+    "razor": "10.0.0-preview.25408.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.36106.43"
   },

--- a/test/razor/razorIntegrationTests/reference.integration.test.ts
+++ b/test/razor/razorIntegrationTests/reference.integration.test.ts
@@ -127,11 +127,6 @@ describe(`Razor References ${testAssetWorkspace.description}`, function () {
     });
 
     test('Find All References - CSharp', async () => {
-        if (!integrationHelpers.usingDevKit()) {
-            // If we're not using devkit, then it means we are testing cohosting, and FAR from C# doesn't currently work in cohosting.
-            return;
-        }
-
         if (!integrationHelpers.isRazorWorkspace(vscode.workspace)) {
             return;
         }


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/ce522dd7670dc8e5885b8d078ff5be2877ee33ed...82b663038ebe314d21a426c12724d0358d921760?w=1)
* Fix logging (PR: [#12092](https://github.com/dotnet/razor/pull/12092))
* Reduce work done in FormNameTagHelperDescriptorProvider.Execute (PR: [#12087](https://github.com/dotnet/razor/pull/12087))
* Fix cohost override setting (PR: [#12082](https://github.com/dotnet/razor/pull/12082))
* Cohost span mapping (PR: [#12055](https://github.com/dotnet/razor/pull/12055))
* Update CODEOWNERS (PR: [#12081](https://github.com/dotnet/razor/pull/12081))
* Explicitly deny certain Roslyn formatting options (PR: [#12064](https://github.com/dotnet/razor/pull/12064))
* Don't use `requestContext` in document closed endpoint (PR: [#12080](https://github.com/dotnet/razor/pull/12080))
* Remove intermediate strings from hint name calculation (PR: [#12077](https://github.com/dotnet/razor/pull/12077))