### PR TITLE
Classify production branches

### DIFF
--- a/.azuredevops/policies/branchClassification.yml
+++ b/.azuredevops/policies/branchClassification.yml
@@ -1,0 +1,19 @@
+name: branch_classification
+description: Branch classification configuration for repository
+resource: repository
+disabled: false
+where:
+configuration:
+  branchClassificationSettings:
+    defaultClassification: nonproduction
+    ruleset:
+    - name: prod-branches
+      branchNames:
+      - main
+      - prerelease
+      - release
+      classification: production
+    - name: nonprod-branches
+      branchNames:
+      - feature
+      classification: nonproduction


### PR DESCRIPTION
<img width="644" height="323" alt="image" src="https://github.com/user-attachments/assets/b5bb7f01-0aaa-4524-b61c-eb08e0e0bf3c" />

the default production branches do not include prerelease.  So we set our own.

Docs - https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/product-catalog/branch-classification/branch-classification#optional-update-branch-classification-at-the-repo