### PR TITLE
Marking pipeline as production

### DIFF
--- a/azure-pipelines/publish-roslyn-copilot.yml
+++ b/azure-pipelines/publish-roslyn-copilot.yml
@@ -33,7 +33,7 @@ extends:
           image: 1ESPT-Windows2022
           os: windows
         templateContext:
-          isProduction: false #change this
+          isProduction: true
           inputs:
           - input: pipelineArtifact
             pipeline: CI


### PR DESCRIPTION
This should ideally be a production pipeline, so marking it so. It was initially set to non-production so I can get a test going quickly.