### PR TITLE
Do not register the project context status item for Razor files

### DIFF
--- a/src/lsptoolshost/projectContext/projectContextStatus.ts
+++ b/src/lsptoolshost/projectContext/projectContextStatus.ts
@@ -11,9 +11,7 @@ import { combineDocumentSelectors } from '../../shared/utils/combineDocumentSele
 
 export class ProjectContextStatus {
     static createStatusItem(context: vscode.ExtensionContext, languageServer: RoslynLanguageServer) {
-        const documentSelector = combineDocumentSelectors(
-            languageServerOptions.documentSelector
-        );
+        const documentSelector = combineDocumentSelectors(languageServerOptions.documentSelector);
         const projectContextService = languageServer._projectContextService;
 
         const item = vscode.languages.createLanguageStatusItem('csharp.projectContextStatus', documentSelector);

--- a/src/lsptoolshost/projectContext/projectContextStatus.ts
+++ b/src/lsptoolshost/projectContext/projectContextStatus.ts
@@ -37,8 +37,8 @@ export class ProjectContextStatus {
 
             item.detail = e.context._vs_is_miscellaneous
                 ? vscode.l10n.t(
-                    'The active document is not part of the open workspace. Not all language features will be available.'
-                )
+                      'The active document is not part of the open workspace. Not all language features will be available.'
+                  )
                 : vscode.l10n.t('Active File Context');
         });
 

--- a/src/lsptoolshost/projectContext/projectContextStatus.ts
+++ b/src/lsptoolshost/projectContext/projectContextStatus.ts
@@ -6,15 +6,13 @@
 import * as vscode from 'vscode';
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import { languageServerOptions } from '../../shared/options';
-import { RazorLanguage } from '../../razor/src/razorLanguage';
 import { ServerState } from '../server/languageServerEvents';
 import { combineDocumentSelectors } from '../../shared/utils/combineDocumentSelectors';
 
 export class ProjectContextStatus {
     static createStatusItem(context: vscode.ExtensionContext, languageServer: RoslynLanguageServer) {
         const documentSelector = combineDocumentSelectors(
-            languageServerOptions.documentSelector,
-            RazorLanguage.documentSelector
+            languageServerOptions.documentSelector
         );
         const projectContextService = languageServer._projectContextService;
 
@@ -39,8 +37,8 @@ export class ProjectContextStatus {
 
             item.detail = e.context._vs_is_miscellaneous
                 ? vscode.l10n.t(
-                      'The active document is not part of the open workspace. Not all language features will be available.'
-                  )
+                        'The active document is not part of the open workspace. Not all language features will be available.'
+                    )
                 : vscode.l10n.t('Active File Context');
         });
 

--- a/src/lsptoolshost/projectContext/projectContextStatus.ts
+++ b/src/lsptoolshost/projectContext/projectContextStatus.ts
@@ -37,8 +37,8 @@ export class ProjectContextStatus {
 
             item.detail = e.context._vs_is_miscellaneous
                 ? vscode.l10n.t(
-                        'The active document is not part of the open workspace. Not all language features will be available.'
-                    )
+                    'The active document is not part of the open workspace. Not all language features will be available.'
+                )
                 : vscode.l10n.t('Active File Context');
         });
 


### PR DESCRIPTION
Reported in https://github.com/microsoft/vscode-dotnettools/issues/1900

The original fix went into the **prerelease** branch in https://github.com/dotnet/vscode-csharp/pull/7680. This must have been around the time we removed our automatic merge backs. The same fix was never made in main and it eventually merged forward again.