### PR TITLE
Do not run legacy Razor tests in CI

### DIFF
--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -28,9 +28,6 @@ jobs:
       DevKitTests:
         npmCommand: test:integration:devkit
         isIntegration: true
-      RazorTests:
-        npmCommand: test:integration:razor
-        isIntegration: true
       RazorCohostTests:
         npmCommand: test:integration:razor:cohost
         isIntegration: true


### PR DESCRIPTION
70% of failed runs come from these tests
<img width="984" height="344" alt="image" src="https://github.com/user-attachments/assets/9b68deb0-bd63-48ac-bd38-d84d961e7aaf" />

cohosting is on by default and I doubt we will be fixing these tests any time soon.  Doesn't seem to make sense to block CI on them.  Potentially these should be entirely deleted but will leave that to the razor folks.