### PR TITLE
Don't run CI on PRs that only update translations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ pr:
     - .github/*
     - azure-pipelines/release.yml
     - CHANGELOG.
+    - 'l10n/bundle.l10n.*.json'
 
 # Run a scheduled build every night on main to run tests against insiders VSCode.
 # The variable testVSCodeVersion is set to insiders based on the build reason.


### PR DESCRIPTION
don't need to run CI in prs like this - https://github.com/dotnet/vscode-csharp/pull/8566/files

Should exclude any changes that just change the translated bundle files (changes to the base bundle.l10n.json should still trigger CI)