### PR TITLE
Adds a new GH action to update the CHANGELOG

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -2,6 +2,10 @@ name: Update CHANGELOG
 on:
   workflow_dispatch
 
+schedule:
+  # Runs every Tuesday at 9 PM Pacific Time (5 AM UTC Wednesday)
+  - cron: '0 5 * * 3'
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,29 @@
+name: Update CHANGELOG
+on:
+  workflow_dispatch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install dependencies
+        run: npm ci
+      - name: Update version.json
+        run: npx gulp updateChangelog
+      - name: Create version update PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update ${{ github.ref_name }} CHANGELOG
+          title: '[automated] Update ${{ github.ref_name }} CHANGELOG'
+          branch: merge/update-${{ github.ref_name }}-changelog

--- a/tasks/gitTasks.ts
+++ b/tasks/gitTasks.ts
@@ -5,6 +5,7 @@
 
 import { spawnSync } from 'child_process';
 import { Octokit } from '@octokit/rest';
+import { EOL } from 'os';
 
 /**
  * Execute a git command with optional logging
@@ -145,4 +146,17 @@ export async function createPullRequest(
         console.warn('Failed to create PR via Octokit:', e);
         return null;
     }
+}
+
+/**
+ * Find all tags that match the given version pattern
+ * @param version The `Major.Minor` version pattern to match
+ * @returns A sorted list of matching tags from oldest to newest
+ */
+export async function findTagsByVersion(version: string): Promise<string[]> {
+    const tagList = await git(['tag', '--list', `v${version}*`, '--sort=creatordate'], false);
+    return tagList
+        .split(EOL)
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0);
 }

--- a/tasks/snapTasks.ts
+++ b/tasks/snapTasks.ts
@@ -183,6 +183,6 @@ async function generatePRList(startSHA: string, endSHA: string): Promise<string[
         return stdout.split(os.EOL).filter((pr) => pr.length > 0);
     } catch (error) {
         logWarning(`PR finder failed: ${error instanceof Error ? error.message : error}`, error);
-        return [];
+        throw error;
     }
 }

--- a/tasks/snapTasks.ts
+++ b/tasks/snapTasks.ts
@@ -88,18 +88,18 @@ gulp.task('updateChangelog', async (): Promise<void> => {
     // Find all the headers in the changelog (and their line numbers)
     const [currentHeaderLine, currentVersion] = findNextVersionHeaderLine(changelogLines);
     if (currentHeaderLine === -1) {
-        throw new Error('Could not find the current header in the changelog.');
+        throw new Error('Could not find the current header in the CHANGELOG');
     }
 
     console.log(`Adding PRs for ${currentVersion} to CHANGELOG`);
 
     const [previousHeaderLine, previousVersion] = findNextVersionHeaderLine(changelogLines, currentHeaderLine + 1);
     if (previousHeaderLine === -1) {
-        throw new Error('Could not find the previous header in the changelog.');
+        throw new Error('Could not find the previous header in the CHANGELOG');
     }
 
     const presentPrIds = getPrIdsBetweenHeaders(changelogLines, currentHeaderLine, previousHeaderLine);
-    console.log(`PRs [#${presentPrIds.join(', #')}] already in the changelog.`);
+    console.log(`PRs [#${presentPrIds.join(', #')}] already in the CHANGELOG`);
 
     const versionTags = await findTagsByVersion(previousVersion!);
     if (versionTags.length === 0) {
@@ -110,7 +110,7 @@ gulp.task('updateChangelog', async (): Promise<void> => {
     const versionTag = versionTags.pop();
     console.log(`Using tag ${versionTag} for previous version ${previousVersion}`);
 
-    console.log(`Generating PR list from ${versionTag} to HEAD...`);
+    console.log(`Generating PR list from ${versionTag} to HEAD`);
     const currentPrs = await generatePRList(versionTag!, 'HEAD');
 
     const newPrs = [];
@@ -122,13 +122,20 @@ gulp.task('updateChangelog', async (): Promise<void> => {
 
         const prId = match[1];
         if (presentPrIds.includes(prId)) {
-            console.log(`PR #${prId} is already present in the changelog.`);
+            console.log(`PR #${prId} is already present in the CHANGELOG`);
             continue;
         }
 
-        console.log(`Adding new PR to changelog: ${pr}`);
+        console.log(`Adding new PR to CHANGELOG: ${pr}`);
         newPrs.push(pr);
     }
+
+    if (newPrs.length === 0) {
+        console.log('No new PRs to add to the CHANGELOG');
+        return;
+    }
+
+    console.log(`Writing ${newPrs.length} new PRs to the CHANGELOG`);
 
     changelogLines.splice(currentHeaderLine + 1, 0, ...newPrs);
     fs.writeFileSync(changelogPath, changelogLines.join(os.EOL));


### PR DESCRIPTION
Log from running against prerelease
```
[09:07:14] Loaded external module: ts-node/register
[09:07:16] Using gulpfile ~/Source/omnisharp-vscode/gulpfile.ts
[09:07:16] Starting 'updateChangelog'...
Determining version from CHANGELOG
Adding PRs for 2.93 to CHANGELOG
Using tag v2.92.18-prerelease for previous version 2.92
PRs [#8646, #8639] already in the CHANGELOG
Generating PR list from v2.92.18-prerelease to HEAD
Executing: roslyn-tools pr-finder -s "v2.92.18-prerelease" -e "HEAD" --format o#
PR #8639 is already present in the CHANGELOG
Adding new PR to CHANGELOG: * Add RESX file nesting pattern for Designer.cs files (PR: [#8644](https://github.com/dotnet/vscode-csharp/pull/8644))
Adding new PR to CHANGELOG: * use '.NET' instead of '.NET Core' (PR: [#8638](https://github.com/dotnet/vscode-csharp/pull/8638))
Writing 2 new PRs to the CHANGELOG
[09:07:16] Finished 'updateChangelog' after 232 ms
```

CHANGELOG diff
```diff
  # 2.93.x
+ * Add RESX file nesting pattern for Designer.cs files (PR: [#8644](https://github.com/dotnet/vscode-csharp/pull/8644))
+ * use '.NET' instead of '.NET Core' (PR: [#8638](https://github.com/dotnet/vscode-csharp/pull/8638))
  * Bump Roslyn to 5.0.0-2.25472.11 (PR: [#8646](https://github.com/dotnet/vscode-csharp/pull/8646))
    * Fix handling edits in types nested in reloadable types(PR: [#80360](https://github.com/dotnet/roslyn/pull/80360))
```