### PR TITLE
Use aka.ms link for ARM32 Linux help page

### DIFF
--- a/src/checkSupportedPlatform.ts
+++ b/src/checkSupportedPlatform.ts
@@ -15,7 +15,7 @@ export function checkIsSupportedPlatform(context: vscode.ExtensionContext, platf
                 title: vscode.l10n.t('How to setup Remote Debugging'),
                 action: async () => {
                     const remoteDebugInfoURL =
-                        'https://github.com/dotnet/vscode-csharp/wiki/Remote-Debugging-On-Linux-Arm';
+                        'https://aka.ms/VSCode-DotNet-RemoteDebuggingOnLinuxArm';
                     await vscode.env.openExternal(vscode.Uri.parse(remoteDebugInfoURL));
                 },
             };

--- a/src/checkSupportedPlatform.ts
+++ b/src/checkSupportedPlatform.ts
@@ -14,8 +14,7 @@ export function checkIsSupportedPlatform(context: vscode.ExtensionContext, platf
             const setupButton: ActionOption = {
                 title: vscode.l10n.t('How to setup Remote Debugging'),
                 action: async () => {
-                    const remoteDebugInfoURL =
-                        'https://aka.ms/VSCode-DotNet-RemoteDebuggingOnLinuxArm';
+                    const remoteDebugInfoURL = 'https://aka.ms/VSCode-DotNet-RemoteDebuggingOnLinuxArm';
                     await vscode.env.openExternal(vscode.Uri.parse(remoteDebugInfoURL));
                 },
             };


### PR DESCRIPTION
The extension has one place where it was incorrectly hard-coding a link to the Wiki. This replaces it with an aka.ms link so we can redirect it as necessary.