### PR TITLE
Bump Razor to 10.0.0-preview.25464.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.92.x
+* Bump Razor to 10.0.0-preview.25464.2 (PR: [#8626](https://github.com/dotnet/vscode-csharp/pull/8626))
+  * Improve go to definition for mvc tag helpers (PR: [#12216](https://github.com/dotnet/razor/pull/12216))                                                                                                               
+  * Filter CSS024 when caused by C# code in an attribute (PR: [#12209](https://github.com/dotnet/razor/pull/12209))
+  * Provide more specific information in cohosting failures (PR: [#12193](https://github.com/dotnet/razor/pull/12193))
+  * Fix renaming file (PR: [#12196](https://github.com/dotnet/razor/pull/12196))
 
 # 2.91.x
 * Bump Roslyn to 5.0.0-2.25458.10 (PR: [#8588](https://github.com/dotnet/vscode-csharp/pull/8588))
@@ -17,12 +22,10 @@
   * Allow Razor to get task list items for a document (PR: [#80102](https://github.com/dotnet/roslyn/pull/80102))
   * Update debugger packages, move to PortableInterop IMetadataImport (PR: [#80063](https://github.com/dotnet/roslyn/pull/80063))
   * Fix issue reporting diagnostic in additional file when diagnostic produced by a source generator (PR: [#80071](https://github.com/dotnet/roslyn/pull/80071))
-  * Always run the razor generator even in balanced mode (PR: [#79510](https://github.com/dotnet/roslyn/pull/79510))
 * Bump Razor to 10.0.0-preview.25454.5 (PR: [#8590](https://github.com/dotnet/vscode-csharp/pull/8590))
   * Fix extra character insertion during attribute completion in VS Code (PR: [#12177](https://github.com/dotnet/razor/pull/12177))
   * Remove UseNewRazorFormattingEngine feature flag (PR: [#12160](https://github.com/dotnet/razor/pull/12160))
   * Allow for weird Uris as file paths (PR: [#12155](https://github.com/dotnet/razor/pull/12155))
-  * Remove the feature flag for precise semantic tokens (PR: [#12149](https://github.com/dotnet/razor/pull/12149))
 * Do not create a proxy agent if proxy url is empty string.  (PR: [#8580](https://github.com/dotnet/vscode-csharp/pull/8580))
 * Use aka.ms link for ARM32 Linux help page (PR: [#8574](https://github.com/dotnet/vscode-csharp/pull/8574))
 * Update Debugger to 2.90.0 (PR: [#8572](https://github.com/dotnet/vscode-csharp/pull/8572))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.92.x
-* Bump Razor to 10.0.0-preview.25464.2 (PR: [#8626](https://github.com/dotnet/vscode-csharp/pull/8626))
+* Bump Razor to 10.0.0-preview.25464.2 (PR: [#8628](https://github.com/dotnet/vscode-csharp/pull/8628))
   * Improve go to definition for mvc tag helpers (PR: [#12216](https://github.com/dotnet/razor/pull/12216))                                                                                                               
   * Filter CSS024 when caused by C# code in an attribute (PR: [#12209](https://github.com/dotnet/razor/pull/12209))
   * Provide more specific information in cohosting failures (PR: [#12193](https://github.com/dotnet/razor/pull/12193))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.0.0-2.25458.10",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25454.5",
+    "razor": "10.0.0-preview.25464.2",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.36106.43"
   },


### PR DESCRIPTION
Weekly bump

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/93db9ca289f6ca8cad92f50750bbdb3c70f7d55d...bde4f70c9560811a7f25023b9d8ac42fd7d0e99f?w=1)
* Revert "Default the cohosting option in the generator to on. (#12214)" (PR: [#12225](https://github.com/dotnet/razor/pull/12225))                                                                                     
* Improve go to definition for mvc tag helpers (PR: [#12216](https://github.com/dotnet/razor/pull/12216))                                                                                                               
* Improve PooledArrayBuilder<T>.ToArray() and ToArrayAndClear() (PR: [#12217](https://github.com/dotnet/razor/pull/12217))                                                                                              
* Further reduce allocations in SemanticToken calculations (PR: [#12206](https://github.com/dotnet/razor/pull/12206))
* Default the cohosting option in the generator to on. (PR: [#12214](https://github.com/dotnet/razor/pull/12214))
* Filter CSS024 when caused by C# code in an attribute (PR: [#12209](https://github.com/dotnet/razor/pull/12209))
* Localized file check-in by OneLocBuild Task: Build definition ID 262: Build ID 2790723 (PR: [#12213](https://github.com/dotnet/razor/pull/12213))
* Share more cohosting tests between VS and VS Code (PR: [#12204](https://github.com/dotnet/razor/pull/12204))
* Perf: Cache IsViewComponent results (PR: [#12201](https://github.com/dotnet/razor/pull/12201))
* Localized file check-in by OneLocBuild Task: Build definition ID 262: Build ID 2789635 (PR: [#12205](https://github.com/dotnet/razor/pull/12205))
* Improve TagHelperObjectBuilderCollection.ToImmutable perf in a specific case (PR: [#12203](https://github.com/dotnet/razor/pull/12203))
* Small allocation improvement to GreenNodeExtensions.WithAnnotationsGreen (PR: [#12199](https://github.com/dotnet/razor/pull/12199))
* Move calculation of TagHelperCollector.MightContainTagHelpers into the cache (PR: [#12195](https://github.com/dotnet/razor/pull/12195))
* Provide more specific information in cohosting failures (PR: [#12193](https://github.com/dotnet/razor/pull/12193))
* Fix renaming file (PR: [#12196](https://github.com/dotnet/razor/pull/12196))
* Default cohosting to on take 2 (PR: [#12198](https://github.com/dotnet/razor/pull/12198))
* Remove unused things (PR: [#12194](https://github.com/dotnet/razor/pull/12194))
* Localized file check-in by OneLocBuild Task: Build definition ID 262: Build ID 2788970 (PR: [#12197](https://github.com/dotnet/razor/pull/12197))
* Compiler: Fix and improve performance of entity decoding (PR: [#12182](https://github.com/dotnet/razor/pull/12182))
* Compiler: Cleanup View Components pass and code gen (PR: [#12174](https://github.com/dotnet/razor/pull/12174))
* Localized file check-in by OneLocBuild Task: Build definition ID 262: Build ID 2787221 (PR: [#12189](https://github.com/dotnet/razor/pull/12189))
* Localized file check-in by OneLocBuild Task: Build definition ID 262: Build ID 2786943 (PR: [#12186](https://github.com/dotnet/razor/pull/12186))
* Default cohosting on (PR: [#12183](https://github.com/dotnet/razor/pull/12183))
* Support Task List in cohosting (PR: [#12181](https://github.com/dotnet/razor/pull/12181))