### PR TITLE
Do not allow client to modify whitespace for auto insert edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.91.x
-* Bump Roslyn to 5.0.0-2.25458.1 (PR: [#8593](https://github.com/dotnet/vscode-csharp/pull/8593))
+* Bump Roslyn to 5.0.0-2.25458.10 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
   * Store client's version for open docs (PR: [#80064](https://github.com/dotnet/roslyn/pull/80064))
   * Pass global properties and the binary log path via RPC to BuildHost (PR: [#80094](https://github.com/dotnet/roslyn/pull/80094))
   * Don't switch runtime / design time solutions if cohosting is on (PR: [#80065](https://github.com/dotnet/roslyn/pull/80065))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.91.x
-* Bump Roslyn to 5.0.0-2.25458.10 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Bump Roslyn to 5.0.0-2.25458.10 (PR: [#8588](https://github.com/dotnet/vscode-csharp/pull/8588))
+  * Move brace adjustment on enter to on auto insert in LSP(PR: [#80075](https://github.com/dotnet/roslyn/pull/80075))
+  * Avoid throwing when obsolete overload of GetUpdatesAsync is invoked with empty array(PR: [#80161](https://github.com/dotnet/roslyn/pull/80161))
+  * Bump patch version of MSBuild packages(PR: [#80156](https://github.com/dotnet/roslyn/pull/80156))
+  * Include category in Hot Reload log messages(PR: [#80160](https://github.com/dotnet/roslyn/pull/80160))
   * Store client's version for open docs (PR: [#80064](https://github.com/dotnet/roslyn/pull/80064))
   * Pass global properties and the binary log path via RPC to BuildHost (PR: [#80094](https://github.com/dotnet/roslyn/pull/80094))
   * Don't switch runtime / design time solutions if cohosting is on (PR: [#80065](https://github.com/dotnet/roslyn/pull/80065))

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@types/semver": "7.3.13",
         "@types/tmp": "0.0.33",
         "@types/uuid": "^9.0.1",
-        "@types/vscode": "1.93.0",
+        "@types/vscode": "1.98.0",
         "@types/yauzl": "2.10.0",
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "@typescript-eslint/parser": "^8.19.0",
@@ -77,7 +77,7 @@
         "vscode-textmate": "^6.0.0"
       },
       "engines": {
-        "vscode": "^1.93.0"
+        "vscode": "^1.98.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3666,9 +3666,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.93.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.93.0.tgz",
-      "integrity": "sha1-HNdXPgJyrvnDV7r8Y1thd8FUAT4=",
+      "version": "1.98.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.98.0.tgz",
+      "integrity": "sha1-W2+lvZm6FTE1Z9OEf7EXeDL+4Iw=",
       "dev": true,
       "license": "MIT"
     },
@@ -17753,9 +17753,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.93.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.93.0.tgz",
-      "integrity": "sha1-HNdXPgJyrvnDV7r8Y1thd8FUAT4=",
+      "version": "1.98.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@types/vscode/-/vscode-1.98.0.tgz",
+      "integrity": "sha1-W2+lvZm6FTE1Z9OEf7EXeDL+4Iw=",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "@types/semver": "7.3.13",
     "@types/tmp": "0.0.33",
     "@types/uuid": "^9.0.1",
-    "@types/vscode": "1.93.0",
+    "@types/vscode": "1.98.0",
     "@types/yauzl": "2.10.0",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
@@ -688,7 +688,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.93.0"
+    "vscode": "^1.98.0"
   },
   "activationEvents": [
     "onDebugInitialConfigurations",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.0.0-2.25458.1",
+    "roslyn": "5.0.0-2.25458.10",
     "omniSharp": "1.39.14",
     "razor": "10.0.0-preview.25454.5",
     "razorOmnisharp": "7.0.0-preview.23363.1",

--- a/src/lsptoolshost/autoInsert/onAutoInsert.ts
+++ b/src/lsptoolshost/autoInsert/onAutoInsert.ts
@@ -56,10 +56,11 @@ export function registerOnAutoInsert(languageServer: RoslynLanguageServer, langu
 
         // Regular expression to match all whitespace characters except the newline character
         let changeTrimmed = change.text.replace(/[^\S\n]+/g, '');
+
         // When hitting enter between braces, we can end up with two new lines added (one to move the cursor down to an empty line,
-        // and another to move the close brace to a new line below that).  We still want to trigger on auto insert here, so remove
-        // duplicates before we check if the change matches a trigger character.
-        if (changeTrimmed.length > 1) {
+        // and another to move the close brace to a new line below that).  We still want to trigger on auto insert here, so if we
+        // have a whitespace only edit (meaning its new lines only) with multiple characters, we reduce it to a single newline.
+        if (changeTrimmed.length > 1 && changeTrimmed.trim() === '') {
             changeTrimmed = [...new Set(changeTrimmed)].join('');
         }
 

--- a/src/lsptoolshost/autoInsert/onAutoInsert.ts
+++ b/src/lsptoolshost/autoInsert/onAutoInsert.ts
@@ -118,8 +118,6 @@ async function applyAutoInsertEdit(
         const startPosition = new vscode.Position(textEdit.range.start.line, textEdit.range.start.character);
         const endPosition = new vscode.Position(textEdit.range.end.line, textEdit.range.end.character);
 
-        //const editor = vscode.window.activeTextEditor?.insertSnippet();
-
         let textEdits: (vscode.TextEdit | vscode.SnippetTextEdit)[] = [];
         if (response._vs_textEditFormat === InsertTextFormat.Snippet) {
             const docComment = new vscode.SnippetString(textEdit.newText);

--- a/src/lsptoolshost/autoInsert/onAutoInsert.ts
+++ b/src/lsptoolshost/autoInsert/onAutoInsert.ts
@@ -57,11 +57,18 @@ export function registerOnAutoInsert(languageServer: RoslynLanguageServer, langu
         // Regular expression to match all whitespace characters except the newline character
         let changeTrimmed = change.text.replace(/[^\S\n]+/g, '');
 
+        // If the change is empty after removing whitespace, we don't need to process it.
+        if (changeTrimmed.length === 0) {
+            return;
+        }
+
         // When hitting enter between braces, we can end up with two new lines added (one to move the cursor down to an empty line,
-        // and another to move the close brace to a new line below that).  We still want to trigger on auto insert here, so if we
-        // have a whitespace only edit (meaning its new lines only) with multiple characters, we reduce it to a single newline.
-        if (changeTrimmed.length > 1 && changeTrimmed.trim() === '') {
-            changeTrimmed = [...new Set(changeTrimmed)].join('');
+        // and another to move the close brace to a new line below that).  We want to detect that edit as a single new line trigger.
+        //
+        // Since we already removed all whitespace except new lines above, we can just trim the string to remove new lines as well
+        // and check if there is anything left.  If not, we know the change is just whitespace and new lines and can set the trigger to the new line character.
+        if (changeTrimmed.trim() === '') {
+            changeTrimmed = '\n';
         }
 
         if (!vsTriggerCharacters.includes(changeTrimmed)) {


### PR DESCRIPTION
Tell the client not to modify the whitespace we provided in auto insert snippets.
Requires https://github.com/dotnet/roslyn/pull/80075
