### PR TITLE
Register the CSharp context provider with Copilot Chat as well.

### DIFF
--- a/src/lsptoolshost/copilot/contextProviders.ts
+++ b/src/lsptoolshost/copilot/contextProviders.ts
@@ -2,7 +2,12 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { ContextProviderApiV1, ResolveRequest, SupportedContextItem } from '@github/copilot-language-server';
+import {
+    ContextProviderApiV1,
+    ResolveRequest,
+    SupportedContextItem,
+    type ContextProvider,
+} from '@github/copilot-language-server';
 import * as vscode from 'vscode';
 import * as lsp from 'vscode-languageserver-protocol';
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
@@ -73,49 +78,105 @@ export function registerCopilotContextProviders(
 
     devkit.activate().then(async () => {
         try {
-            const copilotApi = vscode.extensions.getExtension<CopilotApi>('github.copilot');
-            if (!copilotApi) {
+            const copilotClientApi = await getCopilotClientApi();
+            const copilotChatApi = await getCopilotChatApi();
+            if (!copilotClientApi && !copilotChatApi) {
                 channel.debug(
-                    'Failed to find compatible version of GitHub Copilot extension installed. Skip registeration of Copilot context provider.'
+                    'Failed to find compatible version of GitHub Copilot extension installed. Skip registration of Copilot context provider.'
                 );
                 return;
             }
 
-            const api = await copilotApi.activate();
-            const contextProviderApi = await api.getContextProviderAPI('v1');
-
-            if (!contextProviderApi) {
-                channel.debug(
-                    'Incompatible GitHub Copilot extension installed. Skip registeration of C# context providers.'
-                );
-                return;
-            }
-
-            context.subscriptions.push(
-                contextProviderApi.registerContextProvider<SupportedContextItem>({
-                    id: CSharpExtensionId, // use extension id as provider id for now
-                    selector: [{ language: 'csharp' }],
-                    resolver: {
-                        resolve: async (request, token) => {
-                            const contextResolveParam = createContextResolveParam(request);
-                            if (!contextResolveParam) {
-                                return [];
-                            }
-                            const items = await languageServer.sendRequest(
-                                resolveContextRequest,
-                                contextResolveParam,
-                                token
-                            );
-                            channel.trace(`Copilot context provider resolved ${items.length} items`);
-                            return items;
-                        },
+            const provider: ContextProvider<SupportedContextItem> = {
+                id: CSharpExtensionId, // use extension id as provider id for now
+                selector: [{ language: 'csharp' }],
+                resolver: {
+                    resolve: async (request, token) => {
+                        const contextResolveParam = createContextResolveParam(request);
+                        if (!contextResolveParam) {
+                            return [];
+                        }
+                        const items = await languageServer.sendRequest(
+                            resolveContextRequest,
+                            contextResolveParam,
+                            token
+                        );
+                        channel.trace(`Copilot context provider resolved ${items.length} items`);
+                        return items;
                     },
-                })
-            );
+                },
+            };
 
+            let installCount = 0;
+            if (copilotClientApi) {
+                const disposable = await installContextProvider(copilotClientApi, provider);
+                if (disposable) {
+                    context.subscriptions.push(disposable);
+                    installCount++;
+                }
+            }
+            if (copilotChatApi) {
+                const disposable = await installContextProvider(copilotChatApi, provider);
+                if (disposable) {
+                    context.subscriptions.push(disposable);
+                    installCount++;
+                }
+            }
+
+            if (installCount === 0) {
+                channel.debug(
+                    'Incompatible GitHub Copilot extension installed. Skip registration of C# context providers.'
+                );
+                return;
+            }
             channel.debug('Registration of C# context provider for GitHub Copilot extension succeeded.');
         } catch (error) {
             channel.error('Failed to register Copilot context providers', error);
         }
     });
+}
+
+async function getCopilotClientApi(): Promise<CopilotApi | undefined> {
+    const extension = vscode.extensions.getExtension<CopilotApi>('github.copilot');
+    if (!extension) {
+        return undefined;
+    }
+    try {
+        return await extension.activate();
+    } catch {
+        return undefined;
+    }
+}
+
+async function getCopilotChatApi(): Promise<CopilotApi | undefined> {
+    type CopilotChatApi = { getAPI?(version: number): CopilotApi | undefined };
+    const extension = vscode.extensions.getExtension<CopilotChatApi>('github.copilot-chat');
+    if (!extension) {
+        return undefined;
+    }
+
+    let exports: CopilotChatApi | undefined;
+    try {
+        exports = await extension.activate();
+    } catch {
+        return undefined;
+    }
+    if (!exports || typeof exports.getAPI !== 'function') {
+        return undefined;
+    }
+    return exports.getAPI(1);
+}
+
+async function installContextProvider(
+    copilotAPI: CopilotApi,
+    contextProvider: ContextProvider<SupportedContextItem>
+): Promise<vscode.Disposable | undefined> {
+    const hasGetContextProviderAPI = typeof copilotAPI.getContextProviderAPI === 'function';
+    if (hasGetContextProviderAPI) {
+        const contextAPI = await copilotAPI.getContextProviderAPI('v1');
+        if (contextAPI) {
+            return contextAPI.registerContextProvider(contextProvider);
+        }
+    }
+    return undefined;
 }


### PR DESCRIPTION
We are in the process of moving Inline completions from Copilot client to Copilot chat. For a certain time we therefore need to register the context provider with both Copilot client and Copilot chat. Which path is exercised will be determined by VS Code. So for the same [document,position] pair only one resolve request will occur.

Registering with Copilot Chat has also the advantage that context is resolved during NES. If you want to enable this you can use the setting "github.copilot.chat.advanced.inlineEdits.xtabProvider.languageContext.enabled"

I would also like to ask you to change your active experiment [C# completion context provider in VSCode with code snippets - Azure ExP Studio](https://exp.microsoft.com/feature/b06765d0-0ad4-4769-a86f-0d13f1fabee8?workspaceId=dbd12384-5001-4e90-a863-526321eaf233&group=/vscodeexpws/Copilot) to target `copilot-chat`