### PR TITLE
Wait for maximum 3000 ms for the Copilot chat API.

### DIFF
--- a/src/lsptoolshost/copilot/contextProviders.ts
+++ b/src/lsptoolshost/copilot/contextProviders.ts
@@ -157,7 +157,14 @@ async function getCopilotChatApi(): Promise<CopilotApi | undefined> {
 
     let exports: CopilotChatApi | undefined;
     try {
-        exports = await extension.activate();
+        exports = await Promise.race([
+            extension.activate(),
+            new Promise<undefined>((resolve) => {
+                setTimeout(() => {
+                    resolve(undefined);
+                }, 3000);
+            }),
+        ]);
     } catch {
         return undefined;
     }


### PR DESCRIPTION
We encounter cases where the Copilot chat extension could take a very long time to activate. This would make the CSharp extension not activate successful. To avoid these situations I added protection code to only wait 3 seconds for the Copilot chat extension. 

This is the smallest code change to not run into this situation. A better fix would be to not await the whole context provider registration. However we need to understand if this has some other side effects.