### PR TITLE
Bump Razor to 10.0.0-preview.25503.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Diagnostics related feature requests and improvements [#5951](https://github.com/dotnet/vscode-csharp/issues/5951)
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
+# 2.95.x
+* Bump Razor to 10.0.0-preview.25503.1 (PR: [#8678](https://github.com/dotnet/vscode-csharp/pull/8678))
+  * Ensure RazorVSInternalCompletionParams is used for serialization of completion requests (PR: [#12271](https://github.com/dotnet/razor/pull/12271))
+
 # 2.94.x
 * Fix update changelog script (PR: [#8671](https://github.com/dotnet/vscode-csharp/pull/8671))
 * Update RoslynCopilot url to 18.0.797-alpha (PR: [#8652](https://github.com/OmniSharp/omnisharp-vscode/pull/8652))

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "defaults": {
     "roslyn": "5.1.0-1.25475.3",
     "omniSharp": "1.39.14",
-    "razor": "10.0.0-preview.25472.6",
+    "razor": "10.0.0-preview.25503.1",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.0.11023.10"
   },


### PR DESCRIPTION
Weekly bump

[View Complete Diff of Changes](https://github.com/dotnet/razor/compare/08c6532754d048e959b3b766434a0f202691dcfb...b400e0402eed2002b5f78eff7152691af9d39bf7?w=1)
* Revert "Fix some issues with our options in the new experience" (PR: [#12288](https://github.com/dotnet/razor/pull/12288))
* Cache more SyntaxTokens (PR: [#12283](https://github.com/dotnet/razor/pull/12283))
* Update source generator to pass cancellation tokens to compiler phases and passes (PR: [#12269](https://github.com/dotnet/razor/pull/12269))
* Pull publishdata from branch being published (PR: [#12264](https://github.com/dotnet/razor/pull/12264))
* Ensure RazorVSInternalCompletionParams is used for serialization of completion requests (PR: [#12271](https://github.com/dotnet/razor/pull/12271))
* Revert "Revert "Default the cohosting option in the generator to on. (#12214)." (PR: [#12253](https://github.com/dotnet/razor/pull/12253))
* Fix some issues with our options in the new experience (PR: [#12262](https://github.com/dotnet/razor/pull/12262))
* Allow tag helper discovery to be cancellable (PR: [#12258](https://github.com/dotnet/razor/pull/12258))
* Calculate minimal diffs before updating Html buffer (PR: [#12256](https://github.com/dotnet/razor/pull/12256))
* Update ngen priorities for Razor assemblies (PR: [#12252](https://github.com/dotnet/razor/pull/12252))
* Reduce allocations in TagHelperBinder.ProcessDescriptors (PR: [#12237](https://github.com/dotnet/razor/pull/12237))                                                                                                       
* Update configs for 18.0.P2 snap (PR: [#12247](https://github.com/dotnet/razor/pull/12247))     