### PR TITLE
Bump Razor to 10.0.0-preview.25469.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.93.x
+* Bump Razor to 10.0.0-preview.25469.5 (PR: [#8642](https://github.com/dotnet/vscode-csharp/pull/8642))
+  * Support view components in Go To Def (PR: [#12222](https://github.com/dotnet/razor/pull/12222))                                                                                                                           
+  * Redirect the older named assembly too (PR: [#12239](https://github.com/dotnet/razor/pull/12239))                                                                                                                          
 
 # 2.92.x
 * Bump Razor to 10.0.0-preview.25464.2 (PR: [#8628](https://github.com/dotnet/vscode-csharp/pull/8628))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.0.0-2.25458.10",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25464.2",
+    "razor": "10.0.0-preview.25469.5",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "17.14.36106.43"
   },


### PR DESCRIPTION
Weekly bump, but also fixes cohosting with the default .NET SDK installed on Ubuntu 24

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/bde4f70c9560811a7f25023b9d8ac42fd7d0e99f...5557fc99abe067640cbdd2f8ade2058e06a87290?w=1)
* Fix breakpoint placement in cohosting (PR: [#12242](https://github.com/dotnet/razor/pull/12242))                                                                                                                          
* Support view components in Go To Def (PR: [#12222](https://github.com/dotnet/razor/pull/12222))                                                                                                                           
* Reduce redundant import tree parsing (PR: [#12231](https://github.com/dotnet/razor/pull/12231))                                                                                                                           
* Redirect the older named assembly too (PR: [#12239](https://github.com/dotnet/razor/pull/12239))                                                                                                                          
* Cache ISymbol.ToDisplayString results (PR: [#12220](https://github.com/dotnet/razor/pull/12220))                                                                                                                          
* Reduce closure allocations in TokenizerBackedParser.ConfigureSpanContext (PR: [#12238](https://github.com/dotnet/razor/pull/12238))                                                                                       
* Compiler: Small bits of clean up (PR: [#12200](https://github.com/dotnet/razor/pull/12200))                                                                                                                               
* Remove old options page (PR: [#12233](https://github.com/dotnet/razor/pull/12233))                                                                                                                                        
* Retry running generators if the project config looks good, but the source generator doesn't produce host outputs (PR: [#12228](https://github.com/dotnet/razor/pull/12228))                                               
* Optimize GreenNode.ToString to not potentially not allocate when it has only a single non-null slot value. (PR: [#12227](https://github.com/dotnet/razor/pull/12227))                                                     
* Fix bug in tag helper search engine (PR: [#12226](https://github.com/dotnet/razor/pull/12226))                                                                                                                            
* Skip test on mac (PR: [#12229](https://github.com/dotnet/razor/pull/12229))                                                                                                                                               
* [main] Update dependencies from dotnet/arcade (PR: [#12218](https://github.com/dotnet/razor/pull/12218))                                                                                                                  
* Initialize feature flags in OOP early (PR: [#12079](https://github.com/dotnet/razor/pull/12079))   