### PR TITLE
Bump Razor to 10.0.0-preview.25419.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 # 2.90.x
 * Bump Razor to 10.0.0-preview.25416.1 (PR: [#8557](https://github.com/dotnet/vscode-csharp/pull/8557))
+  * Fix range formatting in the presence of K&R braces (PR: [#12121](https://github.com/dotnet/razor/pull/12121))
+  * Add codelens endpoints and services for cohosting (PR: [#12078](https://github.com/dotnet/razor/pull/12078))
   * Support Go To Def for Mvc tag helpers in cohosting (PR: [#12102](https://github.com/dotnet/razor/pull/12102))
   * Add missing `global::` prefix in a `@ref` scenario (PR: [#12107](https://github.com/dotnet/razor/pull/12107))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.90.x
+* Bump Razor to 10.0.0-preview.25416.1 (PR: [#8557](https://github.com/dotnet/vscode-csharp/pull/8557))
+  * Support Go To Def for Mvc tag helpers in cohosting (PR: [#12102](https://github.com/dotnet/razor/pull/12102))
+  * Add missing `global::` prefix in a `@ref` scenario (PR: [#12107](https://github.com/dotnet/razor/pull/12107))
 
 # 2.89.x
 * Bump Roslyn to 5.0.0-2.25412.5 (PR: [#8527](https://github.com/dotnet/vscode-csharp/pull/8527))

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   ],
   "defaults": {
     "roslyn": "5.0.0-2.25412.5",
-    "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25416.1",
+  "omniSharp": "1.39.14",
+    "razor": "10.0.0-preview.25419.3",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.36106.43"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.0.0-2.25412.5",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25411.5",
+    "razor": "10.0.0-preview.25416.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.36106.43"
   },


### PR DESCRIPTION
Hopefully will be able to add a little more this week, as people come back from vacation and can do some PR reviews :)

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/9ab78c78721106dcf827e397ff71b07114577712...fc8567eef15d72443396710fc009016d376e5242?w=1)
* Fix range formatting in the presence of K&R braces (PR: [#12121](https://github.com/dotnet/razor/pull/12121))
* [main] Source code updates from dotnet/dotnet (PR: [#12119](https://github.com/dotnet/razor/pull/12119))
* Refactor GetTaskListDescriptorsAsync to use async provider (PR: [#12086](https://github.com/dotnet/razor/pull/12086))
* Add codelens endpoints and services for cohosting (PR: [#12078](https://github.com/dotnet/razor/pull/12078))
* Identifier tests (PR: [#12116](https://github.com/dotnet/razor/pull/12116))
* Remove MetadataCollection from BoundAttributeDescriptor and other improvements (PR: [#12108](https://github.com/dotnet/razor/pull/12108))
* Handle surrogate pairs in when sanitizing (PR: [#12111](https://github.com/dotnet/razor/pull/12111))
* Compiler: Avoid allocating strings with writing integer literals (PR: [#12101](https://github.com/dotnet/razor/pull/12101))
* [main] Source code updates from dotnet/dotnet (PR: [#12114](https://github.com/dotnet/razor/pull/12114))
* Update doc author (PR: [#12110](https://github.com/dotnet/razor/pull/12110))
* Support Go To Def for Mvc tag helpers in cohosting (PR: [#12102](https://github.com/dotnet/razor/pull/12102))
* Add missing `global::` prefix in a `@ref` scenario (PR: [#12107](https://github.com/dotnet/razor/pull/12107))
* Reference the right packages on win-arm64 (PR: [#12100](https://github.com/dotnet/razor/pull/12100))
* Compiler: Rework IntermediateToken and LazyIntermediateToken (PR: [#12032](https://github.com/dotnet/razor/pull/12032))