### PR TITLE
Do not include init script in vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -29,6 +29,7 @@ typings/**
 vsix/**
 node_modules
 azure-pipelines
+init.ps1
 
 **/*.map
 *.vsix


### PR DESCRIPTION
Not necessary, and causes a signing warning to be reported (not signed).