### PR TITLE
Make some dotnet skills in box in the C# extension

### DIFF
--- a/.github/skills/update-dotnet-skills-in-box/SKILL.md
+++ b/.github/skills/update-dotnet-skills-in-box/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: update-dotnet-skills-in-box
+description: >-
+  Syncs the bundled Copilot skills from the upstream dotnet/skills GitHub repo,
+  updates skills.lock.json with the new commit SHA and timestamp, and stages all
+  changed files ready for a PR. Use when asked to update the in-box skills,
+  bump the skills version, or pull the latest skill content from dotnet/skills.
+---
+
+# Update Dotnet Skills In-Box
+
+This skill describes how to update the bundled Copilot agent skills shipped with
+the C# extension. The skill files live in `src/lsptoolshost/copilot/skills/` and
+are sourced from the [`dotnet/skills`](https://github.com/dotnet/skills) GitHub
+repository. A lock file (`skills.lock.json`) records the exact upstream commit
+SHA that was synced so reviewers can verify the version in use.
+
+## What Gets Updated
+
+- `src/lsptoolshost/copilot/skills/<skill-name>/SKILL.md` — one per skill
+- `src/lsptoolshost/copilot/skills/<skill-name>/references/*.md` — reference docs
+- `src/lsptoolshost/copilot/skills/skills.lock.json` — per-skill version lock file
+
+The five bundled skills are:
+
+| Skill | Source path in dotnet/skills |
+|-------|------------------------------|
+| `csharp-scripts` | `plugins/dotnet/skills/csharp-scripts` |
+| `analyzing-dotnet-performance` | `plugins/dotnet-diag/skills/analyzing-dotnet-performance` |
+| `dotnet-trace-collect` | `plugins/dotnet-diag/skills/dotnet-trace-collect` |
+| `dump-collect` | `plugins/dotnet-diag/skills/dump-collect` |
+| `microbenchmarking` | `plugins/dotnet-diag/skills/microbenchmarking` |
+
+## Steps
+
+### 1. Check the current versions
+
+Read the existing lock file to see what commit each skill is currently at:
+
+```powershell
+Get-Content src/lsptoolshost/copilot/skills/skills.lock.json
+```
+
+Note each skill's `commitSha` — you will compare these to the new SHAs after updating.
+
+### 2. Copy the updated files
+
+For each skill you want to update, download the files from the upstream repo and
+copy them into the corresponding `src/lsptoolshost/copilot/skills/<name>/`
+directory, replacing existing files.
+
+The raw file URLs follow this pattern:
+```
+https://raw.githubusercontent.com/dotnet/skills/main/<sourcePath>/SKILL.md
+https://raw.githubusercontent.com/dotnet/skills/main/<sourcePath>/references/<file>
+```
+
+Refer to the skill table above for each skill's `sourcePath`.
+
+### 3. Update skills.lock.json
+
+For each skill you updated, find its latest commit SHA using the GitHub API:
+
+```powershell
+(Invoke-RestMethod 'https://api.github.com/repos/dotnet/skills/commits?path=<sourcePath>&per_page=1')[0].sha
+```
+
+Then update the corresponding `commitSha` field in
+`src/lsptoolshost/copilot/skills/skills.lock.json` and set `syncedAt` to the
+current UTC timestamp (ISO 8601 format, e.g. `2026-05-05T21:20:29.989Z`).
+
+The lock file format is:
+
+```json
+{
+  "upstreamRepo": "dotnet/skills",
+  "upstreamRef": "main",
+  "syncedAt": "<timestamp>",
+  "skills": {
+    "<skill-name>": {
+      "sourcePath": "<path-in-dotnet/skills-repo>",
+      "commitSha": "<latest-commit-sha-for-this-skill-directory>"
+    }
+  }
+}
+```
+
+### 4. Review the diff
+
+```powershell
+git diff src/lsptoolshost/copilot/skills/
+```
+
+Review the changes to ensure only expected content was updated. If the diff is
+empty, the skills were already at the latest version — no PR is needed.
+
+### 5. Stage and commit
+
+```
+git add src/lsptoolshost/copilot/skills/
+git commit -m "Update bundled Copilot skills from dotnet/skills"
+```
+
+### 6. Open a PR
+
+Push the branch and open a PR targeting `main`. Use this PR description template:
+
+```
+## Summary
+
+Updates the bundled Copilot agent skills from the upstream `dotnet/skills` repository.
+
+**Previous commit:** `<old-sha>`
+**New commit:** `<new-sha>`
+
+Compare: https://github.com/dotnet/skills/compare/<old-sha>...<new-sha>
+
+## Skills updated
+- `csharp-scripts`
+- `analyzing-dotnet-performance`
+- `dotnet-trace-collect`
+- `dump-collect`
+- `microbenchmarking`
+```
+
+## Adding or Removing a Skill
+
+To add a new skill or remove an existing one, two files must be updated together:
+
+1. **`tasks/skills/syncBundledSkills.ts`** — add or remove an entry in the
+   `bundledSkills` array. Each entry needs `name`, `sourcePath` (path in the
+   upstream repo), and `references` (list of filenames under `references/`).
+
+2. **`package.json`** — add or remove the corresponding entry in
+   `contributes.chatSkills`. The `path` must point to
+   `./src/lsptoolshost/copilot/skills/<name>/SKILL.md`.
+
+After editing both files, run `npm run syncBundledSkills` to download the new
+skill and regenerate the lock file.

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -50,6 +50,7 @@ tsconfig.json
 version.json
 wallaby.js
 esbuild.js
+!src/lsptoolshost/copilot/skills/**
 !src/razor/language-configuration.json
 !src/razor/syntaxes/*
 

--- a/package.json
+++ b/package.json
@@ -730,6 +730,23 @@
     "workspaceContains:**/*.{csproj,csx,cake}"
   ],
   "contributes": {
+    "chatSkills": [
+      {
+        "path": "./src/lsptoolshost/copilot/skills/csharp-scripts/SKILL.md"
+      },
+      {
+        "path": "./src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/SKILL.md"
+      },
+      {
+        "path": "./src/lsptoolshost/copilot/skills/dotnet-trace-collect/SKILL.md"
+      },
+      {
+        "path": "./src/lsptoolshost/copilot/skills/dump-collect/SKILL.md"
+      },
+      {
+        "path": "./src/lsptoolshost/copilot/skills/microbenchmarking/SKILL.md"
+      }
+    ],
     "themes": [
       {
         "label": "Visual Studio 2019 Dark",

--- a/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/SKILL.md
+++ b/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: analyzing-dotnet-performance
+description: >-
+  Scans .NET code for ~50 performance anti-patterns across async, memory,
+  strings, collections, LINQ, regex, serialization, and I/O with tiered
+  severity classification. Use when analyzing .NET code for optimization
+  opportunities, reviewing hot paths, or auditing allocation-heavy patterns.
+license: MIT
+---
+
+# .NET Performance Patterns
+
+Scan C#/.NET code for performance anti-patterns and produce prioritized findings with concrete fixes. Patterns sourced from the official .NET performance blog series, distilled to customer-actionable guidance.
+
+## When to Use
+
+- Reviewing C#/.NET code for performance optimization opportunities
+- Auditing hot paths for allocation-heavy or inefficient patterns
+- Systematic scan of a codebase for known anti-patterns before release
+- Second-opinion analysis after manual performance review
+
+## When Not to Use
+
+- **Algorithmic complexity analysis** — this skill targets API usage patterns, not algorithm design
+- **Code not on a hot path** with no performance requirements — avoid premature optimization
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Source code | Yes | C# files, code blocks, or repository paths to scan |
+| Hot-path context | Recommended | Which code paths are performance-critical |
+| Target framework | Recommended | .NET version (some patterns require .NET 8+) |
+| Scan depth | Optional | `critical-only`, `standard` (default), or `comprehensive` |
+
+## Workflow
+
+### Step 1: Load Reference Files (if available)
+
+Try to load `references/critical-patterns.md` and the topic-specific reference files listed below. These contain detailed detection recipes and grep commands.
+
+**If reference files are not found** (e.g., in a sandboxed environment or when the skill is embedded as instructions only), **skip file loading and proceed directly to Step 3** using the scan recipes listed inline below. Do not spend time searching the filesystem for reference files — if they aren't at the expected relative path, they aren't available.
+
+### Step 2: Detect Code Signals and Select Topic Recipes
+
+Scan the code for signals that indicate which pattern categories to check. If reference files were loaded, use their `## Detection` sections. Otherwise, use the inline recipes in Step 3.
+
+| Signal in Code | Topic |
+|----------------|-------|
+| `async`, `await`, `Task`, `ValueTask` | Async patterns |
+| `Span<`, `Memory<`, `stackalloc`, `ArrayPool`, `string.Substring`, `.Replace(`, `.ToLower()`, `+=` in loops, `params ` | Memory & strings |
+| `Regex`, `[GeneratedRegex]`, `Regex.Match`, `RegexOptions.Compiled` | Regex patterns |
+| `Dictionary<`, `List<`, `.ToList()`, `.Where(`, `.Select(`, LINQ methods, `static readonly Dictionary<` | Collections & LINQ |
+| `JsonSerializer`, `HttpClient`, `Stream`, `FileStream` | I/O & serialization |
+
+Always check structural patterns (unsealed classes) regardless of signals.
+
+**Scan depth controls scope:**
+- `critical-only`: Only critical patterns (deadlocks, >10x regressions)
+- `standard` (default): Critical + detected topic patterns
+- `comprehensive`: All pattern categories
+
+### Step 3: Scan and Report
+
+**For files under 500 lines, read the entire file first** — you'll spot most patterns faster than running individual grep recipes. Use grep to confirm counts and catch patterns you might miss visually.
+
+For each relevant pattern category, run the detection recipes below. Report exact counts, not estimates.
+
+**Core scan recipes** (run these when reference files aren't available):
+```
+# Strings & memory
+grep -n '\.IndexOf(\"' FILE                    # Missing StringComparison
+grep -n '\.Substring(' FILE                    # Substring allocations
+grep -En '\.(StartsWith|EndsWith|Contains)\s*\(' FILE  # Missing StringComparison
+grep -n '\.ToLower()\|\.ToUpper()' FILE        # Culture-sensitive + allocation
+grep -n '\.Replace(' FILE                      # Chained Replace allocations
+grep -n 'params ' FILE                         # params array allocation
+
+# Collections & LINQ
+grep -n '\.Select\|\.Where\|\.OrderBy\|\.GroupBy' FILE  # LINQ on hot path
+grep -n '\.All\|\.Any' FILE                    # LINQ on string/char
+grep -n 'new Dictionary<\|new List<' FILE      # Per-call allocation
+grep -n 'static readonly Dictionary<' FILE     # FrozenDictionary candidate
+
+# Regex
+grep -n 'RegexOptions.Compiled' FILE           # Compiled regex budget
+grep -n 'new Regex(' FILE                      # Per-call regex
+grep -n 'GeneratedRegex' FILE                  # Positive: source-gen regex
+
+# Structural
+grep -n 'public class \|internal class ' FILE  # Unsealed classes
+grep -n 'sealed class' FILE                    # Already sealed
+grep -n ': IEquatable' FILE                    # Positive: struct equality
+```
+
+**Rules:**
+- Run every relevant recipe for the detected pattern categories
+- **Emit a scan execution checklist** before classifying findings — list each recipe and the hit count
+- A result of **0 hits** is valid and valuable (confirms good practice)
+- If reference files were loaded, also run their `## Detection` recipes
+
+**Verify-the-Inverse Rule:** For absence patterns, always count both sides and report the ratio (e.g., "N of M classes are sealed"). The ratio determines severity — 0/185 is systematic, 12/15 is a consistency fix.
+
+### Step 3b: Cross-File Consistency Check
+
+If an optimized pattern is found in one file, check whether sibling files (same directory, same interface, same base class) use the un-optimized equivalent. Flag as 🟡 Moderate with the optimized file as evidence.
+
+### Step 3c: Compound Allocation Check
+
+After running scan recipes, look for these multi-allocation patterns that single-line recipes miss:
+
+1. **Branched `.Replace()` chains:** Methods that call `.Replace()` across multiple `if/else` branches — report total allocation count across all branches, not just per-line.
+2. **Cross-method chaining:** When a public method delegates to another method that itself allocates intermediates (e.g., A calls B which does 3 regex replaces, then A calls C), report the total chain cost as one finding.
+3. **Compound `+=` with embedded allocating calls:** Lines like `result += $"...{Foo().ToLower()}"` are 2+ allocations (interpolation + ToLower + concatenation) — flag the compound cost, not just the `.ToLower()`.
+4. **`string.Format` specificity:** Distinguish resource-loaded format strings (not fixable) from compile-time literal format strings (fixable with interpolation). Enumerate the actionable sites.
+
+### Step 4: Classify and Prioritize Findings
+
+Assign each finding a severity:
+
+| Severity | Criteria | Action |
+|----------|----------|--------|
+| 🔴 **Critical** | Deadlocks, crashes, security vulnerabilities, >10x regression | Must fix |
+| 🟡 **Moderate** | 2-10x improvement opportunity, best practice for hot paths | Should fix on hot paths |
+| ℹ️ **Info** | Pattern applies but code may not be on a hot path | Consider if profiling shows impact |
+
+**Prioritization rules:**
+1. If the user identified hot-path code, elevate all findings in that code to their maximum severity
+2. If hot-path context is unknown, report 🔴 Critical findings unconditionally; report 🟡 Moderate findings with a note: _"Impactful if this code is on a hot path"_
+3. Never suggest micro-optimizations on code that is clearly not performance-sensitive
+
+**Scale-based severity escalation:**
+When the same pattern appears across many instances, escalate severity:
+- 1-10 instances of the same anti-pattern → report at the pattern's base severity
+- 11-50 instances → escalate ℹ️ Info patterns to 🟡 Moderate
+- 50+ instances → escalate to 🟡 Moderate with elevated priority; flag as a codebase-wide systematic issue
+
+Always report exact counts (from scan recipes), not estimates or agent summaries.
+
+### Step 5: Generate Findings
+
+**Keep findings compact.** Each finding is one short block — not an essay. Group by severity (🔴 → 🟡 → ℹ️), not by file.
+
+Format per finding:
+
+```
+#### ID. Title (N instances)
+**Impact:** one-line impact statement
+**Files:** file1.cs:L1, file2.cs:L2, ... (list locations, don't build tables)
+**Fix:** one-line description of the change (e.g., "Add `StringComparison.Ordinal` parameter")
+**Caveat:** only if non-obvious (version requirement, correctness risk)
+```
+
+**Rules for compact output:**
+- **No ❌/✅ code blocks** for trivial fixes (adding a keyword, parameter, or type change). A one-line fix description suffices.
+- **Only include code blocks** for non-obvious transformations (e.g., replacing a LINQ chain with a foreach loop, or hoisting a closure).
+- **File locations as inline comma-separated list**, not a table. Use `File.cs:L42` format.
+- **No explanatory prose** beyond the Impact line — the severity icon already conveys urgency.
+- **Merge related findings** that share the same fix (e.g., all `.ToLower()` calls go in one finding, not split by file).
+- **Positive findings** in a bullet list, not a table. One line per pattern: `✅ Pattern — evidence`.
+
+End with a summary table and disclaimer:
+
+```markdown
+| Severity | Count | Top Issue |
+|----------|-------|-----------|
+| 🔴 Critical | N | ... |
+| 🟡 Moderate | N | ... |
+| ℹ️ Info | N | ... |
+
+> ⚠️ **Disclaimer:** These results are generated by an AI assistant and are non-deterministic. Findings may include false positives, miss real issues, or suggest changes that are incorrect for your specific context. Always verify recommendations with benchmarks and human review before applying changes to production code.
+```
+
+## Validation
+
+Before delivering results, verify:
+
+- [ ] All critical patterns were checked (from reference files or inline recipes)
+- [ ] Topic-specific recipes run only when matching signals detected
+- [ ] Each finding includes a concrete code fix
+- [ ] Scan execution checklist is complete (all recipes run)
+- [ ] Summary table included at end
+
+## Common Pitfalls
+
+| Pitfall | Correct Approach |
+|---------|-----------------|
+| Flagging every `Dictionary` as needing `FrozenDictionary` | Only flag if the dictionary is never mutated after construction |
+| Suggesting `Span<T>` in async methods | Use `Memory<T>` in async code; `Span<T>` only in sync hot paths |
+| Reporting LINQ outside hot paths | Only flag LINQ in identified hot paths or tight loops; LINQ is acceptable in code that runs infrequently. Since .NET 7, LINQ Min/Max/Sum/Average are vectorized — blanket bans on LINQ are misguided |
+| Suggesting `ConfigureAwait(false)` in app code | Only applicable in library code; not primarily a performance concern |
+| Recommending `ValueTask` everywhere | Only for hot paths with frequent synchronous completion |
+| Flagging `new HttpClient()` in DI services | Check if `IHttpClientFactory` is already in use |
+| Suggesting `[GeneratedRegex]` for dynamic patterns | Only flag when the pattern string is a compile-time literal |
+| Suggesting `CollectionsMarshal.AsSpan` broadly | Only for ultra-hot paths with benchmarked evidence; adds complexity and fragility |
+| Suggesting `unsafe` code for micro-optimizations | Avoid `unsafe` except where absolutely necessary — do not recommend it for micro-optimizations that don't matter. Safe alternatives like `Span<T>`, `stackalloc` in safe context, and `ArrayPool` cover the vast majority of performance needs |

--- a/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/async-patterns.md
+++ b/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/async-patterns.md
@@ -1,0 +1,112 @@
+# Async & Concurrency Patterns
+
+### Don't Expose Async Wrappers for Sync Methods
+🟡 **AVOID** wrapping sync methods with `Task.Run` in libraries | .NET Core+
+
+❌
+```csharp
+public Task<int> ComputeHashAsync(byte[] data) =>
+    Task.Run(() => ComputeHash(data));
+```
+✅
+```csharp
+public int ComputeHash(byte[] data) { /* CPU-bound work */ }
+// Consumer decides: var hash = await Task.Run(() => lib.ComputeHash(data));
+```
+
+**Impact: Eliminates unnecessary thread pool queue/dequeue overhead per call.**
+
+### Don't Expose Sync Wrappers for Async Methods
+🟡 **AVOID** creating sync wrappers that block on async implementations | .NET Core+
+
+❌
+```csharp
+public string GetData() => GetDataAsync().Result;
+```
+✅
+```csharp
+public async Task<string> GetDataAsync() { /* ... */ }
+```
+
+**Impact: Prevents deadlocks and thread pool starvation from hidden sync-over-async blocking.**
+
+### Use ValueTask for Hot Paths with Frequent Sync Completion
+🟡 **DO** use `ValueTask<T>` on hot paths where sync completion is common | .NET Core 2.1+
+
+❌
+```csharp
+public async Task<int> ReadAsync(Memory<byte> buffer)
+{
+    if (_bufferedCount > 0)
+        return ReadFromBuffer(buffer.Span);
+    return await ReadAsyncCore(buffer);
+}
+```
+✅
+```csharp
+public ValueTask<int> ReadAsync(Memory<byte> buffer)
+{
+    if (_bufferedCount > 0)
+        return new ValueTask<int>(ReadFromBuffer(buffer.Span));
+    return new ValueTask<int>(ReadAsyncCore(buffer));
+}
+```
+
+**Impact: Eliminates Task\<T\> allocation on synchronous completion — the struct stores results inline.**
+
+### Use Channels for Producer/Consumer
+🟡 **DO** use `System.Threading.Channels` for producer-consumer patterns | .NET Core 3.0+
+
+❌
+```csharp
+var queue = new BlockingCollection<WorkItem>();
+var item = queue.Take();
+```
+✅
+```csharp
+var channel = Channel.CreateUnbounded<WorkItem>();
+
+// Producer
+await channel.Writer.WriteAsync(item);
+
+// Consumer
+await foreach (var item in channel.Reader.ReadAllAsync())
+    Process(item);
+```
+
+**Impact: ~25% faster, ~95% fewer GC collections vs manual approaches.**
+
+### Avoid False Sharing with Thread-Local State
+🟡 **AVOID** adjacent mutable fields written by different threads | .NET 7+
+
+❌
+```csharp
+class SharedCounters
+{
+    public long Counter1;
+    public long Counter2;
+}
+```
+✅
+```csharp
+[StructLayout(LayoutKind.Explicit, Size = 128)]
+struct PaddedCounter
+{
+    [FieldOffset(0)] public long Value;
+}
+```
+
+**Impact: Eliminates cross-core cache invalidation — can improve multi-threaded throughput by 10x+.**
+
+## Detection
+
+Scan recipes for async anti-patterns. Run these and report exact counts.
+
+```bash
+# async void methods (correctness issue — crashes on exception)
+grep -rn --include='*.cs' 'async void' --exclude-dir=bin --exclude-dir=obj . | grep -v 'event' | wc -l
+```
+
+### Patterns Requiring Manual Review
+
+- **Sync-over-async** (`.Result`, `.Wait()`): `.Result` matches any property named Result — needs type context to confirm it's `Task.Result`

--- a/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/collections-and-linq.md
+++ b/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/collections-and-linq.md
@@ -1,0 +1,207 @@
+# Collections & LINQ Patterns
+
+### Use FrozenDictionary/FrozenSet for Read-Heavy Lookup Tables
+🟡 **DO** use `FrozenDictionary`/`FrozenSet` for collections created once and read many times | .NET 8+
+
+❌
+```csharp
+private static readonly Dictionary<string, int> s_statusCodes = new()
+{
+    ["OK"] = 200, ["NotFound"] = 404, ["InternalServerError"] = 500
+};
+```
+✅
+```csharp
+private static readonly FrozenDictionary<string, int> s_statusCodes =
+    new Dictionary<string, int>
+    {
+        ["OK"] = 200, ["NotFound"] = 404, ["InternalServerError"] = 500
+    }.ToFrozenDictionary();
+```
+
+**Impact: ~50% faster lookups than Dictionary, ~14x faster than ImmutableDictionary.**
+
+### Use Dictionary Alternate Lookup for Span-Based Keys
+🟡 **DO** use `GetAlternateLookup<ReadOnlySpan<char>>()` to avoid string allocation on lookups | .NET 9+
+
+❌
+```csharp
+string key = headerLine.Substring(0, colonIndex);
+if (s_dict.TryGetValue(key, out int value)) { /* ... */ }
+```
+✅
+```csharp
+var lookup = s_dict.GetAlternateLookup<ReadOnlySpan<char>>();
+ReadOnlySpan<char> key = headerLine.AsSpan(0, colonIndex);
+if (lookup.TryGetValue(key, out int value)) { }
+```
+
+**Impact: Avoids string allocation per lookup — especially valuable in parser/protocol hot paths.**
+
+### Use CollectionsMarshal.GetValueRefOrNullRef for Lookup-and-Update
+🟡 **DO** use `CollectionsMarshal.GetValueRefOrAddDefault` for dictionary update patterns | .NET 6+
+
+❌
+```csharp
+_counts.TryGetValue(key, out int count);
+_counts[key] = count + 1;
+```
+✅
+```csharp
+ref int count = ref CollectionsMarshal.GetValueRefOrAddDefault(_counts, key, out _);
+count++;
+```
+
+**Impact: ~48% faster for lookup-and-update patterns (95µs → 49µs).**
+
+### Use Collection Expressions [] for Zero-Allocation Span Creation
+🟡 **DO** use collection expressions for `Span<T>` targets | C# 12 / .NET 8+
+
+❌
+```csharp
+int[] values = new int[] { a, b, c, d };
+```
+✅
+```csharp
+Span<int> values = [a, b, c, d];
+ReadOnlySpan<int> daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+```
+
+**Impact: Zero heap allocation for span-targeted collection expressions.**
+
+### Use EnsureCapacity on List/Stack/Queue Before Bulk Adds
+🟡 **DO** call `EnsureCapacity` before bulk insertions | .NET 6+
+
+❌
+```csharp
+var list = new List<int>();
+for (int i = 0; i < 10000; i++)
+    list.Add(i);
+```
+✅
+```csharp
+var list = new List<int>();
+list.EnsureCapacity(10000);
+for (int i = 0; i < 10000; i++)
+    list.Add(i);
+```
+
+**Impact: Reduces reallocations and array copies during bulk operations.**
+
+### Use TryGetNonEnumeratedCount for Pre-Sizing
+🟡 **DO** use `TryGetNonEnumeratedCount` to pre-size destination collections | .NET 6+
+
+❌
+```csharp
+var results = new List<int>();
+foreach (var item in source)
+    results.Add(Transform(item));
+```
+✅
+```csharp
+var results = source.TryGetNonEnumeratedCount(out int count)
+    ? new List<int>(count)
+    : new List<int>();
+foreach (var item in source)
+    results.Add(Transform(item));
+```
+
+**Impact: Avoids O(n) enumeration for counting; eliminates resizing allocations.**
+
+### Hoist Static Data Out of Method Bodies
+🟡 **AVOID** creating collections with static/deterministic data inside method bodies | .NET Core+
+
+❌
+```csharp
+public string Convert(long number)
+{
+    var groupsMap = new Dictionary<long, Func<long, string>>
+    {
+        { 1_000_000_000, n => $"{Convert(n)} billion" },
+        { 1_000_000, n => $"{Convert(n)} million" },
+        { 1_000, n => $"{Convert(n)} thousand" },
+    };
+}
+```
+✅
+```csharp
+private static readonly FrozenDictionary<long, Func<long, string>> s_groupsMap =
+    new Dictionary<long, Func<long, string>>
+    {
+        { 1_000_000_000, n => $"{Convert(n)} billion" },
+        { 1_000_000, n => $"{Convert(n)} million" },
+        { 1_000, n => $"{Convert(n)} thousand" },
+    }.ToFrozenDictionary();
+
+public string Convert(long number)
+{
+    // ... use s_groupsMap
+}
+```
+
+**Impact: Eliminates collection + internal storage + closure allocations per call. For a Dictionary with N entries, saves ~N+3 allocations per invocation.**
+
+### Add Overloads to Avoid params Array Allocation
+🟡 **DO** add 1- and 2-argument overloads for methods that accept `params T[]`, or use `params ReadOnlySpan<T>` on .NET 9+ | .NET Core+
+
+❌
+```csharp
+public static string Transform(this string input, params IStringTransformer[] transformers) =>
+    transformers.Aggregate(input, (current, t) => t.Transform(current));
+
+"hello".Transform(To.TitleCase);
+```
+✅
+```csharp
+// Option A: Explicit overloads for common arities
+public static string Transform(this string input, IStringTransformer transformer) =>
+    transformer.Transform(input);
+
+public static string Transform(this string input, IStringTransformer t1, IStringTransformer t2) =>
+    t2.Transform(t1.Transform(input));
+
+public static string Transform(this string input, params IStringTransformer[] transformers) =>
+    transformers.Aggregate(input, (current, t) => t.Transform(current));
+
+// Option B (.NET 9+ / C# 13): params ReadOnlySpan<T> — zero heap allocation
+public static string Transform(this string input, params ReadOnlySpan<IStringTransformer> transformers)
+{
+    foreach (var t in transformers)
+        input = t.Transform(input);
+    return input;
+}
+```
+
+**Impact: Eliminates one array allocation per call for the common 1- and 2-argument cases. `params ReadOnlySpan<T>` eliminates it for all arities.**
+
+## Detection
+
+Scan recipes for collection and LINQ anti-patterns. Run these and report exact counts.
+
+```bash
+# Static Dictionary not using FrozenDictionary (read-only after init)
+grep -rn --include='*.cs' 'static readonly Dictionary<' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# Static FrozenDictionary (already optimized — verify the inverse)
+grep -rn --include='*.cs' 'static readonly FrozenDictionary<' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# Per-call List allocation (inside method bodies, not static/readonly fields)
+grep -rn --include='*.cs' 'new List<' --exclude-dir=bin --exclude-dir=obj . | grep -v 'static\|readonly' | wc -l
+
+# Per-call Dictionary allocation (inside method bodies, not static/readonly fields)
+grep -rn --include='*.cs' 'new Dictionary<' --exclude-dir=bin --exclude-dir=obj . | grep -v 'static\|readonly' | wc -l
+
+# StringComparer.CurrentCulture usage (almost always wrong in library code — use Ordinal)
+grep -rn --include='*.cs' 'StringComparer.CurrentCulture' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# LINQ chains in extension/hot-path files (.Select, .Where, .Cast, .Take, .Aggregate)
+grep -rn --include='*.cs' -E '\.(Select|Where|Cast|Take|Aggregate)\(' --exclude-dir=bin --exclude-dir=obj . | wc -l
+```
+
+For the LINQ chain recipe: any hit in a file whose name ends in `Extensions.cs`, `Formatter.cs`, or implements a method called from a public extension method is a hot-path candidate. Inspect each hit in these files and flag LINQ chains that allocate delegates, enumerators, or intermediate collections on every call. Hits in localization converters or one-time initialization are lower priority.
+
+### Patterns Requiring Manual Review
+
+- **ContainsKey + indexer double-lookup**: Requires verifying the same key is used in a subsequent indexer access — multi-line/multi-statement context
+- **LINQ on hot paths**: The LINQ chain recipe above catches call sites, but distinguishing hot-path from cold-path requires context. Prioritize hits in `*Extensions.cs` and `*Formatter.cs` files, which are typically called on every user invocation
+- **`new Dictionary/List<` in method bodies vs fields**: The grep heuristic (`grep -v 'static\|readonly'`) catches most cases but may include false positives from field initializers without `static`/`readonly` — spot-check flagged lines

--- a/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/critical-patterns.md
+++ b/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/critical-patterns.md
@@ -1,0 +1,280 @@
+# Critical .NET Performance Anti-Patterns
+
+17 patterns that cause deadlocks, order-of-magnitude regressions, or excessive allocations.
+
+## Async / Tasks
+
+### Never Block on Async (Sync-over-Async)
+🔴 **AVOID** | .NET Core+
+
+❌
+```csharp
+public string GetData()
+    => GetDataAsync().Result;
+```
+✅
+```csharp
+public async Task<string> GetDataAsync()
+    => await GetDataInternalAsync();
+```
+**Impact: Deadlocks or thread pool starvation; wastes threads, destroys scalability.**
+
+### Never Await a ValueTask Multiple Times
+🔴 **AVOID** | .NET Core 2.1+
+
+❌
+```csharp
+ValueTask<int> vt = SomeMethodAsync();
+int a = await vt;
+int b = await vt;
+```
+✅
+```csharp
+int result = await SomeMethodAsync();
+```
+**Impact: Undefined behavior — silent data corruption or exceptions.**
+
+## Memory / Allocation
+
+### Use Span\<T\> / AsSpan Instead of Substring for Slicing
+🔴 **DO** | .NET Core 2.1+
+
+❌
+```csharp
+string sub = input.Substring(5, 10);
+```
+✅
+```csharp
+ReadOnlySpan<char> sub = input.AsSpan(5, 10);
+```
+**Impact: Eliminates per-slice allocations; 2-4x faster via vectorization.**
+
+### Use ArrayPool\<T\> for Temporary Buffers
+🔴 **DO** | .NET Core+
+
+❌
+```csharp
+byte[] buf = new byte[4096];
+```
+✅
+```csharp
+byte[] buf = ArrayPool<byte>.Shared.Rent(4096);
+Process(buf);
+ArrayPool<byte>.Shared.Return(buf);
+```
+**Impact: Dramatically reduces GC pressure for buffer-heavy workloads.**
+
+### Avoid stackalloc in Loops
+🔴 **AVOID** | .NET 5+
+
+❌
+```csharp
+for (int i = 0; i < 10_000; i++)
+    Span<byte> buf = stackalloc byte[1024];
+```
+✅
+```csharp
+Span<byte> buf = stackalloc byte[1024];
+for (int i = 0; i < 10_000; i++) { Process(buf); }
+```
+**Impact: StackOverflowException — unrecoverable, no catch possible.**
+
+### Avoid Boxing Value Types
+🔴 **AVOID** | .NET 6+
+
+❌
+```csharp
+string s = string.Format("{0}.{1}", major, minor);
+```
+✅
+```csharp
+string s = $"{major}.{minor}";
+```
+**Impact: When replacing `string.Format` with C# 10+ interpolation, typical improvements are ~40% faster with significantly less allocation. Actual gains vary by call site.**
+
+## Strings
+
+### Use StringComparison.Ordinal for Non-Linguistic Comparisons
+🔴 **DO** | .NET Core+
+
+❌
+```csharp
+bool found = text.IndexOf("Content-Type") >= 0;
+```
+✅
+```csharp
+bool found = text.Contains("Content-Type", StringComparison.Ordinal);
+```
+**Impact: 2-3x faster; OrdinalIgnoreCase hash codes ~3.3x faster.**
+
+### Use AsSpan Instead of Substring
+🔴 **DO** | .NET Core 2.1+
+
+❌
+```csharp
+int val = int.Parse(str.Substring(5, 3));
+```
+✅
+```csharp
+int val = int.Parse(str.AsSpan(5, 3));
+```
+**Impact: Eliminates one string allocation per parse operation.**
+
+## Regular Expressions
+
+### Use Source-Generated Regex [GeneratedRegex]
+🔴 **ALWAYS** use `[GeneratedRegex]` for all static regex patterns | .NET 7+
+
+❌
+```csharp
+private static readonly Regex s_re =
+    new(@"\w+@\w+\.\w+", RegexOptions.Compiled);
+```
+✅
+```csharp
+[GeneratedRegex(@"\w+@\w+\.\w+")]
+private static partial Regex EmailRegex();
+```
+**Impact: Always beneficial or neutral for static patterns — near-zero startup, better throughput, and required for AOT/trimming scenarios.**
+
+### Avoid Nested Quantifiers (Catastrophic Backtracking)
+🔴 **AVOID** | .NET Core+
+
+❌
+```csharp
+var r = new Regex(@"^(\w+)+$");
+```
+✅
+```csharp
+var r = new Regex(@"^\w+$", RegexOptions.NonBacktracking);
+```
+**Impact: Can hang process indefinitely on crafted input.**
+
+### Use TryGetValue Instead of ContainsKey + Indexer
+🔴 **DO** | .NET Core+
+
+❌
+```csharp
+if (dict.ContainsKey(key))
+    Use(dict[key]);
+```
+✅
+```csharp
+if (dict.TryGetValue(key, out var value))
+    Use(value);
+```
+**Impact: ~2x faster (50% reduction in lookup time).**
+
+### Avoid LINQ in Hot Paths
+🔴 **AVOID** | .NET Core+
+
+❌
+```csharp
+bool found = items.Any(x => x.Name == target);
+```
+✅
+```csharp
+bool found = false;
+foreach (var item in items)
+    if (item.Name == target) { found = true; break; }
+```
+**Impact: Eliminates 1-3 allocations per call; measurable in tight loops.**
+
+### Don't Iterate IEnumerable Multiple Times
+🔴 **AVOID** | .NET Core+
+
+❌
+```csharp
+foreach (Type t in types) { Validate(t); }
+_types = types.ToArray();
+```
+✅
+```csharp
+Type[] arr = types.ToArray();
+foreach (Type t in arr) { Validate(t); }
+_types = arr;
+```
+**Impact: Halves enumeration cost; prevents bugs from re-executing deferred queries.**
+
+## JSON Serialization
+
+### Use System.Text.Json Source Generator
+🔴 **DO** | .NET 6+
+
+❌
+```csharp
+string json = JsonSerializer.Serialize(post);
+```
+✅
+```csharp
+[JsonSerializable(typeof(BlogPost))]
+internal partial class AppJsonCtx : JsonSerializerContext { }
+string json = JsonSerializer.Serialize(post, AppJsonCtx.Default.BlogPost);
+```
+**Impact: 37-44% faster; enables trimming and Native AOT.**
+
+### Cache JsonSerializerOptions
+🔴 **DO** | .NET 5+
+
+❌
+```csharp
+JsonSerializer.Serialize(obj, new JsonSerializerOptions());
+```
+✅
+```csharp
+private static readonly JsonSerializerOptions s_opts = new();
+JsonSerializer.Serialize(obj, s_opts);
+```
+**Impact: Up to 592x slower without caching (.NET 6); always cache or use defaults.**
+
+## Networking
+
+### Reuse HttpClient Instances
+🔴 **DO** | .NET Core 2.1+
+
+❌
+```csharp
+using var client = new HttpClient();
+await client.GetStringAsync(url);
+```
+✅
+```csharp
+private static readonly HttpClient s_http = new(new SocketsHttpHandler
+{ PooledConnectionLifetime = TimeSpan.FromMinutes(5) });
+await s_http.GetStringAsync(url);
+```
+**Impact: Prevents socket exhaustion; 6-12x faster concurrent HTTPS.**
+
+## General
+
+### Use SearchValues\<T\> for Repeated Set Searches
+🔴 **DO** | .NET 8+
+
+❌
+```csharp
+int pos = text.IndexOfAny("ABCDEF".ToCharArray());
+```
+✅
+```csharp
+private static readonly SearchValues<char> s_hex = SearchValues.Create("ABCDEF");
+int pos = text.AsSpan().IndexOfAny(s_hex);
+```
+**Impact: 2-10x faster for chars; 10-30x faster for multi-string (.NET 9+).**
+
+## Detection
+
+Scan recipes for critical anti-patterns. Run these and report exact counts of issues found in each case.
+
+```bash
+# .IndexOf(string) without StringComparison (culture-aware, 2-3x slower)
+grep -rn --include='*.cs' -E '\.IndexOf\("[^"]+"\)' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# .Substring( calls (allocates new string — consider AsSpan)
+grep -rn --include='*.cs' '\.Substring(' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# .StartsWith/.EndsWith without StringComparison (culture-aware, 2-3x slower)
+grep -rn --include='*.cs' -E '\.(StartsWith|EndsWith)\("[^"]+"\)' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# .Contains(string) without StringComparison — NOTE: will also match collection .Contains() calls; filter to string receivers
+grep -rn --include='*.cs' -E '\.Contains\("[^"]+"\)' --exclude-dir=bin --exclude-dir=obj . | wc -l
+```

--- a/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/io-and-serialization.md
+++ b/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/io-and-serialization.md
@@ -1,0 +1,124 @@
+# I/O, Serialization & General Patterns
+
+### Use HttpCompletionOption.ResponseHeadersRead for Streaming
+🟡 **DO** use `ResponseHeadersRead` when downloading large responses | .NET Core 3.0+
+
+❌
+```csharp
+var response = await client.GetAsync(uri);
+```
+✅
+```csharp
+using var response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead);
+using var stream = await response.Content.ReadAsStreamAsync();
+await stream.CopyToAsync(destinationStream);
+```
+
+**Impact: ~2x faster for large downloads (10MB+), dramatically reduced memory usage.**
+
+### Use Async FileStream Operations
+🟡 **DO** use `FileStream` with `useAsync: true` for scalable file I/O | .NET 6+
+
+❌
+```csharp
+using var fs = new FileStream(path, FileMode.Open);
+```
+✅
+```csharp
+await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read,
+    FileShare.Read, bufferSize: 4096, useAsync: true);
+
+byte[] buffer = new byte[1024];
+while (await fs.ReadAsync(buffer) != 0) { /* process */ }
+```
+
+**Impact: Up to 3x faster async reads; allocation reduced from megabytes to hundreds of bytes.**
+
+### Use Memory\<byte\> Overloads for Stream.ReadAsync/WriteAsync
+🟡 **DO** use `Memory<byte>`-based stream overloads instead of `byte[]` overloads | .NET 5+
+
+❌
+```csharp
+await stream.ReadAsync(buffer, 0, buffer.Length);
+await stream.WriteAsync(buffer, 0, buffer.Length);
+```
+✅
+```csharp
+await stream.ReadAsync(buffer.AsMemory());
+await stream.WriteAsync(buffer.AsMemory());
+```
+
+**Impact: Eliminates ~72 KB allocation per 1,000 read/write pairs on NetworkStream.**
+
+### Use Span-Based TryFormat for Number Formatting
+🟡 **DO** use `TryFormat` to format numbers into `Span<char>` buffers | .NET Core 2.1+
+
+❌
+```csharp
+string formatted = value.ToString();
+destination.Write(formatted);
+```
+✅
+```csharp
+Span<char> buffer = stackalloc char[20];
+if (value.TryFormat(buffer, out int charsWritten))
+    destination.Write(buffer[..charsWritten]);
+```
+
+**Impact: Int32.ToString() ~2x faster in .NET Core 2.1, Int32 parsing ~5x faster in .NET Core 3.0.**
+
+### Use static readonly for Runtime Devirtualization
+🟡 **DO** store implementations in `static readonly` fields for JIT devirtualization | .NET Core 3.0+
+
+❌
+```csharp
+private static Base s_impl = new DerivedImpl();
+s_impl.Process();
+```
+✅
+```csharp
+private static readonly Base s_impl = new DerivedImpl();
+s_impl.Process();
+
+private static readonly bool s_feature =
+    Environment.GetEnvironmentVariable("Feature") == "1";
+```
+
+**Impact: Virtual call eliminated entirely — can be inlined to zero overhead. Dead code elimination in tier 1.**
+
+### Avoid Explicit Static Constructors — Use Field Initializers
+🟡 **AVOID** explicit `static` constructors when field initializers suffice | .NET Core 3.0+
+
+❌
+```csharp
+class Foo
+{
+    static readonly int s_value;
+    static Foo() { s_value = ComputeValue(); }
+}
+```
+✅
+```csharp
+class Foo
+{
+    static readonly int s_value = ComputeValue();
+}
+```
+
+**Impact: Enables better JIT optimization and reduces potential lock overhead on static method access.**
+
+## Detection
+
+Scan recipes for I/O and serialization anti-patterns. Run these and report exact counts.
+
+```bash
+# new HttpClient() (socket exhaustion risk)
+grep -rn --include='*.cs' 'new HttpClient(' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# new JsonSerializerOptions() not cached (592x slower in .NET 6)
+grep -rn --include='*.cs' 'new JsonSerializerOptions' --exclude-dir=bin --exclude-dir=obj . | grep -v 'static\|readonly' | wc -l
+```
+
+### Patterns Requiring Manual Review
+
+- **`JsonSerializer.Serialize/Deserialize` without source-gen context**: Can't determine from grep if a context parameter is passed

--- a/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/memory-and-strings.md
+++ b/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/memory-and-strings.md
@@ -1,0 +1,205 @@
+# Memory & String Patterns
+
+### Use ReadOnlySpan\<byte\> for Constant Byte Data
+🟡 **DO** assign constant byte arrays to `ReadOnlySpan<byte>` | .NET 5+
+
+❌
+```csharp
+byte[] data = new byte[] { 0x48, 0x65, 0x6C, 0x6C, 0x6F };
+```
+✅
+```csharp
+ReadOnlySpan<byte> data = [0x48, 0x65, 0x6C, 0x6C, 0x6F];
+ReadOnlySpan<int> primes = [2, 3, 5, 7, 11, 13];
+```
+
+**Impact: ~100x faster access than static byte[] field, zero allocation.**
+
+### Use stackalloc for Small Temporary Buffers
+🟡 **DO** use `stackalloc` for small, fixed-size temporary buffers | .NET Core+
+
+❌
+```csharp
+char[] buffer = new char[64];
+guid.TryFormat(buffer, out int written);
+```
+✅
+```csharp
+Span<char> buffer = stackalloc char[64];
+guid.TryFormat(buffer, out int written);
+```
+
+**Impact: Zero heap allocation, no GC pressure, instant alloc/dealloc.**
+
+### Use Span.TryWrite for Allocation-Free Interpolation
+🟡 **DO** use `MemoryExtensions.TryWrite` to format into `Span<char>` buffers | .NET 6+
+
+❌
+```csharp
+string formatted = $"Date: {dt:R}";
+destination.Write(formatted);
+```
+✅
+```csharp
+Span<char> buffer = stackalloc char[64];
+buffer.TryWrite($"Date: {dt:R}", out int charsWritten);
+```
+
+**Impact: Zero heap allocation for formatting operations.**
+
+### Use Span.Split() for Zero-Allocation Splitting
+🟡 **DO** use `MemoryExtensions.Split` for allocation-free string splitting | .NET 9+
+
+❌
+```csharp
+string[] parts = input.Split(',');
+```
+✅
+```csharp
+foreach (Range range in input.AsSpan().Split(','))
+{
+    ReadOnlySpan<char> segment = input.AsSpan(range);
+}
+```
+
+**Impact: 208 bytes → 0 bytes per split, 2x faster.**
+
+### Use UTF8 String Literals (u8 suffix)
+🟡 **DO** use the `u8` suffix for compile-time UTF8 `ReadOnlySpan<byte>` | .NET 7+
+
+❌
+```csharp
+byte[] header = Encoding.UTF8.GetBytes("Content-Type");
+```
+✅
+```csharp
+ReadOnlySpan<byte> header = "Content-Type"u8;
+```
+
+**Impact: 17ns → 0.006ns — eliminates runtime transcoding entirely.**
+
+### Use ReadOnlySpan\<char\> Pattern Matching with switch
+🟡 **DO** use `switch` on `ReadOnlySpan<char>` for allocation-free string matching | C# 11+
+
+❌
+```csharp
+switch (attr.Value.Trim()) { case "preserve": /* ... */ break; }
+```
+✅
+```csharp
+switch (attr.Value.AsSpan().Trim())
+{
+    case "preserve": return Preserve;
+    case "default": return Default;
+}
+```
+
+**Impact: Eliminates string allocation from Trim() in switch-based dispatch.**
+
+### Use params ReadOnlySpan\<T\> to Eliminate Array Allocations
+🟡 **DO** add `params ReadOnlySpan<T>` overloads to library methods | C# 13 / .NET 9+
+
+❌
+```csharp
+public static void Log(params string[] messages) { /* ... */ }
+Log("Starting", "Processing", "Done");
+```
+✅
+```csharp
+public static void Log(params ReadOnlySpan<string> messages) { /* ... */ }
+Log("Starting", "Processing", "Done");
+```
+
+**Impact: Eliminates params array allocation. E.g., Path.Join with 5+ segments saves 64 bytes per call.**
+
+### Avoid Chained String-Returning Operations
+🟡 **AVOID** chains of 3+ string-returning method calls that each allocate intermediates | .NET Core+
+
+**Pattern 1: Chained .Replace() calls**
+
+❌
+```csharp
+string result = input.Replace("a", "b").Replace("c", "d").Replace("e", "f");
+```
+✅
+```csharp
+var sb = new StringBuilder(input.Length);
+// single pass replacing all patterns
+```
+
+**Pattern 2: Chained Regex.Replace() calls**
+
+❌
+```csharp
+public static string Underscore(this string input) =>
+    Regex3.Replace(Regex2.Replace(Regex1.Replace(input, "$1_$2"), "$1_$2"), "_").ToLower();
+```
+✅
+```csharp
+return string.Create(totalLength, state, (span, s) => { /* write directly */ });
+```
+
+**Pattern 3: += string concatenation in loops**
+
+❌
+```csharp
+string result = "";
+foreach (var part in parts)
+    result += separator + part;
+```
+✅
+```csharp
+var sb = new StringBuilder();
+foreach (var part in parts)
+    sb.Append(separator).Append(part);
+return sb.ToString();
+```
+
+**Impact: Eliminates N-1 intermediate string allocations per chain. For `+=` in loops, eliminates O(n²) total allocation.**
+
+### Cache char.ToString() for Known Character Sets
+🟡 **DO** cache `char.ToString()` results when the set of characters is small and known | .NET Core+
+
+❌
+```csharp
+return symbol.ToString();
+
+foreach (var prefix in UnitPrefixes)
+    input = input.Replace(prefix.Value.Name, prefix.Key.ToString());
+```
+✅
+```csharp
+private static readonly FrozenDictionary<char, string> s_charStrings =
+    new Dictionary<char, string>
+    {
+        ['k'] = "k", ['M'] = "M", ['G'] = "G",
+    }.ToFrozenDictionary();
+
+return s_charStrings[symbol];
+```
+
+**Impact: Eliminates one string allocation per char.ToString() call. Significant when called in loops or on hot paths.**
+
+## Detection
+
+Scan recipes for memory and string anti-patterns. Run these and report exact counts.
+
+```bash
+# .ToLower()/.ToUpper() without culture parameter (allocates + culture-sensitive)
+grep -rn --include='*.cs' -E '\.(ToLower|ToUpper)\(\)' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# Chained .Replace( calls (3+ on one line — intermediate string allocations)
+grep -rn --include='*.cs' '\.Replace(.*\.Replace(.*\.Replace(' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# params in method signatures (array allocation per call)
+grep -rn --include='*.cs' 'params ' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# LINQ on strings — .All/.Any on IEnumerable<char> (replace with foreach loop)
+grep -rn --include='*.cs' -E '\.(All|Any)\(char\.' --exclude-dir=bin --exclude-dir=obj . | wc -l
+```
+
+### Patterns Requiring Manual Review
+
+- **Boxing via string.Format**: Can't determine argument types from grep — needs type analysis
+- **`+=` string concatenation in loops**: `+=` matches all types (int, list, event, string) — needs type context to confirm string
+- **`char.ToString()`**: Requires knowing the variable type is `char` — not reliably greppable

--- a/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/regex-patterns.md
+++ b/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/regex-patterns.md
@@ -1,0 +1,95 @@
+# Regex Patterns
+
+### Choose the Right Regex Engine Mode
+🟡 **DO** use `[GeneratedRegex]` for all static regex patterns, but never remove `NonBacktracking` if present | .NET 7+
+
+❌
+```csharp
+var r = new Regex(dynamicPattern, RegexOptions.Compiled);
+```
+✅
+```csharp
+[GeneratedRegex("pattern")]
+private static partial Regex MyRegex();
+
+var safe = new Regex(untrustedPattern, RegexOptions.NonBacktracking);
+
+var oneOff = new Regex("pattern");
+```
+
+**Impact: Source generator is always beneficial for static patterns. NonBacktracking prevents O(2^N) worst case — never remove it if present.**
+
+### Use IsMatch When You Only Need a Boolean Result
+🟡 **DO** use `IsMatch` instead of `Match(...).Success` | .NET 7+
+
+❌
+```csharp
+bool found = Regex.Match(input, pattern).Success;
+```
+✅
+```csharp
+bool found = Regex.IsMatch(input, pattern);
+```
+
+**Impact: Avoids Match object allocation; with NonBacktracking, ~3x faster by skipping capture computation.**
+
+### Use Regex.Count/EnumerateMatches Instead of Matches
+🟡 **DO** use `Count()` and `EnumerateMatches()` for allocation-free match processing | .NET 7+
+
+❌
+```csharp
+int count = 0;
+Match m = regex.Match(text);
+while (m.Success) { count++; m = m.NextMatch(); }
+```
+✅
+```csharp
+int count = regex.Count(text);
+
+foreach (ValueMatch m in Regex.EnumerateMatches(text, @"\b\w+\b"))
+{
+    ReadOnlySpan<char> word = text.AsSpan(m.Index, m.Length);
+}
+```
+
+**Impact: ~3x faster than Match/NextMatch with NonBacktracking. Zero allocations for both Count and EnumerateMatches.**
+
+### Use Span-Based Regex APIs for Allocation-Free Matching
+🟡 **DO** use `ReadOnlySpan<char>` overloads for regex matching on spans | .NET 7+
+
+❌
+```csharp
+string sub = largeBuffer.Substring(start, length);
+bool found = Regex.IsMatch(sub, pattern);
+```
+✅
+```csharp
+ReadOnlySpan<char> text = largeBuffer.AsSpan(start, length);
+foreach (ValueMatch m in Regex.EnumerateMatches(text, @"\b\w+\b"))
+{
+    ReadOnlySpan<char> word = text.Slice(m.Index, m.Length);
+}
+```
+
+**Impact: Eliminates string allocations when working with spans — particularly valuable in high-throughput parsing pipelines.**
+
+## Detection
+
+Scan recipes for regex anti-patterns. Run these and report exact counts.
+
+```bash
+# Compiled regex count (startup cost budget — compare ratio to GeneratedRegex)
+grep -rn --include='*.cs' 'RegexOptions.Compiled' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# GeneratedRegex count (already optimized — verify the inverse)
+grep -rn --include='*.cs' 'GeneratedRegex' --exclude-dir=bin --exclude-dir=obj . | wc -l
+
+# Uncached new Regex() calls (construction cost per call)
+grep -rn --include='*.cs' 'new Regex(' --exclude-dir=bin --exclude-dir=obj . | wc -l
+```
+
+When `RegexOptions.Compiled` appears inside a class constructor or field initializer of an instantiated class (not a static singleton), count how many instances of that class are created at startup to determine total compiled regex budget. For example, if a `Rule` class compiles a regex in its constructor and 122 rules are registered, that is 122 compiled regexes at startup.
+
+### Patterns Requiring Manual Review
+
+- **`new Regex(` uncached**: Field assignment may span multiple lines — grep on one line is unreliable. Verify that matched instances are stored in `static readonly` fields or `[GeneratedRegex]`.

--- a/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/structural-patterns.md
+++ b/src/lsptoolshost/copilot/skills/analyzing-dotnet-performance/references/structural-patterns.md
@@ -1,0 +1,38 @@
+# Structural Patterns
+
+Patterns detected by the **absence** of a keyword or interface. These require codebase-wide counting scans, not single-file matching.
+
+### Seal Classes for Devirtualization
+🟡 **DO** seal all leaf classes (those not subclassed) | .NET Core 3.0+
+
+Sealing lets the JIT devirtualize/inline virtual calls and use pointer comparison for type checks. Every non-abstract, non-static class that is not subclassed should be sealed.
+
+**Detection:** This is an absence pattern — scan for classes that are NOT sealed.
+
+```bash
+# Count unsealed (non-abstract, non-static) classes
+grep -rn --include='*.cs' -E '^\s*((public|internal|private|protected|file)\s+)?(partial\s+)?class ' --exclude-dir=bin --exclude-dir=obj . | grep -v 'sealed' | grep -v 'abstract' | grep -v 'static' | wc -l
+
+# Count already-sealed classes (verify the inverse)
+grep -rn --include='*.cs' 'sealed class' --exclude-dir=bin --exclude-dir=obj . | wc -l
+```
+
+**Exclusions:** Do not seal classes that are subclassed elsewhere in the codebase. Identifying base classes requires manual review — grep for `: ClassName` patterns and cross-reference, but expect false positives from interface implementations and generic constraints.
+
+❌
+```csharp
+internal class MyHandler : Base
+{ public override int Run() => 42; }
+```
+✅
+```csharp
+internal sealed class MyHandler : Base
+{ public override int Run() => 42; }
+```
+
+**Impact: Virtual calls up to 500x faster; type checks ~25x faster. Severity scales with count.**
+
+**Scale-based severity:**
+- 1-10 unsealed leaf classes → ℹ️ Info
+- 11-50 unsealed leaf classes → 🟡 Moderate
+- 50+ unsealed leaf classes → 🟡 Moderate (elevated priority)

--- a/src/lsptoolshost/copilot/skills/csharp-scripts/SKILL.md
+++ b/src/lsptoolshost/copilot/skills/csharp-scripts/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: csharp-scripts
+description: Run single-file C# programs as scripts (file-based apps) for quick experimentation, prototyping, and concept testing. Use when the user wants to write and execute a small C# program without creating a full project.
+license: MIT
+---
+
+# C# Scripts
+
+## When to Use
+
+- Testing a C# concept, API, or language feature with a quick one-file program
+- Prototyping logic before integrating it into a larger project
+
+## When Not to Use
+
+- The user needs a full project with multiple files or project references
+- The user is working inside an existing .NET solution and wants to add code there
+- The program is too large or complex for a single file
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| C# code or intent | Yes | The code to run, or a description of what the script should do |
+
+## Workflow
+
+### Step 1: Check the .NET SDK version
+
+Run `dotnet --version` to verify the SDK is installed and note the major version number. File-based apps require .NET 10 or later. If the version is below 10, follow the [fallback for older SDKs](#fallback-for-net-9-and-earlier) instead.
+
+### Step 2: Write the script file
+
+Create a single `.cs` file using top-level statements. Place it outside any existing project directory to avoid conflicts with `.csproj` files.
+
+```csharp
+// hello.cs
+Console.WriteLine("Hello from a C# script!");
+
+var numbers = new[] { 1, 2, 3, 4, 5 };
+Console.WriteLine($"Sum: {numbers.Sum()}");
+```
+
+Guidelines:
+
+- Use top-level statements (no `Main` method, class, or namespace boilerplate)
+- Place `using` directives at the top of the file (after the `#!` line and any `#:` directives if present)
+- Place type declarations (classes, records, enums) after all top-level statements
+
+### Step 3: Run the script
+
+```bash
+dotnet hello.cs
+```
+
+Builds and runs the file automatically. Cached so subsequent runs are fast. Pass arguments after `--`:
+
+```bash
+dotnet hello.cs -- arg1 arg2 "multi word arg"
+```
+
+### Step 4: Add directives (if needed)
+
+Place directives at the top of the file (immediately after an optional shebang line), before any `using` directives or other C# code. All directives start with `#:`.
+
+#### `#:package` — NuGet package references
+
+Always specify a version:
+
+```csharp
+#:package Humanizer@2.14.1
+
+using Humanizer;
+
+Console.WriteLine("hello world".Titleize());
+```
+
+#### `#:property` — MSBuild properties
+
+Set any MSBuild property inline. Syntax: `#:property PropertyName=Value`
+
+```csharp
+#:property AllowUnsafeBlocks=true
+#:property PublishAot=false
+#:property NoWarn=CS0162
+```
+
+MSBuild expressions and property functions are supported:
+
+```csharp
+#:property LogLevel=$([MSBuild]::ValueOrDefault('$(LOG_LEVEL)', 'Information'))
+```
+
+Common properties:
+
+| Property | Purpose |
+|----------|---------|
+| `AllowUnsafeBlocks=true` | Enable `unsafe` code |
+| `PublishAot=false` | Disable native AOT (enabled by default) |
+| `NoWarn=CS0162;CS0219` | Suppress specific warnings |
+| `LangVersion=preview` | Enable preview language features |
+| `InvariantGlobalization=false` | Enable culture-specific globalization |
+
+#### `#:project` — Project references
+
+Reference another project by relative path:
+
+```csharp
+#:project ../MyLibrary/MyLibrary.csproj
+```
+
+#### `#:sdk` — SDK selection
+
+Override the default SDK (`Microsoft.NET.Sdk`):
+
+```csharp
+#:sdk Microsoft.NET.Sdk.Web
+```
+
+### Step 5: Clean up
+
+Remove the script file when the user is done. To clear cached build artifacts:
+
+```bash
+dotnet clean hello.cs
+```
+
+## Unix shebang support
+
+On Unix platforms, make a `.cs` file directly executable:
+
+1. Add a shebang as the first line of the file:
+
+    ```csharp
+    #!/usr/bin/env dotnet
+    Console.WriteLine("I'm executable!");
+    ```
+
+2. Set execute permissions:
+
+    ```bash
+    chmod +x hello.cs
+    ```
+
+3. Run directly:
+
+    ```bash
+    ./hello.cs
+    ```
+
+Use `LF` line endings (not `CRLF`) when adding a shebang. This directive is ignored on Windows.
+
+## Source-generated JSON
+
+File-based apps enable native AOT by default. Reflection-based APIs like `JsonSerializer.Serialize<T>(value)` fail at runtime under AOT. Use source-generated serialization instead:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+var person = new Person("Alice", 30);
+var json = JsonSerializer.Serialize(person, AppJsonContext.Default.Person);
+Console.WriteLine(json);
+
+var deserialized = JsonSerializer.Deserialize(json, AppJsonContext.Default.Person);
+Console.WriteLine($"Name: {deserialized!.Name}, Age: {deserialized.Age}");
+
+record Person(string Name, int Age);
+
+[JsonSerializable(typeof(Person))]
+partial class AppJsonContext : JsonSerializerContext;
+```
+
+## Converting to a project
+
+When a script outgrows a single file, convert it to a full project:
+
+```bash
+dotnet project convert hello.cs
+```
+
+## Fallback for .NET 9 and earlier
+
+If the .NET SDK version is below 10, file-based apps are not available. Use a temporary console project instead:
+
+```bash
+mkdir -p /tmp/csharp-script && cd /tmp/csharp-script
+dotnet new console -o . --force
+```
+
+Replace the generated `Program.cs` with the script content and run with `dotnet run`. Add NuGet packages with `dotnet add package <name>`. Remove the directory when done.
+
+## Validation
+
+- [ ] `dotnet --version` reports 10.0 or later (or fallback path is used)
+- [ ] The script compiles without errors (can be checked explicitly with `dotnet build <file>.cs`)
+- [ ] `dotnet <file>.cs` produces the expected output
+- [ ] Script file and cached artifacts are cleaned up after the session
+
+## Common Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| `.cs` file is inside a directory with a `.csproj` | Move the script outside the project directory, or use `dotnet run --file file.cs` |
+| `#:package` without a version | Specify a version: `#:package PackageName@1.2.3` or `@*` for latest |
+| `#:property` with wrong syntax | Use `PropertyName=Value` with no spaces around `=` and no quotes: `#:property AllowUnsafeBlocks=true` |
+| Directives placed after C# code | All `#:` directives must appear immediately after an optional shebang line (if present) and before any `using` directives or other C# statements |
+| Reflection-based JSON serialization fails | Use source-generated JSON with `JsonSerializerContext` (see [Source-generated JSON](#source-generated-json)) |
+| Unexpected build behavior or version errors | File-based apps inherit `global.json`, `Directory.Build.props`, `Directory.Build.targets`, and `nuget.config` from parent directories. Move the script to an isolated directory if the inherited settings conflict |
+
+## More info
+
+See https://learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps for a full reference on file-based apps.

--- a/src/lsptoolshost/copilot/skills/dotnet-trace-collect/SKILL.md
+++ b/src/lsptoolshost/copilot/skills/dotnet-trace-collect/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: dotnet-trace-collect
+description: Guide developers through capturing diagnostic artifacts to diagnose production .NET performance issues. Use when the user needs help choosing diagnostic tools, collecting performance data, or understanding tool trade-offs across different environments (Windows/Linux, .NET Framework/modern .NET, container/non-container).
+license: MIT
+---
+
+# .NET Trace Collect
+
+This skill helps developers diagnose production performance issues by recommending the right diagnostic tools for their environment, guiding data collection, and suggesting analysis approaches. It does not analyze code for anti-patterns or perform the analysis itself.
+
+## When to Use
+
+- A developer needs to investigate a production performance issue (high CPU, memory leak, slow requests, excessive GC, networking errors, etc.)
+- Choosing the right diagnostic tool for a specific runtime, OS, or deployment topology
+- Setting up and running diagnostic tool commands for data collection
+- Understanding trade-offs between available tools (e.g. PerfView vs dotnet-trace)
+- Collecting diagnostics from containerized or Kubernetes workloads
+
+## When Not to Use
+
+- Reviewing source code for performance anti-patterns (use a code review skill instead)
+- Benchmarking during development (e.g. BenchmarkDotNet setup)
+- Analyzing collected trace or dump files (this skill recommends tools for analysis, but does not perform it)
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| Symptom | Yes | What the developer is observing (high CPU, memory growth, slow requests, hangs, excessive GC, HTTP 5xx errors, networking timeouts, connection failures, assembly loading failures, etc.) |
+| Runtime | Yes | .NET Framework or modern .NET (and version, especially whether .NET 10+) |
+| OS | Yes | Windows or Linux |
+| Deployment | Yes | Non-container, container, or Kubernetes |
+| Admin privileges | Recommended | Whether the developer has admin/root access on the target machine |
+| Repro characteristics | Recommended | Whether the issue is easy to reproduce or requires a long time to manifest |
+
+## Workflow
+
+### Step 1: Understand the environment
+
+Determine or ask the developer to clarify:
+
+1. **Symptom**: What they are observing (high CPU, memory leak, slow requests, hangs, excessive GC, HTTP 5xx errors, networking timeouts, connection failures, assembly loading failures, etc.)
+2. **Runtime**: .NET Framework or modern .NET? If modern .NET, which version? (Especially whether .NET 10 or later.)
+3. **OS**: Windows or Linux?
+4. **Deployment**: Running directly on the host, in a container, or in Kubernetes?
+5. **Admin privileges**: Do they have admin/root access on the target machine or container?
+6. **Repro characteristics**: Does the issue reproduce quickly, or does it take a long time to manifest?
+7. **Workload context**: Determine or ask the user if you are running in the context of the workload (i.e., on the same machine or connected to the same environment where the issue is occurring). If so, you can run diagnostic commands directly on their behalf. If not, provide the commands as guidance for the user to run themselves.
+
+Use this information to select the right tool in Step 2.
+
+### Step 2: Recommend diagnostic tools
+
+Select tools based on the environment using the priority rules below. Once a tool is selected, load the corresponding reference file for detailed command-line usage.
+
+#### Tool reference lookup
+
+| Environment | Reference file(s) |
+|-------------|-------------------|
+| Windows + modern .NET + admin | `references/perfview.md` |
+| Windows + modern .NET, no admin | `references/dotnet-trace-collect.md` |
+| Windows + .NET Framework | `references/perfview.md` |
+| Linux + .NET 10+ + root | `references/dotnet-trace-collect-linux.md` |
+| Linux + pre-.NET 10 | `references/dotnet-trace-collect.md` |
+| Linux + native stacks needed | `references/perfcollect.md` |
+| Container/K8s (console access) | `references/dotnet-trace-collect.md` (or `dotnet-trace-collect-linux.md`) |
+| Container/K8s (no console) | `references/dotnet-monitor.md` |
+
+#### Quick decision matrix (first-pass triage)
+
+| Environment | Preferred tool | Fallback / Notes |
+|-------------|----------------|------------------|
+| Windows + modern .NET + admin | PerfView | If admin is unavailable, use `dotnet-trace` |
+| Windows + .NET Framework + admin | PerfView | Without admin, there is no trace fallback; for hangs/memory leaks, provide dump commands directly (`procdump -ma` or Task Manager) since `dump-collect` does not support .NET Framework |
+| Linux + .NET 10+ + root | `dotnet-trace collect-linux` | Use `dotnet-trace` if root or kernel prerequisites are not met |
+| Linux + pre-.NET 10 | `dotnet-trace` | Add `perfcollect` when native stacks are needed (requires root) |
+| Linux container/Kubernetes | Console tools if in workload context; `dotnet-monitor` if no console access | See Linux Container / Kubernetes section for details |
+
+#### Windows (non-container, modern .NET)
+
+1. **PerfView** (preferred) — produces richer ETW-based data; requires admin privileges. For **slow requests**, add `/ThreadTime` to capture thread-level wait and block detail.
+2. **`dotnet-trace`** — fallback when admin privileges are not available.
+3. For **long-running repros**: use PerfView with a `/StopOn` trigger that fires on the **symptom you want to capture** (e.g., `/StopOnPerfCounter`, `/StopOnGCEvent`, `/StopOnException`) and a circular buffer (`/CircularMB` + `/BufferSizeMB`). **Critical: the stop trigger must fire on the interesting event, not the recovery.** The circular buffer continuously overwrites old data, so if you trigger on recovery, the buffer may have already overwritten the interesting behavior by the time collection stops. Only add `/StartOn` if the start event is known to precede the stop event. For **slow requests**, do not include a stop trigger by default — let the user design one based on their specific scenario.
+
+#### Windows containers
+
+1. **PerfView** — most Windows containers (including Kubernetes on Windows) use process-isolation by default. Collect from the host with `/EnableEventsInContainers`. After collection, you have two options:
+   - **Analyze locally while the container is still running** — PerfView can reach into the live container to resolve symbols, so you can open the trace immediately on the host machine.
+   - **Analyze off-machine** — before the container shuts down, copy the `.etl.zip` into the container and run `PerfViewCollect merge /ImageIDsOnly` inside it to embed symbol information. Then copy the merged trace out. Without this merge step, symbols for binaries inside the container will be unresolvable on other machines.
+
+   For the less common Hyper-V containers, collect inside the container directly. See [references/perfview.md](references/perfview.md) for detailed commands.
+2. **`dotnet-monitor`**, **`dotnet-trace`** — inside the container if the tools are installed in the image. For dumps, invoke the **`dump-collect`** skill.
+
+#### Windows (.NET Framework)
+
+1. **PerfView** — the primary diagnostic tool for .NET Framework on Windows. Requires admin.
+2. Same trigger guidance for long repros: use `/StopOn` triggers that fire on the symptom (e.g., `/StopOnPerfCounter`, `/StopOnGCEvent`, `/StopOnException`) with `/CircularMB` + `/BufferSizeMB`.
+3. **Without admin**: PerfView requires admin, and there are no alternative trace tools for .NET Framework. Process dumps can still be captured without admin — provide dump commands directly (e.g., `procdump -ma <PID>` or Task Manager) since the `dump-collect` skill does not support .NET Framework. Dumps can help diagnose hangs and memory leaks. However, for **high CPU**, **slow requests**, and **excessive GC**, there is no way to investigate on .NET Framework without admin access. Advise the user to obtain admin privileges.
+
+#### Linux (non-container, .NET 10+)
+
+1. **`dotnet-trace collect-linux`** (preferred) — uses `perf_events` for richer traces including native call stacks and kernel events. Captures machine-wide by default (no PID required). Requires root and kernel >= 6.4.
+2. **`dotnet-trace`** — fallback when root privileges are not available or kernel requirements are not met. Managed stacks only.
+
+#### Linux (non-container, pre-.NET 10)
+
+1. **`dotnet-trace`** (preferred) — managed trace collection; no admin required.
+2. **`perfcollect`** — when **native call stacks** are needed (requires admin/root).
+
+#### Linux Container / Kubernetes
+
+**If running in the context of the workload** (i.e., you have console access to the container), prefer console-based tools. These are easier to set up than `dotnet-monitor`, which requires authentication configuration and sidecar deployment:
+
+1. **`dotnet-trace collect-linux`** (.NET 10+ with root) — produces the richest traces including native call stacks and kernel events.
+2. **`dotnet-trace`** — inside the container if the tool is installed in the image. For dumps, invoke the **`dump-collect`** skill.
+3. **`perfcollect`** — inside the container when native stacks are needed on pre-.NET 10 (requires `SYS_ADMIN` / `--privileged`).
+
+**If not running in the workload context** (no console access), or if `dotnet-monitor` is already deployed:
+
+1. **`dotnet-monitor`** — designed for containers; runs as a sidecar. No tools needed in the app container. Easiest option when console access is not available.
+
+#### Memory dumps
+
+When dumps are needed (memory leaks, hangs), **do not provide dump collection commands directly** for modern .NET — invoke the **`dump-collect`** skill instead. The `dump-collect` skill only supports modern .NET (.NET Core 3.0+). For **.NET Framework**, provide dump collection guidance directly (e.g., `procdump -ma <PID>` or Task Manager). This skill focuses on trace collection only.
+
+#### Memory leaks
+
+- **Capture two dumps** as memory is increasing (e.g., one early, one after significant growth). Invoke the **`dump-collect`** skill for dump collection — do not provide dump commands directly. Diff the dumps in PerfView to see which objects have increased — this is the most effective way to identify what is leaking.
+- **Without admin privileges**: Two process dumps can give a sense of what's growing on the heap, but may not be enough to identify the root cause. If dumps aren't sufficient, reproduce the issue in an environment where admin privileges are available to collect richer data (traces).
+- **Modern .NET on Linux (pre-.NET 10)**: Recommend two dump captures (invoke `dump-collect` skill) for heap diff, plus `dotnet-trace` while memory is growing (for allocation tracking). No trigger needed — capture during the growth period. Both together give the best picture.
+- **Modern .NET 10+ on Linux with admin**: Recommend two dump captures (invoke `dump-collect` skill) for heap diff, plus `dotnet-trace collect-linux` while memory is growing (richer data including native stacks). No trigger needed.
+- **.NET Framework**: Recommend two dumps plus a PerfView trace while memory is growing to see what is being allocated. The `dump-collect` skill does not support .NET Framework, so provide dump commands directly (e.g., `procdump -ma <PID>` or right-click → Create Dump File in Task Manager). No trigger is needed — just capture the trace during the growth period. Do not wait for an `OutOfMemoryException`.
+
+#### Excessive GC
+
+Excessive GC requires a **trace** to analyze GC events, pause times, and allocation patterns — a dump is not sufficient.
+
+- **Windows (PerfView)**: Use `PerfView collect /GCCollectOnly` to capture GC events.
+- **Linux (dotnet-trace)**: Use `dotnet-trace collect -p <PID> --profile gc-verbose`.
+- **Linux .NET 10+ with root**: Use `dotnet-trace collect-linux --profile gc-verbose` for richer data with native stacks.
+- **Containers**: `dotnet-monitor` can capture GC traces via its REST API (`/trace?profile=gc-verbose`).
+
+#### Slow Requests
+
+Slow requests require a **thread time trace** to see where threads are spending time — waiting on locks, I/O, external calls, etc. Use larger buffers since thread time traces generate more data. For ASP.NET Core applications, also enable `Microsoft.AspNetCore.Hosting` and `Microsoft-AspNetCore-Server-Kestrel` providers to get server-side request lifecycle timing (when requests arrive, how long they take to process).
+
+- **Windows (PerfView)**: Use `PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048`. The `/ThreadTime` argument adds thread-level wait and block detail. For ASP.NET Core, add Kestrel providers: `PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048 /Providers:*Microsoft.AspNetCore.Hosting,*Microsoft-AspNetCore-Server-Kestrel`. Do not include a stop trigger by default — let the user design one based on their specific scenario.
+- **Linux (dotnet-trace)**: `dotnet-trace` captures thread time data by default — no special arguments needed. Use `dotnet-trace collect -p <PID>`. For ASP.NET Core, add Kestrel providers: `dotnet-trace collect -p <PID> --providers Microsoft.AspNetCore.Hosting,Microsoft-AspNetCore-Server-Kestrel`.
+- **Linux .NET 10+ with root**: Use `dotnet-trace collect-linux --profile thread-time` for richer data with native stacks. For ASP.NET Core, add: `--providers Microsoft.AspNetCore.Hosting,Microsoft-AspNetCore-Server-Kestrel`.
+- **Containers**: `dotnet-monitor` can capture traces via its REST API (`/trace?pid=<PID>&durationSeconds=30`).
+
+#### Hangs
+
+1. **Start with a trace** to understand what threads are doing. Use the appropriate trace tool for the environment (PerfView with `/ThreadTime` on Windows, `dotnet-trace` on Linux, `dotnet-trace collect-linux --profile thread-time` on .NET 10+ Linux with root). The trace can reveal:
+   - **Livelocks** (threads spinning without forward progress) — threads appear busy but the application makes no progress.
+   - **Thread starvation** — the ThreadPool is exhausted and queued work items are not being processed. This can look like a deadlock but has a different root cause.
+   - **Whether there is any forward progress at all** — if some threads are making progress, the issue may be a bottleneck rather than a true hang.
+2. **If the trace does not explain the hang**, the issue may be a **true deadlock** (threads waiting on each other in a cycle). In this case, invoke the **`dump-collect`** skill to collect a process dump — do not provide dump commands directly.
+3. **Analyze the dump with a debugger** to inspect thread stacks and identify the lock cycle:
+   - **Windows**: Visual Studio or WinDbg with the SOS debugger extension.
+   - **Linux**: `lldb` with the SOS debugger extension.
+
+#### Networking Issues
+
+Networking issues (HTTP 5xx errors from downstream services, request timeouts, connection failures, DNS resolution failures, TLS handshake failures, connection pool exhaustion) require **both** a thread-time trace and networking event providers. The thread-time trace shows where threads are blocked (slow downstream calls, thread starvation), while the networking events show the request lifecycle — which requests failed, what status codes came back, how long DNS resolution and TLS handshakes took, and how long requests waited for a connection from the pool.
+
+For **.NET Framework**, `PerfView /ThreadTime` already collects the relevant networking events (from the `System.Net` ETW provider) — no additional providers are needed.
+
+For **modern .NET**, you must explicitly enable the `System.Net.*` EventSource providers:
+
+| Provider | What it covers |
+|----------|---------------|
+| `System.Net.Http` | HttpClient/SocketsHttpHandler — request lifecycle, HTTP status codes, connection pool |
+| `System.Net.NameResolution` | DNS lookups (start/stop, duration) |
+| `System.Net.Security` | TLS/SSL handshakes (SslStream) |
+| `System.Net.Sockets` | Low-level socket connect/disconnect |
+
+Key events from `System.Net.Http`: `RequestStart` (scheme, host, port, path), `RequestStop` (statusCode — `-1` if no response was received), `RequestFailed` (exception message for timeouts, connection refused, etc.), `RequestLeftQueue` (time waiting for a connection from the pool — indicates connection pool exhaustion), `ConnectionEstablished`, `ConnectionClosed`.
+
+Collect a thread-time trace with networking providers enabled (modern .NET only — .NET Framework needs only `PerfView /ThreadTime`):
+
+- **Windows (PerfView)**: Use `PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048 /Providers:*System.Net.Http,*System.Net.NameResolution,*System.Net.Security,*System.Net.Sockets`. For .NET Framework, omit the `/Providers` flag — `/ThreadTime` already includes the networking events. The thread-time trace shows where threads are blocked while the networking events show what requests are failing and why.
+- **Linux (dotnet-trace)**: `dotnet-trace` captures thread time data by default, but specifying `--providers` overrides the defaults so you must also include `--profile`: `dotnet-trace collect -p <PID> --profile dotnet-common,dotnet-sampled-thread-time --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets`.
+- **Linux .NET 10+ with root**: Use `dotnet-trace collect-linux --profile dotnet-common,cpu-sampling,thread-time --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets`.
+- **Containers**: `dotnet-monitor` can capture traces with custom providers via its REST API.
+
+#### Assembly Loading Issues
+
+For modern .NET, assembly loading issues (`FileNotFoundException`, `FileLoadException`, `ReflectionTypeLoadException`, version conflicts, duplicate assembly loads across AssemblyLoadContexts) require collecting **assembly loader binder events** from the `Microsoft-Windows-DotNETRuntime` provider with the Loader keyword (`0x4`). These events trace every step of the runtime's assembly resolution algorithm — which paths were probed, which AssemblyLoadContext handled the load, whether the load succeeded or failed, and why. For .NET Framework, the same provider and keyword work for ETW-based collection; additionally, the Fusion Log Viewer (`fuslogvw.exe`) can diagnose assembly binding failures without requiring a trace.
+
+The provider specification is `Microsoft-Windows-DotNETRuntime:0x4:4` (provider name, AssemblyLoader keyword, Informational verbosity).
+
+- **Windows (PerfView)**: A default PerfView trace already includes binder events - simply run `PerfView collect` with no extra providers. For a smaller trace file, use `PerfView collect /ClrEvents:Default-Profile`, which removes the most verbose default events while keeping the events necessary for diagnosing assembly loading issues.
+- **Linux / cross-platform (dotnet-trace)**: Use `dotnet-trace collect --clrevents assemblyloader -- <path-to-built-exe>` to launch and trace the process, or `dotnet-trace collect --clrevents assemblyloader -p <PID>` to attach to a running process.
+- **Linux .NET 10+ with root**: Use `dotnet-trace collect-linux --clrevents assemblyloader`.
+- **Containers**: `dotnet-monitor` can capture traces with the loader provider via its REST API.
+
+For short-lived processes that fail on startup (common with assembly loading issues), prefer the `dotnet-trace` launch form (`-- <path-to-built-exe>`) over attaching by PID, since the process may exit before you can attach.
+
+Explain the trade-offs when recommending a tool. For example:
+- PerfView gives richer data but needs admin; runs on Windows including Windows containers.
+- `dotnet-trace` works cross-platform without admin but captures less system-level detail.
+- `perfcollect` captures native call stacks but needs admin/root.
+- `dotnet-monitor` is the best option for containers/K8s when console access is not available, but requires sidecar deployment and authentication configuration.
+
+### Step 3: Guide data collection
+
+Provide the specific commands for the recommended tool. Load the appropriate reference file from the [tool reference lookup](#tool-reference-lookup) table for detailed command-line examples.
+
+Key guidance to include:
+
+1. **Installation**: How to install the tool if it is not already available (e.g. `dotnet tool install -g dotnet-trace`). **When recommending multiple tools, provide installation and usage instructions for each one** — do not mention a tool without showing how to install and use it.
+2. **PID discovery (required before any `-p <PID>` command)**: Verify the target process first (for example: `dotnet-trace ps`, `curl <monitor-endpoint>/processes`, or `ps` inside a container). If the app is expected to be PID 1 in a container, still verify before collecting.
+3. **Collection command**: The exact command to run, including relevant providers, output format, and duration.
+4. **Container considerations**:
+   - Collecting from **inside** the container: ensure the tool is installed in the image or use `kubectl cp` to copy it in.
+   - Collecting from **outside** the container: use `dotnet-monitor` as a sidecar with a shared diagnostic port (Unix domain socket in `/tmp`).
+   - Kubernetes: `dotnet-monitor` as a sidecar container, or `kubectl debug` for ephemeral debug containers.
+5. **Long-running repros** (Windows/PerfView): show how to use trigger arguments and circular buffer settings.
+6. **Output location**: Where the collected file will be saved and how to copy it off the target for analysis.
+7. **Artifact handoff checklist**: Include runtime version, OS/kernel, container image tag or build SHA, PID/process name, UTC collection start/end timestamps, exact command used, and final artifact path when handing traces to someone else for analysis.
+
+### Step 4: Recommend analysis approach
+
+After data is collected, recommend the appropriate tool for analysis. Do **not** perform the analysis — just point the developer to the right tool and documentation.
+
+| Collected Data | Analysis Tool | Notes |
+|----------------|---------------|-------|
+| `.nettrace` file | PerfView (Windows), Speedscope (web) | PerfView gives the richest view on Windows |
+| `.etl` / `.etl.zip` file | PerfView | ETW traces from PerfView or perfcollect |
+| `perf.data.nl` from perfcollect | PerfView (Windows) | Copy the file to a Windows machine and open with PerfView |
+
+## Validation
+
+- [ ] The recommended tool is compatible with the developer's runtime, OS, and deployment topology
+- [ ] The collection command runs without errors
+- [ ] The output file is generated in the expected location
+- [ ] The developer knows which analysis tool to use for the collected data
+
+## Common Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| Using `dotnet-trace` on .NET Framework | `dotnet-trace` only works with modern .NET (.NET Core 3.0+). Use PerfView for .NET Framework. |
+| PerfView without admin privileges | PerfView requires admin for ETW tracing. Fall back to `dotnet-trace` if admin is not available. |
+| `perfcollect` in container without `SYS_ADMIN` | Containers drop `SYS_ADMIN` by default. Run with `--privileged` or add `SYS_ADMIN` capability, or fall back to `dotnet-trace`. |
+| Huge trace files from long repros | On Windows, use PerfView `/StopOn` triggers that fire on the symptom you want to capture (e.g., `/StopOnPerfCounter`, `/StopOnGCEvent`, `/StopOnException`) with `/CircularMB` and `/BufferSizeMB`. **Never trigger on recovery** — the circular buffer continuously overwrites old data, so the interesting behavior may be lost by the time collection stops. |
+| Diagnostic port not accessible in container | Mount `/tmp` as a shared volume between the app container and `dotnet-monitor` sidecar for the diagnostic Unix domain socket. |
+| Forgetting to install tools in container image | Add `dotnet tool install` to your Dockerfile, or use `dotnet-monitor` as a sidecar to avoid modifying the app image. |
+| Exposing `dotnet-monitor` with `--no-auth` in production | Keep auth enabled, bind to localhost, and use `kubectl port-forward` for access. Use `--no-auth` only for short-lived isolated debugging. |
+| Collecting only CPU/thread-time trace for networking issues | CPU and thread-time traces alone do not show HTTP status codes, DNS timing, or connection pool behavior. Add the networking providers (`System.Net.Http`, `System.Net.NameResolution`, `System.Net.Security`, `System.Net.Sockets`) alongside the thread-time trace. |
+| Enabling all networking providers when only one is needed | Each networking provider adds overhead. If the issue is clearly HTTP-level (5xx status codes), `System.Net.Http` alone may be sufficient. Add DNS, TLS, and socket providers when the root cause is unclear. |

--- a/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/dotnet-monitor.md
+++ b/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/dotnet-monitor.md
@@ -1,0 +1,96 @@
+# dotnet-monitor
+
+**Purpose**: REST API-based diagnostics collection, designed for container and Kubernetes environments.
+
+| Attribute | Value |
+|-----------|-------|
+| OS | Windows, Linux, macOS |
+| Runtime | Modern .NET (.NET Core 3.1+) |
+| .NET Framework | ❌ Not supported |
+| Admin required | No |
+| Container | ✅ Designed for containers/K8s — runs as a sidecar |
+
+## Installation
+
+```bash
+# As a global tool
+dotnet tool install -g dotnet-monitor
+
+# As a container image (for K8s sidecar)
+# mcr.microsoft.com/dotnet/monitor
+```
+
+## Common Commands
+
+```bash
+# Production-safe default: keep auth enabled (default) and bind to loopback
+dotnet-monitor collect --urls http://127.0.0.1:52323 --metricUrls http://127.0.0.1:52325
+
+# Dev-only shortcut in isolated environments (avoid in production)
+dotnet-monitor collect --urls http://127.0.0.1:52323 --no-auth
+```
+
+## Security Guidance (Production)
+
+- Do **not** run `dotnet-monitor` with `--no-auth` on production workloads.
+- Bind to localhost (`127.0.0.1`) and access through `kubectl port-forward` (or another local-only tunnel).
+- If remote access is required, keep auth enabled and restrict network exposure to trusted operators.
+
+## REST API Endpoints
+
+```bash
+# Access via local tunnel (recommended in Kubernetes)
+kubectl port-forward pod/<pod-name> 52323:52323
+
+# List processes (auth enabled by default)
+curl -H "Authorization: Bearer <monitor-token>" http://localhost:52323/processes
+
+# Collect a trace
+curl -H "Authorization: Bearer <monitor-token>" -o trace.nettrace http://localhost:52323/trace?pid=<PID>&durationSeconds=30
+
+# Collect GC trace
+curl -H "Authorization: Bearer <monitor-token>" -o trace.nettrace "http://localhost:52323/trace?pid=<PID>&profile=gc-verbose&durationSeconds=30"
+
+# Collect trace with networking providers (HTTP status codes, DNS, TLS, sockets)
+curl -H "Authorization: Bearer <monitor-token>" -o trace.nettrace "http://localhost:52323/trace?pid=<PID>&durationSeconds=30&providers=System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets"
+
+# Get live metrics
+curl -H "Authorization: Bearer <monitor-token>" http://localhost:52323/livemetrics?pid=<PID>
+```
+
+## Kubernetes Sidecar Setup
+
+```yaml
+# Pod spec with dotnet-monitor as sidecar
+spec:
+  containers:
+  - name: app
+    image: myapp:latest
+    volumeMounts:
+    - name: diag
+      mountPath: /tmp
+  - name: monitor
+    image: mcr.microsoft.com/dotnet/monitor:latest
+    args: ["collect", "--urls", "http://127.0.0.1:52323", "--metricUrls", "http://127.0.0.1:52325"]
+    volumeMounts:
+    - name: diag
+      mountPath: /tmp
+    ports:
+    - containerPort: 52323
+  volumes:
+  - name: diag
+    emptyDir: {}
+```
+
+The shared `/tmp` volume allows `dotnet-monitor` to access the app's diagnostic Unix domain socket.
+Keep auth enabled (default), and access the API via `kubectl port-forward` rather than exposing a public Service unless you have explicit authentication and network controls in place.
+
+## Trade-offs
+
+- ✅ Purpose-built for containers and Kubernetes
+- ✅ No tools needed inside the app container
+- ✅ REST API is easy to automate and integrate
+- ❌ Requires sidecar setup and shared volume
+- ❌ Additional resource overhead from sidecar container
+- ❌ Requires authentication setup (API key or `--no-auth` flag)
+- ⚠️ **When running in the workload context** (console access to the container), prefer console-based tools (`dotnet-trace`, `dotnet-trace collect-linux`) to avoid authentication setup. Use `dotnet-monitor` when console access is not available or when it is already deployed.

--- a/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/dotnet-trace-collect-linux.md
+++ b/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/dotnet-trace-collect-linux.md
@@ -1,0 +1,84 @@
+# dotnet-trace collect-linux (.NET 10+)
+
+**Purpose**: Collects diagnostic traces using `perf_events`, a Linux OS technology. Provides native call stacks, kernel events, and machine-wide tracing that standard `dotnet-trace collect` cannot.
+
+| Attribute | Value |
+|-----------|-------|
+| OS | Linux only (kernel >= 6.4 with `CONFIG_USER_EVENTS=y`) |
+| Runtime | .NET 10+ only |
+| .NET Framework | ❌ Not supported |
+| Admin required | Yes (root) |
+| Container | Works inside container (requires root) |
+| glibc | >= 2.35 (not supported on Alpine 3.22, CentOS Stream 9, or RHEL 9-based distros) |
+
+## Key Differences from `dotnet-trace collect`
+
+| Feature | `collect` | `collect-linux` |
+|---------|-----------|-----------------|
+| Trace all processes simultaneously | No | Yes (default — no PID required) |
+| Capture native library and kernel events | No | Yes |
+| Event callstacks include native frames | No | Yes |
+| Requires admin/root | No | Yes |
+
+## Usage
+
+```bash
+# Machine-wide trace (all processes, no PID needed)
+sudo dotnet-trace collect-linux
+
+# Trace a specific process
+sudo dotnet-trace collect-linux -p <PID>
+
+# Trace a process by name
+sudo dotnet-trace collect-linux -n <process-name>
+
+# Trace for a specific duration
+sudo dotnet-trace collect-linux --duration 00:00:30
+
+# Trace with specific providers
+sudo dotnet-trace collect-linux --providers Microsoft-Windows-DotNETRuntime
+
+# Trace with networking providers (HTTP status codes, DNS, TLS, sockets)
+sudo dotnet-trace collect-linux --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets
+
+# Trace with networking providers and thread-time profile
+sudo dotnet-trace collect-linux --profile thread-time --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets
+
+# Trace with specific profiles
+sudo dotnet-trace collect-linux --profile gc-verbose
+sudo dotnet-trace collect-linux --profile thread-time
+
+# Trace with additional Linux perf events
+sudo dotnet-trace collect-linux --perf-events <list-of-perf-events>
+
+# Output to a specific file
+sudo dotnet-trace collect-linux -o /tmp/trace.nettrace
+```
+
+When `--providers`, `--profile`, `--clrevents`, and `--perf-events` are not specified, `collect-linux` enables these profiles by default: `dotnet-common` (lightweight .NET runtime diagnostics) and `cpu-sampling` (kernel CPU sampling).
+
+## Container Usage
+
+```bash
+# Inside container (machine-wide — captures all processes in the container)
+sudo dotnet-trace collect-linux -o /tmp/trace.nettrace
+
+# Inside container (specific process)
+sudo dotnet-trace collect-linux -p 1 -o /tmp/trace.nettrace
+
+# Copy trace out
+kubectl cp <pod>:/tmp/trace.nettrace ./trace.nettrace
+```
+
+## Trade-offs
+
+- ✅ Machine-wide tracing without specifying a PID
+- ✅ Native (unmanaged) call stacks — essential for diagnosing native interop or runtime issues
+- ✅ Captures kernel events and native library events
+- ✅ Designed for Linux-first workflows
+- ❌ Requires root privileges
+- ❌ Only available on .NET 10 and later
+- ❌ Linux only (kernel >= 6.4)
+- ❌ Requires glibc >= 2.35 (not all supported Linux distros qualify)
+- ❌ Native code symbols must be present on disk next to the binary (or in a standard location) during trace capture for symbol resolution
+- ❌ Unable to trace cross-namespace processes

--- a/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/dotnet-trace-collect.md
+++ b/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/dotnet-trace-collect.md
@@ -1,0 +1,86 @@
+# dotnet-trace collect
+
+**Purpose**: Collect EventPipe traces for CPU profiling, event analysis, and runtime diagnostics.
+
+| Attribute | Value |
+|-----------|-------|
+| OS | Windows, Linux, macOS |
+| Runtime | Modern .NET (.NET Core 3.0+) |
+| .NET Framework | ❌ Not supported |
+| Admin required | No |
+| Container | Works inside container; use `--diagnostic-port` for sidecar |
+
+## Installation
+
+```bash
+# As a .NET global tool (requires .NET SDK)
+dotnet tool install -g dotnet-trace
+
+# Direct download via aka.ms (no SDK required — useful in containers)
+# Linux x64
+curl -JL https://aka.ms/dotnet-trace/linux-x64 -o dotnet-trace
+chmod +x dotnet-trace
+
+# Linux Arm64
+curl -JL https://aka.ms/dotnet-trace/linux-arm64 -o dotnet-trace
+chmod +x dotnet-trace
+
+# Linux musl x64 (Alpine)
+curl -JL https://aka.ms/dotnet-trace/linux-musl-x64 -o dotnet-trace
+chmod +x dotnet-trace
+
+# Windows x64
+curl -JL https://aka.ms/dotnet-trace/win-x64 -o dotnet-trace.exe
+```
+
+## Common Commands
+
+```bash
+# List running .NET processes
+dotnet-trace ps
+
+# Collect a trace with the default profiles (dotnet-common and dotnet-sampled-thread-time)
+dotnet-trace collect -p <PID>
+
+# Collect with a specific profile
+dotnet-trace collect -p <PID> --profile dotnet-sampled-thread-time
+dotnet-trace collect -p <PID> --profile gc-verbose
+
+# Collect with specific providers
+dotnet-trace collect -p <PID> --providers Microsoft-DotNETCore-SampleProfiler,Microsoft-Windows-DotNETRuntime
+
+# Collect with networking providers (HTTP status codes, DNS, TLS, sockets)
+dotnet-trace collect -p <PID> --providers System.Net.Http,System.Net.NameResolution,System.Net.Security,System.Net.Sockets
+
+# Collect for a fixed duration (time span in hh:mm:ss format)
+dotnet-trace collect -p <PID> --duration 00:00:30
+
+# Output in Speedscope format for web-based viewing
+dotnet-trace collect -p <PID> --format speedscope
+```
+
+## Output Formats
+
+| Format | Extension | Analysis Tool |
+|--------|-----------|---------------|
+| `nettrace` (default) | `.nettrace` | PerfView, Visual Studio, `dotnet-trace report` |
+| `speedscope` | `.speedscope.json` | Speedscope |
+| `chromium` | `.chromium.json` | Chrome DevTools (chrome://tracing) |
+
+## Container Usage
+
+```bash
+# Inside container (process is typically PID 1)
+dotnet-trace collect -p 1 -o /tmp/trace.nettrace
+
+# Copy trace out of container
+kubectl cp <pod>:/tmp/trace.nettrace ./trace.nettrace
+# or
+docker cp <container>:/tmp/trace.nettrace ./trace.nettrace
+```
+
+## Trade-offs
+
+- ✅ Cross-platform, no admin needed, lightweight
+- ❌ No native (unmanaged) call stacks — only managed frames
+- ❌ Less system-level detail than ETW (PerfView) or perf (perfcollect)

--- a/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/perfcollect.md
+++ b/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/perfcollect.md
@@ -1,0 +1,177 @@
+# perfcollect
+
+**Purpose**: Wrapper script for `perf` and `LTTng` on Linux. Collects CPU profiles with native call stacks.
+
+| Attribute | Value |
+|-----------|-------|
+| OS | Linux only |
+| Runtime | Modern .NET (.NET Core 2.0+) |
+| .NET Framework | ❌ Not supported |
+| Admin required | Yes (root) |
+| Container | Needs `SYS_ADMIN` / `--privileged` |
+
+## Installation
+
+```bash
+# Download the script
+curl -OL https://aka.ms/perfcollect
+chmod +x perfcollect
+
+# Install prerequisites (perf, LTTng)
+sudo ./perfcollect install
+```
+
+## Common Commands
+
+```bash
+# Collect a trace (runs until Ctrl+C)
+sudo ./perfcollect collect mytrace
+
+# Collect for a specific duration
+sudo timeout 30 ./perfcollect collect mytrace
+```
+
+## Container Usage
+
+```bash
+# Docker — run with privileged mode
+docker run --privileged ...
+```
+
+## Kubernetes Usage
+
+In Kubernetes, use a **diagnostics sidecar container** to avoid modifying your application image. The sidecar runs alongside your app, shares its process namespace and `/tmp` directory, and contains the diagnostic tools.
+
+### Step 1: Add a privileged diagnostics sidecar
+
+Add a diagnostics container to your deployment and mark it as privileged:
+
+```yaml
+      - name: diagnostics-container
+        image: ubuntu
+        command: ["/bin/sh", "-c", "sleep infinity"]
+        securityContext:
+          privileged: true
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: shared-tmp
+          mountPath: /tmp
+```
+
+### Step 2: Enable shared process namespace
+
+Set `shareProcessNamespace: true` in the pod spec so the sidecar can see and profile the app's processes:
+
+```yaml
+    spec:
+      shareProcessNamespace: true
+```
+
+### Step 3: Share /tmp between containers
+
+Create an `emptyDir` volume mounted at `/tmp` in both the app and sidecar containers. This is needed for perf map files (`perf-$pid.map`), perfcollect logs, and other profiling artifacts:
+
+```yaml
+      volumes:
+      - name: shared-tmp
+        emptyDir: {}
+```
+
+Mount it in both containers:
+
+```yaml
+        volumeMounts:
+        - name: shared-tmp
+          mountPath: /tmp
+```
+
+### Step 4: Set environment variables in the app container
+
+Enable perf map generation and LTTng event logging in the application container:
+
+```yaml
+        env:
+        - name: COMPlus_PerfMapEnabled
+          value: "1"
+        - name: COMPlus_EnableEventLog
+          value: "1"
+```
+
+### Step 5: Collect the trace
+
+Connect to the cluster node, exec into the diagnostics sidecar, install perfcollect, and capture:
+
+```bash
+# Exec into the diagnostics sidecar
+kubectl exec -it <pod-name> -c diagnostics-container -- /bin/bash
+
+# Inside the sidecar: install perfcollect
+curl -OL https://aka.ms/perfcollect
+chmod +x perfcollect
+./perfcollect install
+
+# Capture a trace
+./perfcollect collect mytrace
+```
+
+This produces `mytrace.trace.zip`, which can be copied out and analyzed.
+
+### End-to-end Kubernetes deployment example
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sample
+  template:
+    metadata:
+      labels:
+        app: sample
+    spec:
+      shareProcessNamespace: true
+      volumes:
+      - name: shared-tmp
+        emptyDir: {}
+      containers:
+      - name: sample-app
+        image: myapp:latest
+        ports:
+        - containerPort: 80
+        env:
+        - name: COMPlus_PerfMapEnabled
+          value: "1"
+        - name: COMPlus_EnableEventLog
+          value: "1"
+        volumeMounts:
+        - name: shared-tmp
+          mountPath: /tmp
+      - name: diagnostics-container
+        image: ubuntu
+        command: ["/bin/sh", "-c", "sleep infinity"]
+        securityContext:
+          privileged: true
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        - name: shared-tmp
+          mountPath: /tmp
+```
+
+## Analyzing perfcollect Output
+
+The output is a `*.trace.zip` file containing `perf.data.nl`. To analyze:
+
+1. Copy the `.trace.zip` to a Windows machine
+2. Open with PerfView — it can read perfcollect output and display flame graphs
+
+## Trade-offs
+
+- ✅ Captures native (unmanaged) call stacks — essential for diagnosing native interop or runtime issues
+- ✅ Uses kernel-level `perf` for accurate CPU profiling
+- ❌ Requires root/admin privileges
+- ❌ Linux only
+- ❌ In containers, requires `SYS_ADMIN` or `--privileged`

--- a/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/perfview.md
+++ b/src/lsptoolshost/copilot/skills/dotnet-trace-collect/references/perfview.md
@@ -1,0 +1,131 @@
+# PerfView
+
+**Purpose**: ETW-based tracing on Windows. The richest diagnostic tool for .NET on Windows.
+
+| Attribute | Value |
+|-----------|-------|
+| OS | Windows only |
+| Runtime | .NET Framework ✅, Modern .NET ✅ |
+| Admin required | Yes |
+| Container | ✅ Windows containers (Hyper-V and process-isolation) |
+
+## Installation
+
+Download from [https://github.com/microsoft/perfview/releases](https://github.com/microsoft/perfview/releases). PerfView is a standalone `.exe` — no installation required.
+
+## Common Commands
+
+Always include `/BufferSizeMB:1024 /CircularMB:2048` for short traces to ensure adequate buffer space.
+
+```powershell
+# Collect a CPU trace (default providers)
+PerfView collect /BufferSizeMB:1024 /CircularMB:2048
+
+# Collect for slow request / latency investigation (ThreadTime adds thread-level wait/block detail)
+PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048
+
+# Collect with GC and allocation events
+PerfView collect /GCCollectOnly /BufferSizeMB:1024 /CircularMB:2048
+
+# Collect with specific providers
+PerfView collect /Providers:Microsoft-Windows-DotNETRuntime /BufferSizeMB:1024 /CircularMB:2048
+
+# Collect with networking providers (HTTP status codes, DNS, TLS, sockets)
+PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048 /Providers:*System.Net.Http,*System.Net.NameResolution,*System.Net.Security,*System.Net.Sockets
+
+# Collect with Kestrel/ASP.NET providers for slow inbound requests
+PerfView /ThreadTime collect /BufferSizeMB:1024 /CircularMB:2048 /Providers:*Microsoft.AspNetCore.Hosting,*Microsoft-AspNetCore-Server-Kestrel
+
+# Collect for a specific duration (seconds)
+PerfView collect /MaxCollectSec:30 /BufferSizeMB:1024 /CircularMB:2048
+
+# Collect from command line without GUI
+PerfView /nogui collect /MaxCollectSec:30 /BufferSizeMB:1024 /CircularMB:2048
+```
+
+## Trigger Arguments for Long-Running Repros
+
+When the issue takes a long time to reproduce, use trigger arguments with a circular buffer to capture the issue without generating huge trace files.
+
+**Important**: The `/StopOn` trigger should fire on the **symptom you want to capture** — not on the recovery. PerfView uses a circular buffer (`/CircularMB`) that continuously overwrites old data, so the most recent data before the stop trigger fires is what gets preserved. When a `/StopOn` trigger fires, PerfView checks the condition a few times over several seconds before actually stopping, so the trigger event and surrounding context are reliably captured.
+
+Use `/StartOn` only when you know the start event happens **before** the stop event (e.g., to avoid recording idle time before the issue begins). If in doubt, omit `/StartOn` and just use `/StopOn` with a circular buffer.
+
+**Note**: For **slow requests**, do not include a stop trigger by default — the right trigger depends on the specific scenario. Provide the collection command without a trigger and let the user design one based on what they're seeing.
+
+```powershell
+# Stop when CPU spikes — captures the high-CPU window
+PerfView collect /StopOnPerfCounter:"Processor:% Processor Time:_Total>80" /BufferSizeMB:2048 /CircularMB:4096
+
+# Stop on a GC event (e.g. Gen2 collection)
+PerfView collect /StopOnGCEvent /BufferSizeMB:2048 /CircularMB:4096
+
+# Stop when a specific exception is thrown (not recommended for memory leaks — capture during growth instead)
+PerfView collect /StopOnException:"System.OutOfMemoryException" /BufferSizeMB:2048 /CircularMB:4096
+
+# StartOn + StopOn — only when the start event is known to precede the stop event
+# Here: start recording when CPU goes above 50%, stop when the spike hits 90%
+PerfView collect /StartOnPerfCounter:"Processor:% Processor Time:_Total>50" /StopOnPerfCounter:"Processor:% Processor Time:_Total>90" /BufferSizeMB:2048 /CircularMB:4096
+```
+
+Key trigger parameters:
+
+| Parameter | Description |
+|-----------|-------------|
+| `/StopOnPerfCounter:"Category:Counter:Instance>Threshold"` | Stop when a performance counter crosses a threshold. **Use this on the symptom you want to capture.** |
+| `/StartOnPerfCounter:"Category:Counter:Instance>Threshold"` | Start collection when a counter crosses a threshold. Only use when you know this fires before the stop trigger. |
+| `/StopOnGCEvent` | Stop when a GC event occurs |
+| `/StopOnException:"ExceptionType"` | Stop when a specific exception is thrown |
+| `/BufferSizeMB:N` | In-memory buffer size (increase for long collections) |
+| `/CircularMB:N` | Circular log size on disk (keeps only the last N MB of data) |
+
+## Windows Container Usage
+
+PerfView works with both types of Windows containers. Most Windows containers (including Kubernetes on Windows) use **process-isolation** by default.
+
+> **PerfView inside containers**: `PerfView.exe` does not run in many slimmed-down Windows container images. To run PerfView inside a container (needed for the merge step in process-isolation, or for direct collection in Hyper-V), build **PerfViewCollect** from [https://github.com/microsoft/perfview](https://github.com/microsoft/perfview) as a self-contained publish, then copy the output binaries into the container.
+
+### Process-isolation containers (default)
+
+Process-isolation containers share the host kernel. Collect from **outside** the container (on the host) using `/EnableEventsInContainers`:
+
+```powershell
+# On the host — captures all processes including those inside containers
+PerfView collect /EnableEventsInContainers /MaxCollectSec:30 /BufferSizeMB:1024 /CircularMB:2048
+```
+
+The resulting trace can be analyzed immediately on the host while the container is still running — PerfView can reach into the container to fetch binaries for symbol resolution.
+
+**To analyze on another machine**, you must complete a merge step inside the container **before the container shuts down**. Without this, binaries inside the container won't have their symbol lookup information saved in the trace:
+
+```powershell
+# 1. Copy the .etl.zip into the container
+docker cp trace.etl.zip <container>:C:\trace.etl.zip
+
+# 2. Inside the container — complete the merge to embed symbol info
+PerfViewCollect merge /ImageIDsOnly C:\trace.etl.zip
+
+# 3. Copy the merged trace back out
+docker cp <container>:C:\trace.etl.zip ./trace-merged.etl.zip
+```
+
+The merged trace can now be analyzed on any machine with full symbol resolution. If you skip the in-container merge step, symbols for binaries that live only inside the container will be unresolvable on other machines because the Windows merge component cannot reach into the container's filesystem.
+
+### Hyper-V containers
+
+Hyper-V containers are less common and are effectively lightweight VMs. Collect traces from **inside** the container the same way you would on a regular machine:
+
+```powershell
+# Inside the Hyper-V container
+PerfView collect /MaxCollectSec:30 /BufferSizeMB:1024 /CircularMB:2048
+```
+
+## Trade-offs
+
+- ✅ Richest diagnostic data available on Windows (ETW kernel + CLR providers)
+- ✅ Works with both .NET Framework and modern .NET
+- ✅ Powerful trigger system for capturing hard-to-reproduce issues
+- ✅ Works with Windows containers (Hyper-V and process-isolation)
+- ❌ Windows only
+- ❌ Requires admin privileges
+- ⚠️ **For .NET Framework without admin**: PerfView is the only trace tool for .NET Framework, and it requires admin. Without admin, there is **no way to investigate high CPU, slow requests, or excessive GC** on .NET Framework. Dumps can help with hangs and memory leaks (delegate to the `dump-collect` skill), but trace-based investigation requires admin access.

--- a/src/lsptoolshost/copilot/skills/dump-collect/SKILL.md
+++ b/src/lsptoolshost/copilot/skills/dump-collect/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: dump-collect
+description: "Configure and collect crash dumps for modern .NET applications. USE FOR: enabling automatic crash dumps for CoreCLR or NativeAOT, capturing dumps from running .NET processes, setting up dump collection in Docker or Kubernetes, using dotnet-dump collect or createdump. DO NOT USE FOR: analyzing or debugging dumps, post-mortem investigation with lldb/windbg/dotnet-dump analyze, profiling or tracing, or for .NET Framework processes."
+license: MIT
+---
+
+# .NET Crash Dump Collection
+
+This skill configures and collects crash dumps for modern .NET applications (CoreCLR and NativeAOT) on Linux, macOS, and Windows — including containers.
+
+## Stop Signals
+
+🚨 **Read before starting any workflow.**
+
+- **Stop after dumps are enabled or collected.** Do not open, analyze, or triage dump files.
+- **If the user already has a dump file**, this skill does not cover analysis. Let them know analysis is out of scope.
+- **Do not install analysis tools** (dotnet-dump analyze, windbg). Only install collection tools (dotnet-dump collect). Using `lldb` for on-demand dump capture on macOS is allowed — it ships with Xcode command-line tools and is not being used for analysis.
+- **Do not trace root cause** of crashes. Report the dump file location and move on.
+- **Do not modify application code.** Configuration is environment-only (env vars, OS settings, container specs).
+
+## Step 1 — Identify the Scenario
+
+Ask or determine:
+
+1. **Goal**: Enable automatic crash dumps, or capture a dump from a running process right now?
+2. **Platform**: Linux, macOS, or Windows? Running in a container (Docker/Kubernetes)?
+3. **Runtime**: CoreCLR or NativeAOT?
+
+### Detecting CoreCLR vs NativeAOT
+
+**From a binary file (Linux/macOS):**
+```bash
+# CoreCLR — has IL metadata / managed entry point
+strings <binary> | grep -q "CorExeMain" && echo "CoreCLR"
+
+# NativeAOT — has Redhawk runtime symbols
+strings <binary> | grep -q "Rhp" && echo "NativeAOT"
+
+# On macOS/Linux, also try:
+nm <binary> 2>/dev/null | grep -qi "Rhp" && echo "NativeAOT"
+```
+
+**From a binary file (Windows):**
+```powershell
+# CoreCLR — has a CLI header (IL entry point)
+dumpbin /clrheader <binary.exe> | Select-String "CLI Header" -Quiet
+
+# NativeAOT — no CLI header, has Redhawk symbols
+dumpbin /symbols <binary.exe> | Select-String "Rhp" -Quiet
+```
+
+**From a running process (Linux):**
+```bash
+# Resolve the binary, then use the same file checks
+BINARY=$(readlink /proc/<pid>/exe)
+strings "$BINARY" | grep -q "CorExeMain" && echo "CoreCLR" || echo "NativeAOT"
+```
+
+**From a running process (macOS):**
+```bash
+# Resolve the binary path from the running process
+BINARY=$(ps -o comm= -p <pid>)
+strings "$BINARY" | grep -q "CorExeMain" && echo "CoreCLR" || echo "NativeAOT"
+```
+
+**From a running process (Windows PowerShell):**
+```powershell
+# CoreCLR — loads coreclr.dll
+(Get-Process -Id <pid>).Modules.ModuleName -contains "coreclr.dll"
+
+# .NET Framework — loads clr.dll (this skill does not apply)
+(Get-Process -Id <pid>).Modules.ModuleName -contains "clr.dll"
+```
+
+> **If the app is .NET Framework (`clr.dll`), stop.** This skill covers modern .NET (CoreCLR and NativeAOT) only.
+>
+> **If neither CoreCLR nor NativeAOT is detected, stop.** This skill only applies to .NET applications — do not proceed.
+
+## Step 2 — Load the Appropriate Reference
+
+Based on the scenario identified in Step 1, read the relevant reference file:
+
+| Scenario | Reference |
+|----------|-----------|
+| CoreCLR app (any platform) | `references/coreclr-dumps.md` |
+| NativeAOT app (any platform) | `references/nativeaot-dumps.md` |
+| Any app in Docker or Kubernetes | `references/container-dumps.md` (then also load the runtime-specific reference) |
+
+## Step 3 — Execute
+
+Follow the instructions in the loaded reference to configure or collect dumps. Always:
+
+1. **Confirm the dump output directory exists** and has write permissions before enabling collection.
+2. **Report the dump file path** back to the user after collection succeeds.
+3. **Verify configuration took effect** — for env vars, echo them; for OS settings, read them back.
+4. **Remind the user to disable automatic dumps if they were enabled temporarily** — remove or unset `DOTNET_DbgEnableMiniDump` and related env vars to avoid accumulating dump files.

--- a/src/lsptoolshost/copilot/skills/dump-collect/references/container-dumps.md
+++ b/src/lsptoolshost/copilot/skills/dump-collect/references/container-dumps.md
@@ -1,0 +1,400 @@
+# Container Crash Dump Collection
+
+| Need | Tool | Runtime | Requires |
+|------|------|---------|----------|
+| Automatic dump on crash (CoreCLR) | `DOTNET_DbgEnableMiniDump` env vars + `createdump` | CoreCLR | `SYS_PTRACE`, volume mount |
+| Automatic dump on crash (NativeAOT, preferred) | `--ulimit core=-1` + `core_pattern` | NativeAOT | `SYS_PTRACE`, volume mount |
+| Automatic dump on crash (NativeAOT, alternative) | `createdump` + `DOTNET_DbgEnableMiniDump` env vars | NativeAOT | `SYS_PTRACE`, volume mount |
+| On-demand from running container | `dotnet-dump collect` (CoreCLR), `gcore` (NativeAOT) | Per-runtime | `SYS_PTRACE` |
+| Copy dump out of container | `docker cp` / `kubectl cp` | Both | — |
+
+Collecting crash dumps from .NET applications running in Docker or Kubernetes containers requires additional configuration for capabilities, storage, and environment variables.
+
+> **Note:** The `%e`, `%p`, `%h`, `%t` format specifiers in `DOTNET_DbgMiniDumpName` require .NET 7+. On .NET 6, use a literal path instead.
+>
+> **Dump types** for `DOTNET_DbgMiniDumpType`: 1=Mini, 2=Heap, 3=Triage, 4=Full. Use 4 for maximum diagnostic value. NativeAOT and CoreCLR single-file apps only support full dumps (type 4).
+
+## Docker
+
+### Required Capability
+
+The `SYS_PTRACE` capability is required for `dotnet-dump collect`, `createdump`, and `gcore` to attach to processes:
+
+```bash
+# docker run
+docker run --cap-add=SYS_PTRACE -v /tmp/dumps:/dumps myapp
+
+# docker compose
+```
+
+```yaml
+# docker-compose.yml
+services:
+  myapp:
+    image: myapp
+    cap_add:
+      - SYS_PTRACE
+    volumes:
+      - ./dumps:/dumps
+    environment:
+      # CoreCLR automatic crash dumps
+      DOTNET_DbgEnableMiniDump: "1"
+      DOTNET_DbgMiniDumpType: "4"
+      DOTNET_DbgMiniDumpName: "/dumps/%e_%p_%t.dmp"
+      DOTNET_EnableCrashReport: "1"
+```
+
+### CoreCLR in Docker
+
+Add environment variables to enable automatic crash dumps. Either in `docker run`:
+
+```bash
+docker run --cap-add=SYS_PTRACE \
+  -v /tmp/dumps:/dumps \
+  -e DOTNET_DbgEnableMiniDump=1 \
+  -e DOTNET_DbgMiniDumpType=4 \
+  -e DOTNET_DbgMiniDumpName="/dumps/%e_%p_%t.dmp" \
+  -e DOTNET_EnableCrashReport=1 \
+  myapp
+```
+
+Or in the Dockerfile (baked into the image):
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+
+# Configure crash dump collection
+ENV DOTNET_DbgEnableMiniDump=1
+ENV DOTNET_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName="/dumps/%e_%p_%t.dmp"
+ENV DOTNET_EnableCrashReport=1
+
+# Create dump directory
+RUN mkdir -p /dumps
+
+COPY --from=build /app .
+ENTRYPOINT ["dotnet", "myapp.dll"]
+```
+
+### NativeAOT in Docker
+
+Since NativeAOT only supports full dumps, OS-level core dump mechanisms are the simplest approach — no extra tooling to copy or configure.
+
+**Preferred: OS-level core dumps:**
+
+```bash
+docker run --cap-add=SYS_PTRACE \
+  --ulimit core=-1 \
+  -v /tmp/dumps:/dumps \
+  myapp
+```
+
+**Note:** You may also need to set the core pattern inside the container. If the host's `core_pattern` pipes to `systemd-coredump`, container core dumps may not be written where expected. Override at runtime:
+
+```bash
+docker run --cap-add=SYS_PTRACE \
+  --ulimit core=-1 \
+  --privileged \
+  -v /tmp/dumps:/dumps \
+  myapp sh -c 'echo "/dumps/core.%e.%p" > /proc/sys/kernel/core_pattern && exec ./myapp'
+```
+
+⚠️ `--privileged` is needed to write to `/proc/sys/kernel/core_pattern`. For production, prefer configuring the core pattern on the host instead.
+
+**Alternative: Use createdump with DOTNET_DbgEnableMiniDump** (same env vars as CoreCLR). Copy `createdump` next to the app binary in the image:
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0
+
+# Copy createdump from the runtime (match your .NET version)
+COPY --from=mcr.microsoft.com/dotnet/runtime:10.0 /usr/share/dotnet/shared/Microsoft.NETCore.App/ /tmp/runtime/
+RUN find /tmp/runtime -name createdump -exec cp {} /app/ \; && rm -rf /tmp/runtime/
+
+# Configure crash dump collection
+ENV DOTNET_DbgEnableMiniDump=1
+ENV DOTNET_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName="/dumps/%e_%p_%t.dmp"
+
+RUN mkdir -p /dumps
+
+COPY --from=build /app .
+ENTRYPOINT ["./myapp"]
+```
+
+For .NET 11+, use `DOTNET_DbgCreateDumpToolPath` instead of co-locating:
+
+```dockerfile
+ENV DOTNET_DbgCreateDumpToolPath=/opt/tools/createdump
+ENV DOTNET_DbgEnableMiniDump=1
+ENV DOTNET_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName="/dumps/%e_%p_%t.dmp"
+```
+
+Run with:
+```bash
+docker run --cap-add=SYS_PTRACE \
+  -v /tmp/dumps:/dumps \
+  myapp
+```
+
+### On-Demand Collection in Docker
+
+```bash
+# Find the container and process
+docker exec <container> dotnet-dump ps         # CoreCLR
+docker exec <container> sh -c 'ps aux | grep myapp'    # NativeAOT
+
+# Collect dump (CoreCLR)
+docker exec <container> dotnet-dump collect -p <pid> --output /dumps/myapp.dmp
+
+# Collect dump (NativeAOT — requires gdb/gcore in the image)
+docker exec <container> gcore -o /dumps/myapp <pid>
+
+# Copy dump out of container (alternative to volume mount)
+docker cp <container>:/dumps/myapp.dmp ./myapp.dmp
+```
+
+## Kubernetes
+
+### Pod Spec for CoreCLR
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  containers:
+    - name: myapp
+      image: myapp:latest
+      securityContext:
+        capabilities:
+          add: ["SYS_PTRACE"]
+      env:
+        - name: DOTNET_DbgEnableMiniDump
+          value: "1"
+        - name: DOTNET_DbgMiniDumpType
+          value: "4"
+        - name: DOTNET_DbgMiniDumpName
+          value: "/dumps/%e_%p_%t.dmp"
+        - name: DOTNET_EnableCrashReport
+          value: "1"
+      volumeMounts:
+        - name: dumps
+          mountPath: /dumps
+  volumes:
+    - name: dumps
+      emptyDir:
+        sizeLimit: 5Gi    # Adjust based on expected dump size
+```
+
+### Pod Spec for NativeAOT
+
+**Preferred: OS-level core dumps** (simplest — no extra tooling needed):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-nativeaot
+spec:
+  containers:
+    - name: myapp
+      image: myapp:latest
+      securityContext:
+        capabilities:
+          add: ["SYS_PTRACE"]
+      command: ["/bin/sh", "-c"]
+      args: ["ulimit -c unlimited && exec ./myapp"]
+      volumeMounts:
+        - name: dumps
+          mountPath: /dumps
+  volumes:
+    - name: dumps
+      emptyDir:
+        sizeLimit: 10Gi
+```
+
+**Alternative: Use createdump** (bundled in the image next to the app, or via `DOTNET_DbgCreateDumpToolPath` on .NET 11+):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-nativeaot
+spec:
+  containers:
+    - name: myapp
+      image: myapp:latest
+      securityContext:
+        capabilities:
+          add: ["SYS_PTRACE"]
+      env:
+        - name: DOTNET_DbgEnableMiniDump
+          value: "1"
+        - name: DOTNET_DbgMiniDumpType
+          value: "4"
+        - name: DOTNET_DbgMiniDumpName
+          value: "/dumps/%e_%p_%t.dmp"
+        # .NET 11+ only — uncomment if createdump is not next to the binary:
+        # - name: DOTNET_DbgCreateDumpToolPath
+        #   value: "/opt/tools/createdump"
+      volumeMounts:
+        - name: dumps
+          mountPath: /dumps
+  volumes:
+    - name: dumps
+      emptyDir:
+        sizeLimit: 5Gi
+```
+
+### Using a Persistent Volume for Dumps
+
+For production, use a PersistentVolumeClaim instead of `emptyDir` so dumps survive pod restarts:
+
+```yaml
+volumes:
+  - name: dumps
+    persistentVolumeClaim:
+      claimName: dump-storage
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dump-storage
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+```
+
+### On-Demand Collection in Kubernetes
+
+```bash
+# Find the pod and process
+kubectl exec <pod> -- dotnet-dump ps           # CoreCLR
+kubectl exec <pod> -- sh -c 'ps aux | grep myapp'      # NativeAOT
+
+# Collect dump
+kubectl exec <pod> -- dotnet-dump collect -p <pid> --output /dumps/myapp.dmp
+
+# Copy dump out of the pod
+kubectl cp <pod>:/dumps/myapp.dmp ./myapp.dmp
+```
+
+### Deployment-Level Configuration
+
+To apply dump collection to all pods in a Deployment:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  template:
+    spec:
+      containers:
+        - name: myapp
+          image: myapp:latest
+          securityContext:
+            capabilities:
+              add: ["SYS_PTRACE"]
+          env:
+            - name: DOTNET_DbgEnableMiniDump
+              value: "1"
+            - name: DOTNET_DbgMiniDumpType
+              value: "4"
+            - name: DOTNET_DbgMiniDumpName
+              value: "/dumps/%e_%p_%t.dmp"
+          volumeMounts:
+            - name: dumps
+              mountPath: /dumps
+      volumes:
+        - name: dumps
+          emptyDir:
+            sizeLimit: 5Gi
+```
+
+## Verification
+
+**Docker:**
+
+```bash
+# Check env vars inside the container
+docker exec <container> env | grep DOTNET_Dbg
+
+# Check dump directory exists and is writable
+docker exec <container> ls -la /dumps/
+
+# Check createdump is available (NativeAOT)
+docker exec <container> ls -la /app/createdump 2>/dev/null || echo "createdump not co-located"
+
+# After a crash, check for dump files
+docker exec <container> sh -c 'ls -la /dumps/*.dmp' 2>/dev/null
+# Or from the host via volume mount:
+ls -la /tmp/dumps/*.dmp
+```
+
+**Kubernetes:**
+
+```bash
+# Check env vars
+kubectl exec <pod> -- env | grep DOTNET_Dbg
+
+# Check dump directory
+kubectl exec <pod> -- ls -la /dumps/
+
+# After a crash, list dumps
+kubectl exec <pod> -- sh -c 'ls -la /dumps/*.dmp' 2>/dev/null
+
+# Copy dumps out for inspection
+kubectl cp <pod>:/dumps/ ./dumps/
+```
+
+## Container Considerations
+
+### Non-Root Users
+
+If your container runs as a non-root user, ensure the dump directory is writable:
+
+```dockerfile
+RUN mkdir -p /dumps && chown -R app:app /dumps
+USER app
+```
+
+For Kubernetes, use an init container or `securityContext.fsGroup`:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000    # matches the app user's group
+```
+
+When using `runAsNonRoot: true`, the dump directory must be writable by the non-root user. Use `fsGroup` to grant group write access to the mounted volume, or set permissions in the Dockerfile.
+
+### Alpine / musl-Based Images
+
+`createdump`, `dotnet-dump`, and CoreCLR automatic crash dumps all work on the supported .NET Alpine images. No special configuration is needed beyond the standard setup described above.
+
+### SELinux / AppArmor
+
+On hosts with SELinux or AppArmor, `SYS_PTRACE` alone may not be sufficient:
+
+- **SELinux**: The container may need `--security-opt label=disable` or an appropriate SELinux policy allowing ptrace
+- **AppArmor**: Use `--security-opt apparmor=unconfined` for debugging, or create a custom profile that allows ptrace
+
+⚠️ Disabling security modules is acceptable for debugging but should not be used in production.
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `dotnet-dump collect` fails with "permission denied" | Missing `SYS_PTRACE` capability | Add `SYS_PTRACE` to securityContext / cap_add |
+| Dump file not created on crash | Dump directory doesn't exist | Ensure `/dumps` directory exists in the image or init container |
+| Core dump goes to wrong location | Host `core_pattern` overrides container | Configure `core_pattern` on the host or use `--privileged` |
+| Dump file is 0 bytes | Disk space exhausted | Increase `emptyDir.sizeLimit` or PVC size |
+| `createdump` not found in container | Minimal runtime image | For CoreCLR: use `dotnet-dump collect` instead. For NativeAOT: copy `createdump` from the runtime image (see NativeAOT in Docker section) or use the full SDK image |

--- a/src/lsptoolshost/copilot/skills/dump-collect/references/coreclr-dumps.md
+++ b/src/lsptoolshost/copilot/skills/dump-collect/references/coreclr-dumps.md
@@ -1,0 +1,100 @@
+# CoreCLR Crash Dump Collection
+
+| Need | Tool | Platforms |
+|------|------|-----------|
+| Automatic dump on crash | `DOTNET_DbgEnableMiniDump` env vars | All |
+| On-demand from running process | `dotnet-dump collect` (recommended) | All |
+| On-demand via OS tools | `gcore` (Linux) | Linux |
+
+## Automatic Crash Dumps (All Platforms)
+
+CoreCLR has built-in crash dump support via environment variables. Set these before launching the app:
+
+```bash
+# Enable crash dumps (required)
+export DOTNET_DbgEnableMiniDump=1
+
+# Dump type: 1=Mini, 2=Heap, 3=Triage, 4=Full
+# Use 4 (Full) for maximum diagnostic value, 1 (Mini) for smaller files
+export DOTNET_DbgMiniDumpType=4
+
+# Output path — supports format specifiers (.NET 7+):
+#   %p = PID, %e = process name, %h = hostname, %t = timestamp
+export DOTNET_DbgMiniDumpName=/tmp/dumps/%e_%p_%t.dmp
+
+# Optional: generate a JSON crash report alongside the dump
+export DOTNET_EnableCrashReport=1
+
+# Optional: diagnostics if dump creation itself fails
+export DOTNET_CreateDumpDiagnostics=1
+```
+
+**On Windows (PowerShell):**
+```powershell
+$env:DOTNET_DbgEnableMiniDump = "1"
+$env:DOTNET_DbgMiniDumpType = "4"
+$env:DOTNET_DbgMiniDumpName = "C:\dumps\%e_%p_%t.dmp"
+$env:DOTNET_EnableCrashReport = "1"
+```
+
+### Dump Type Reference
+
+| Value | Type | Size | Use When |
+|-------|------|------|----------|
+| 1 | Mini | Small | Stack traces only, minimal disk usage |
+| 2 | Heap | Large | Need to inspect managed heap objects |
+| 3 | Triage | Small | The same as mini, but redacts known file paths |
+| 4 | Full | Largest | Full process memory, maximum diagnostic value |
+
+### Important Notes
+
+- The dump output directory must exist before the crash — CoreCLR will not create it.
+- Format specifiers (`%p`, `%e`, `%h`, `%t`) require .NET 7+. On .NET 6, use a literal path.
+- The legacy `COMPlus_` prefix (e.g., `COMPlus_DbgEnableMiniDump`) still works but `DOTNET_` is preferred for .NET 6+.
+- Single-file published apps only support full dumps (`DOTNET_DbgMiniDumpType=4`), same as NativeAOT.
+
+## On-Demand Dump Collection
+
+### Using dotnet-dump (Recommended)
+
+```bash
+# Install (one-time, requires .NET SDK)
+dotnet tool install -g dotnet-dump
+
+# Without the SDK, download directly from https://github.com/dotnet/diagnostics/releases
+
+# List .NET processes
+dotnet-dump ps
+
+# Collect a dump from a running process
+dotnet-dump collect -p <pid>
+
+# Specify dump type and output path
+dotnet-dump collect -p <pid> --type Full --output /tmp/dumps/myapp.dmp
+```
+
+**Supported `--type` values:** `Full`, `Heap`, `Mini`
+
+### Using gcore (Linux Only)
+
+```bash
+# Requires gdb installed
+gcore -o /tmp/dumps/myapp <pid>
+# Produces /tmp/dumps/myapp.<pid>
+```
+
+## Verification
+
+After enabling crash dumps, verify the configuration:
+
+```bash
+# Check env vars are set
+env | grep DOTNET_Dbg
+env | grep DOTNET_EnableCrashReport
+
+# Ensure dump directory exists and is writable
+ls -la /tmp/dumps/
+
+# After a crash, check for dump files
+ls -la /tmp/dumps/*.dmp
+```

--- a/src/lsptoolshost/copilot/skills/dump-collect/references/nativeaot-dumps.md
+++ b/src/lsptoolshost/copilot/skills/dump-collect/references/nativeaot-dumps.md
@@ -1,0 +1,271 @@
+# NativeAOT Crash Dump Collection
+
+| Need | Tool | Platforms |
+|------|------|-----------|
+| Automatic dump on crash (preferred) | OS-level core dumps (`ulimit`, `core_pattern`, WER) | All |
+| Automatic dump on crash (alternative) | `createdump` + `DOTNET_DbgEnableMiniDump` env vars | All |
+| On-demand from running process | `gcore` (Linux), `lldb` (macOS), `procdump` (Windows) | Per-platform |
+
+NativeAOT applications are native executables. Since NativeAOT only supports full dumps, OS-level core dump mechanisms are the simplest approach — no extra tooling to copy or configure.
+
+> **Note:** NativeAOT only supports full dumps. `DOTNET_DbgMiniDumpType` must be set to `4` (Full).
+
+## OS-Level Core Dumps (Preferred)
+
+### Linux
+
+**Option A: Direct core dumps (simplest)**
+
+```bash
+# Enable core dumps for the current shell session
+ulimit -c unlimited
+
+# Set the core dump output pattern (system-wide, requires root)
+echo '/tmp/dumps/core.%e.%p.%t' | sudo tee /proc/sys/kernel/core_pattern
+
+# Make persistent across reboots — add to /etc/sysctl.conf:
+# kernel.core_pattern = /tmp/dumps/core.%e.%p.%t
+
+# Ensure dump directory exists
+mkdir -p /tmp/dumps
+```
+
+> **Note:** `ulimit` only applies to processes started in the current shell session. For an already-running process, use on-demand collection with `gcore` (see On-Demand Dump Collection below).
+
+**Format specifiers for `core_pattern`:**
+| Spec | Meaning |
+|------|---------|
+| `%p` | PID |
+| `%e` | Executable name (first 15 chars) |
+| `%t` | Unix timestamp |
+| `%h` | Hostname |
+| `%u` | UID |
+
+**Option B: systemd-coredump (systemd systems)**
+
+Many Linux distributions pipe core dumps to `systemd-coredump` by default. Check:
+
+```bash
+cat /proc/sys/kernel/core_pattern
+# If it shows: |/usr/lib/systemd/systemd-coredump ...
+# Then systemd-coredump is already handling dumps.
+```
+
+Using `coredumpctl`:
+
+```bash
+# List collected dumps
+coredumpctl list
+
+# Show details of the most recent dump
+coredumpctl info
+
+# Export a dump to a file
+coredumpctl dump -o /tmp/dumps/myapp.core
+
+# Filter by executable name
+coredumpctl list myapp
+coredumpctl dump myapp -o /tmp/dumps/myapp.core
+```
+
+Configure systemd-coredump storage in `/etc/systemd/coredump.conf`:
+```ini
+[Coredump]
+Storage=external
+MaxUse=2G
+ProcessSizeMax=8G
+```
+
+### On-Demand Dump Collection
+
+```bash
+# Using gcore (from gdb package)
+gcore -o /tmp/dumps/myapp <pid>
+```
+
+## macOS
+
+### Automatic Crash Dumps
+
+```bash
+# Enable core dumps for the current shell session
+ulimit -c unlimited
+
+# Core dumps go to /cores/core.<pid>
+# Ensure the directory exists and is writable
+sudo mkdir -p /cores
+sudo chmod 1777 /cores
+
+# Verify the setting
+ulimit -c  # Should print "unlimited"
+```
+
+**Notes:**
+- macOS also generates `.crash` reports in `~/Library/Logs/DiagnosticReports/` automatically — these are text-based crash logs, not full memory dumps.
+- On Apple Silicon, core dumps may require SIP (System Integrity Protection) adjustments for certain processes.
+
+### Retrieving Dumps from an Already-Crashed Process
+
+If the app has already crashed and core dumps were enabled (`ulimit -c unlimited` was set):
+
+```bash
+# Check /cores/ for core dumps
+ls -la /cores/core.*
+
+# Check macOS crash reports (always generated, even without ulimit)
+ls -la ~/Library/Logs/DiagnosticReports/*.crash
+# Or on newer macOS:
+ls -la ~/Library/Logs/DiagnosticReports/*.ips
+```
+
+If core dumps were **not** enabled before the crash, the core dump is lost. The `.crash`/`.ips` report in `DiagnosticReports` is the only artifact — it contains the stack trace and crash reason but not full memory.
+
+### On-Demand Dump Collection
+
+```bash
+# Using lldb (ships with Xcode command-line tools)
+lldb -p <pid> -o "process save-core /tmp/dumps/myapp.core" -o "quit"
+
+# Using gcore if gdb is installed (via Homebrew)
+gcore -o /tmp/dumps/myapp <pid>
+```
+
+## Windows
+
+### Automatic Crash Dumps (Windows Error Reporting)
+
+WER is a Windows OS-level mechanism — it uses its own `DumpType` values (0=Custom, 1=Mini, 2=Full) which are separate from the `DOTNET_DbgMiniDumpType` environment variable. WER works for any process, including NativeAOT apps without `createdump`.
+
+Configure via the registry. Run in an **elevated PowerShell**:
+
+```powershell
+# Enable local dumps for a specific application
+$appName = "myapp.exe"
+$dumpPath = "C:\dumps"
+$regPath = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\$appName"
+
+New-Item -Path $regPath -Force
+New-ItemProperty -Path $regPath -Name "DumpFolder" -Value $dumpPath -PropertyType ExpandString -Force
+New-ItemProperty -Path $regPath -Name "DumpCount" -Value 10 -PropertyType DWord -Force
+New-ItemProperty -Path $regPath -Name "DumpType" -Value 2 -PropertyType DWord -Force
+# DumpType: 0=Custom, 1=Mini, 2=Full
+
+# Ensure dump directory exists
+New-Item -Path $dumpPath -ItemType Directory -Force
+```
+
+**To enable for ALL applications** (not just one), use the parent key:
+```powershell
+$regPath = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps"
+New-Item -Path $regPath -Force
+New-ItemProperty -Path $regPath -Name "DumpFolder" -Value "C:\dumps" -PropertyType ExpandString -Force
+New-ItemProperty -Path $regPath -Name "DumpType" -Value 2 -PropertyType DWord -Force
+```
+
+### On-Demand Dump Collection
+
+**Using procdump (recommended — download from Sysinternals):**
+
+```powershell
+# Download procdump (one-time)
+Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Procdump.zip" -OutFile "$env:TEMP\Procdump.zip"
+Expand-Archive "$env:TEMP\Procdump.zip" -DestinationPath "$env:TEMP\Procdump" -Force
+
+# Capture a full dump
+& "$env:TEMP\Procdump\procdump.exe" -ma <pid> C:\dumps\myapp.dmp
+
+# Capture on crash (waits for an unhandled exception)
+& "$env:TEMP\Procdump\procdump.exe" -ma -e -w <processname> C:\dumps\myapp.dmp
+```
+
+**Using Task Manager:**
+1. Open Task Manager → Details tab
+2. Right-click the process → "Create memory dump file"
+3. Note the output path shown in the dialog
+
+## Alternative: Using createdump with DOTNET_DbgEnableMiniDump
+
+NativeAOT apps also support the `DOTNET_DbgEnableMiniDump` environment variables if `createdump` is available. This gives you the same env-var-based workflow as CoreCLR, but requires copying `createdump` to the right location.
+
+If `createdump` is placed **next to the application binary**:
+
+```bash
+export DOTNET_DbgEnableMiniDump=1
+export DOTNET_DbgMiniDumpType=4
+export DOTNET_DbgMiniDumpName="/tmp/dumps/%e_%p_%t.dmp"
+export DOTNET_EnableCrashReport=1
+```
+
+> **Note:** The `%e`, `%p`, `%h`, `%t` format specifiers in `DOTNET_DbgMiniDumpName` require .NET 7+. On .NET 6, use a literal path instead.
+
+**Setup:** Copy `createdump` from the .NET runtime into the same directory as your published NativeAOT binary:
+
+```bash
+# Linux
+cp /usr/share/dotnet/shared/Microsoft.NETCore.App/<version>/createdump ./publish/
+
+# macOS
+cp /usr/local/share/dotnet/shared/Microsoft.NETCore.App/<version>/createdump ./publish/
+
+# Windows (PowerShell)
+Copy-Item "C:\Program Files\dotnet\shared\Microsoft.NETCore.App\<version>\createdump.exe" .\publish\
+```
+
+**If the .NET runtime is not installed** (fully self-contained deployment), extract `createdump` from the runtime Docker image or NuGet package:
+
+```bash
+# Extract from Docker runtime image
+docker run --rm -v "$(pwd)/publish:/out" mcr.microsoft.com/dotnet/runtime:10.0 \
+  sh -c 'cp /usr/share/dotnet/shared/Microsoft.NETCore.App/*/createdump /out/'
+```
+
+### .NET 11+: DOTNET_DbgCreateDumpToolPath
+
+Starting with .NET 11, you can point to `createdump` at any location instead of requiring it next to the binary:
+
+```bash
+export DOTNET_DbgCreateDumpToolPath=/opt/tools/createdump
+export DOTNET_DbgEnableMiniDump=1
+export DOTNET_DbgMiniDumpType=4
+export DOTNET_DbgMiniDumpName="/tmp/dumps/%e_%p_%t.dmp"
+```
+
+This is especially useful in containers where you can install `createdump` once in a shared location.
+
+## Verification
+
+### When using OS-level core dumps
+
+```bash
+# Linux — check core_pattern and ulimit
+cat /proc/sys/kernel/core_pattern
+ulimit -c
+
+# macOS — check ulimit and /cores/
+ulimit -c
+ls -la /cores/
+
+# Linux (systemd) — check for recent dumps
+coredumpctl list --no-pager | tail -5
+```
+
+```powershell
+# Windows — check WER registry
+Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -ErrorAction SilentlyContinue
+Get-ChildItem "C:\dumps" -ErrorAction SilentlyContinue
+```
+
+### When using createdump + DOTNET_DbgEnableMiniDump
+
+```bash
+# Verify env vars are set
+env | grep DOTNET_Dbg
+env | grep DOTNET_EnableCrashReport
+
+# Verify createdump is next to the binary (or at DOTNET_DbgCreateDumpToolPath)
+ls -la ./createdump        # co-located
+# or: ls -la $DOTNET_DbgCreateDumpToolPath   # .NET 11+
+
+# Verify dump directory exists
+ls -la /tmp/dumps/
+```

--- a/src/lsptoolshost/copilot/skills/microbenchmarking/SKILL.md
+++ b/src/lsptoolshost/copilot/skills/microbenchmarking/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: microbenchmarking
+description: >
+  Activate this skill when BenchmarkDotNet (BDN) is involved in the task — creating,
+  running, configuring, or reviewing BDN benchmarks. Also activate when
+  microbenchmarking .NET code would be useful and BenchmarkDotNet is the likely
+  tool. Consider activating when answering a .NET performance question requires
+  measurement and BenchmarkDotNet may be needed.
+  Covers microbenchmark design, BDN configuration and project setup, how to run
+  BDN microbenchmarks efficiently and effectively, and using BDN for side-by-side
+  performance comparisons.
+  Do NOT use for profiling/tracing .NET code (dotnet-trace, PerfView), production
+  telemetry, or load/stress testing (Crank, k6).
+license: MIT
+---
+
+# Benchmark Authoring Guidelines
+
+BenchmarkDotNet (BDN) is a .NET library for writing and running microbenchmarks. Throughout this skill, "BDN" refers to BenchmarkDotNet.
+
+> **Note:** Evaluations of LLMs writing BenchmarkDotNet benchmarks have revealed common failure patterns caused by outdated assumptions about BDN's behavior — particularly around runtime comparison, job configuration, and execution defaults that have changed in recent versions. The reference files in this skill contain verified, current information. **You MUST read the reference files relevant to the task before writing any code** — your training data likely contains outdated or incorrect BDN patterns.
+
+## Key concepts
+
+- **Job** — describes how to run a benchmark: runtime, iteration counts, launch count, run strategy, and environment settings. Multiple jobs can be configured to run the same benchmarks under different conditions.
+- **Benchmark case** — one method × one parameter combination × one job. The atomic unit BDN measures.
+- **Operation** — the logical unit of work being measured. All BDN output columns (Mean, Error, etc.) report time per operation.
+- **Invocation** — a single call to the benchmark method. By default, 1 invocation = 1 operation. With `OperationsPerInvoke=N`, each invocation counts as N operations.
+- **Iteration** — a timed batch of invocations. BDN measures the total time for all invocations in an iteration, then divides by the total operation count to get per-operation time.
+
+## Benchmarks are comparative instruments
+
+A single benchmark number has limited value — it can confirm the order of magnitude of a measurement, but the exact value changes across machines, operating systems, and runtime configurations. Benchmarks produce the most useful information when compared against something. Before writing benchmarks, identify the **comparison axis** for the current task:
+
+- **Approaches (A vs B)**: comparing alternative implementations side-by-side in the same run.
+- **Runtimes**: comparing the same code across .NET versions (e.g., net8.0 vs net9.0).
+- **Package versions**: comparing different versions of a NuGet dependency.
+- **Builds (before/after)**: comparing a saved DLL of the old code against the current source.
+- **Runtime configuration (GC mode, JIT settings)**: understanding how runtime settings affect performance — compared via multiple jobs in a single run.
+- **Scale (N=100 vs N=1000)**: understanding how performance changes as input size grows.
+- **Hardware/OS**: comparing across different machines or operating systems — requires separate runs on each environment.
+- **Historical measurements**: comparing against measurements recorded at a previous point in time.
+
+BDN can compare the first six axes side-by-side in a single run, but each requires specific CLI flags or configuration that differ from what you might expect — read [references/comparison-strategies.md](references/comparison-strategies.md) for the correct approach for each strategy before configuring a comparison.
+
+## Use cases and benchmark lifecycle
+
+There are four distinct reasons a developer writes a benchmark, and each one changes how the benchmark should be designed and where it should live:
+
+1. **Coverage suite**: Write benchmarks to maximize coverage of real-world usage patterns so that regressions affecting most users are caught. These benchmarks are permanent — they belong in the project's benchmark suite, follow its conventions (directory structure, base classes, naming), and are checked in.
+
+2. **Issue investigation**: Someone has reported a specific performance problem. Write benchmarks to reproduce and diagnose that specific issue. These benchmarks are task-scoped — they persist across the investigation (reproduce → isolate → verify fix) but are not part of the permanent suite.
+
+3. **Change validation**: A developer has a PR or change and wants to understand its performance characteristics before merging. These benchmarks are task-scoped — they persist across the review cycle but are not checked in.
+
+4. **Development feedback**: A developer is actively working on a task and wants to use benchmarks to evaluate approaches and get information early. These benchmarks are task-scoped and throwaway — they persist across the development session but are deleted when the decision is made.
+
+For use case 1, add to the existing benchmark project following its conventions. For use cases 2–4, create a standalone project in a working directory that persists for the task but is clearly not part of the permanent codebase.
+
+For **coverage suite** benchmarks, design from the perspective of real callers — what code patterns use this API, what inputs they pass, and what performance characteristics matter to them. Each permanent benchmark should justify its maintenance cost through real-world relevance. For **temporary benchmarks**, keep the case count intentional — each additional test case costs wall-clock time (read [Cost awareness](#cost-awareness)).
+
+## Cost awareness
+
+Each benchmark case (one method × one parameter combination × one job) takes **15–25 seconds** with default settings. `[Params]` creates a Cartesian product: two `[Params]` with 3 and 4 values across 5 methods = 60 cases ≈ 20 minutes. Multiple jobs multiply this further. Before running, estimate the total case count and match the job preset to the situation:
+
+| Preset | Per-case time | When to use |
+|--------|--------------|-------------|
+| `--job Dry` | <1s | Validate correctness — confirms compilation and execution without measurement |
+| `--job Short` | 5–8s | Quick measurements during development or investigation |
+| *(default)* | 15–25s | Final measurements for a coverage suite |
+| `--job Medium` | 33–52s | Higher confidence when results matter |
+| `--job Long` | 3–12 min | High statistical confidence |
+
+If benchmark runs take longer than expected, results seem unstable, or you need to tune iteration counts or execution settings, read [references/bdn-internals-and-tuning.md](references/bdn-internals-and-tuning.md) for detailed information about BDN's execution pipeline and configuration options.
+
+## Entry points and configuration
+
+BDN programs use either **`BenchmarkSwitcher`** (provides interactive benchmark selection for humans, parses CLI arguments) or **`BenchmarkRunner`** (runs specified benchmarks directly). Both support CLI flags like `--filter` and `--runtimes`, but only when `args` is passed through — without it, CLI flags are silently ignored. When using `BenchmarkSwitcher`, always pass `--filter` to avoid hanging on an interactive prompt.
+
+BDN behavior is customized through **attributes**, **config objects**, and **CLI flags**.
+
+Read [references/project-setup-and-running.md](references/project-setup-and-running.md) for entry point setup, config object patterns, and CLI flags. If you need to collect data beyond wall-clock time — such as memory allocations, hardware counters, or profiling traces — read [references/diagnosers-and-exporters.md](references/diagnosers-and-exporters.md).
+
+## Running benchmarks
+
+BenchmarkDotNet console output is extremely verbose — hundreds of lines per case showing internal calibration, warmup, and measurement details. Redirect all output to a file to avoid consuming context on verbose iteration output:
+
+```
+dotnet run -c Release -- --filter "*MethodName" --noOverwrite > benchmark.log 2>&1
+```
+
+Each benchmark method can take several minutes. Rather than running all benchmarks at once, use `--filter` to run a subset at a time (e.g. one or two methods per invocation), read the results, then run the next subset. This keeps each invocation short — avoiding session or terminal timeouts — and lets you verify results incrementally. Read [references/project-setup-and-running.md](references/project-setup-and-running.md) for filter syntax, CLI flags, and project setup.
+
+After each run, read the Markdown report (`*-report-github.md`) from the results directory for the summary table. Only read `benchmark.log` if you need to investigate errors or unexpected results.
+
+## Writing new benchmarks
+
+### Step 1: Plan the test cases
+
+Before writing any code, determine:
+- Which use case this benchmark serves (coverage, investigation, change validation, or development feedback).
+- Which comparison axis applies (what will the number be compared against?).
+- What real-world scenarios to benchmark, based on how callers actually use the API.
+
+Each benchmark case should justify its cost. An uncovered scenario is usually more valuable than another parameter combination for one already covered, but when a specific parameter dimension genuinely affects performance characteristics, the depth is warranted.
+
+Decide on the list of test cases. For each test case, think through:
+
+- **How to express variation**: BenchmarkDotNet provides several mechanisms for parameterizing benchmarks — `[Params]` and `[ParamsSource]` for property-level parameters, `[Arguments]` and `[ArgumentsSource]` for method-level arguments, `[ParamsAllValues]` to enumerate all values of a `bool` or enum, and `[GenericTypeArguments]` for varying type parameters on generic benchmark classes. Choose the mechanism that best fits the dimension being varied. Read [references/writing-benchmarks.md](references/writing-benchmarks.md) for the full set of options and correctness patterns.
+- **Where input data comes from** — consider which sources are appropriate (these can be combined):
+  - Hard-coded values — small, fixed values where the exact input matters (e.g., specific strings, known edge-case sizes). Store in fields or `[Params]` to avoid constant folding.
+  - Asset files — static data that is too large or impractical to embed in source code such as binary blobs.
+  - Programmatically generated via `[ParamsSource]`/`[ArgumentsSource]`/`[GlobalSetup]` — when data shape matters more than specific content, or when input must be parameterized by size.
+- **Whether randomness is appropriate**: If using generated data, use seeded randomness for reproducibility. When generating random data, use a large enough sample that the generated distribution is representative (e.g., 4 random values may cluster in a narrow range, while 1000 will better exercise the full distribution).
+
+### Step 2: Implement the benchmarks
+
+For **coverage suite** benchmarks, add to the existing benchmark project and follow its conventions. For **temporary benchmarks** (investigation, change validation, development feedback), create a standalone project — read [references/project-setup-and-running.md](references/project-setup-and-running.md) for project setup and entry point configuration.
+
+**Adding the BenchmarkDotNet package**: Always use `dotnet add package BenchmarkDotNet` (no version) — this lets NuGet resolve the latest compatible version. Do NOT manually write a `<PackageReference>` with a version number into the `.csproj`; BDN versions in training data are outdated and may lack support for current .NET runtimes.
+
+Write the benchmark code. Follow the patterns in [references/writing-benchmarks.md](references/writing-benchmarks.md) to avoid common measurement errors — in particular:
+- **Return results** from benchmark methods to prevent dead code elimination
+- **Move initialization to `[GlobalSetup]`** — setup inside the benchmark method is measured; use `[IterationSetup]` only when the benchmark mutates state that must be reset between iterations
+- **Do not add manual loops** — BDN controls invocation count automatically
+- **Mark a baseline** when comparing alternatives — use `[Benchmark(Baseline = true)]` for method-level comparisons or `.AsBaseline()` on a job for multi-job comparisons so results show relative ratios
+- **Store inputs in fields or `[Params]`**, not as literals or `const` values — the JIT can fold constant expressions at compile time, making the benchmark measure a precomputed result instead of the actual computation
+
+### Step 3: Validate and run
+
+Validate before committing to a long run:
+
+1. Run with `--job Dry` first to catch compilation errors and runtime exceptions without spending time on measurement.
+2. Run a single representative case with default settings to verify the output looks correct and the numbers are in the expected range.
+3. Only run the full suite after validation passes.
+
+When iterating on benchmark design, use `--job Short` until confident, then switch to default for final numbers.

--- a/src/lsptoolshost/copilot/skills/microbenchmarking/references/bdn-internals-and-tuning.md
+++ b/src/lsptoolshost/copilot/skills/microbenchmarking/references/bdn-internals-and-tuning.md
@@ -1,0 +1,132 @@
+# BenchmarkDotNet Execution and Configuration
+
+## Build and execution
+
+BDN generates a standalone project containing the measurement harness, builds it **once per unique build configuration**, and runs each case in its **own process**. Cases are partitioned into separate builds when they differ in factors including runtime, toolchain, platform, JIT, GC settings, build configuration, or MSBuild arguments. All cases sharing the same build configuration share a single build (~5s).
+
+BDN determines the number of invocations per iteration automatically.
+
+`[Params]` creates a full Cartesian product: two `[Params]` properties with 3 and 4 values across 5 methods = 3 × 4 × 5 = 60 cases.
+
+Build overhead (~5s) is paid once regardless of case count. When running cases individually (separate `dotnet run` per case), each pays the build cost, adding ~5s per case.
+
+## Execution stages per case (default job settings)
+
+Each case runs through these stages sequentially. Some stage defaults have changed between BDN versions and may change in future releases — check which version of the BenchmarkDotNet NuGet package is installed when the exact behavior matters.
+
+1. **Process launch + JIT** — The benchmark method is invoked to trigger initial JIT compilation, ensuring the method is compiled before the pilot stage calibrates invocation count. This stage's time is not included in results.
+2. **Pilot** — Determines the invocation count per iteration. Fast methods get many invocations per iteration (targeting ~500ms per iteration). Methods slower than ~333ms/op (where two invocations would exceed the target) are fixed at one invocation per iteration.
+3. **Warmup** — Adaptive, typically 6–10 iterations for stable benchmarks (those with low variance). During warmup the runtime may further optimize the method (e.g., tiered JIT recompilation).
+4. **Actual** — Adaptive, typically 15 iterations for stable benchmarks. Stops when the confidence interval is sufficiently narrow (controlled by `MaxRelativeError`, default 2%).
+
+**Note (versions before 0.16.0):** prior to BDN 0.16.0, an additional **Overhead** stage ran between Pilot and Warmup by default. It measured the internal invocation loop's own cost and subtracted it from results. Starting in 0.16.0 this stage is off by default and the API to re-enable it (`[EvaluateOverhead]` / `.WithEvaluateOverhead()`) is marked obsolete.
+
+## Job preset configurations
+
+| Preset | Per-case time | Warmup | Target iterations | Launch count | Strategy |
+|--------|--------------|--------|-------------------|-------------|----------|
+| `Dry` | <1s | 0 | 1 | 1 | ColdStart |
+| `Short` | 5–8s | 3 | 3 | 1 | Throughput |
+| Default | 15–25s | 6–50 (adaptive) | 15–100 (adaptive) | 1 | Throughput |
+| `Medium` | 33–52s | 10 | 15 | 2 | Throughput |
+| `Long` | 3–12 min | 15 | 100 | 3 | Throughput |
+
+The `Dry` preset reuses the ColdStart strategy for minimal execution; its purpose is validation (confirming the benchmark compiles and runs), not first-call measurement.
+
+## Run strategies
+
+The `RunStrategy` controls how BDN calibrates and measures:
+
+- **Throughput** (default) — measures steady-state performance. BDN auto-calibrates invocation count via the pilot stage, runs warmup, and adapts iteration count. Use for microbenchmarks.
+- **ColdStart** — single invocation per iteration, skips all preliminary stages (JIT pre-trigger, pilot, warmup, overhead). The first measured invocation includes JIT compilation time. Use for startup time evaluation.
+- **Monitoring** — single invocation per iteration. Skips JIT pre-trigger, pilot, and overhead stages (like ColdStart), but includes the warmup stage (default 0 iterations, configurable). Use for macrobenchmarks with high variance that don't reach a steady state.
+
+## Jobs and mutators
+
+A **job** defines a complete set of run conditions — runtime, iteration counts, launch count, strategy, etc. A benchmark class can have **multiple jobs**, and BDN will run all benchmark methods under each job separately. For example, `[SimpleJob(RuntimeMoniker.Net80)]` and `[SimpleJob(RuntimeMoniker.Net90)]` on the same class runs every method twice — once per runtime.
+
+A **mutator** is not a standalone job. It is a partial override that gets applied to every existing job. This distinction matters when a class has multiple jobs:
+
+```csharp
+[SimpleJob(RuntimeMoniker.Net80)]      // Job A
+[SimpleJob(RuntimeMoniker.Net90)]      // Job B
+[WarmupCount(3)]                        // Mutator — applied to BOTH Job A and Job B
+public class MyBenchmarks { ... }
+```
+
+Without the mutator distinction, `[WarmupCount(3)]` would be a third job with just a warmup count override and default everything else — probably not what was intended.
+
+Jobs are resolved by collecting all standard jobs (from `[SimpleJob]`, etc.; `Job.Default` if none), then applying all mutators to every job. CLI flags like `--warmupCount 3` act as mutators — they override that setting on all jobs defined in source code. `--job Short` adds a standard job.
+
+## Execution-related attributes
+
+**Class or method level (mutator attributes):**
+These override specific job settings. When applied to a method, they affect only that method's cases. When applied to a class, they affect all methods in the class.
+
+| Attribute | Default | Config (on Job) | CLI flag |
+|-----------|---------|----------------|----------|
+| `[WarmupCount(N)]` | null (adaptive) | `.WithWarmupCount(N)` | `--warmupCount N` |
+| `[IterationCount(N)]` | null (adaptive) | `.WithIterationCount(N)` | `--iterationCount N` |
+| `[MinWarmupCount(N)]` | 6 | `.WithMinWarmupCount(N)` | `--minWarmupCount N` |
+| `[MaxWarmupCount(N)]` | 50 | `.WithMaxWarmupCount(N)` | `--maxWarmupCount N` |
+| `[MinIterationCount(N)]` | 15 | `.WithMinIterationCount(N)` | `--minIterationCount N` |
+| `[MaxIterationCount(N)]` | 100 | `.WithMaxIterationCount(N)` | `--maxIterationCount N` |
+| `[InvocationCount(N)]` | null (auto pilot) | `.WithInvocationCount(N)` | `--invocationCount N` |
+| `[IterationTime(ms)]` | 500ms | `.WithIterationTime(TimeInterval.FromMilliseconds(ms))` | `--iterationTime ms` |
+| `[ProcessCount(N)]` | 1 | `.WithLaunchCount(N)` | `--launchCount N` |
+| `[MaxRelativeError(pct)]` | 0.02 (= 2%) | `.WithMaxRelativeError(pct)` | — |
+
+Note: `[ProcessCount]` and `--launchCount` control the same setting (how many separate processes BDN launches per case). The naming differs between API surfaces.
+
+The `[RunOncePerIteration]` attribute (also available as `.RunOncePerIteration()` or `--runOncePerIteration`) is shorthand for setting `InvocationCount=1` and `UnrollFactor=1`.
+
+**Note (versions before 0.16.0):** `[EvaluateOverhead(bool)]` / `.WithEvaluateOverhead(bool)` / `--noOverheadEvaluation` controlled overhead subtraction. These are obsolete since 0.16.0 when overhead evaluation was disabled by default.
+
+**Class or assembly level:**
+- Job attributes: `[SimpleJob(...)]`, `[DryJob]`, `[ShortRunJob]`, `[MediumRunJob]`, `[LongRunJob]`, `[VeryLongRunJob]`. AllowMultiple — can stack to run the same benchmarks under different job configurations.
+
+## Unroll factor
+
+BDN generates a measurement method that contains the benchmark code repeated `UnrollFactor` times (default 16). This reduces measurement loop overhead relative to the actual work.
+
+UnrollFactor is distinct from `OperationsPerInvoke`: UnrollFactor is an engine optimization, while `OperationsPerInvoke` is a user declaration that each invocation performs multiple logical operations.
+
+When `[IterationSetup]` or `[IterationCleanup]` is used, BDN defaults to `UnrollFactor=1` and `InvocationCount=1` so that setup/cleanup runs before and after each single invocation of the benchmark method. Explicitly setting `InvocationCount` or `UnrollFactor` overrides this behavior.
+
+| Attribute | Config API | CLI flag |
+|-----------|------------|----------|
+| `[UnrollFactor(N)]` | `.WithUnrollFactor(N)` | `--unrollFactor N` |
+
+## Execution environment
+
+The settings below configure the runtime environment the benchmark process runs in. They are orthogonal to the execution pipeline above — they don't change how many iterations run or how the engine measures, they change *what* is being measured.
+
+| Purpose | Attribute | Config API | CLI flag |
+|---------|-----------|------------|----------|
+| Target runtimes | `[SimpleJob(RuntimeMoniker.Net80)]` | `Job.Default.WithRuntime(CoreRuntime.Core80)` | `--runtimes net8.0 net9.0` (first is baseline) |
+| Environment variables | — | `job.WithEnvironmentVariable("key", "value")` | `--envVars KEY:VALUE` |
+
+Multiple runtimes multiply the total case count and each requires a separate build.
+
+### GC configuration
+
+| Setting | Attribute | Config API |
+|---------|-----------|------------|
+| Server GC | `[GcServer(true)]` | `.WithGcServer(true)` |
+| Concurrent GC | `[GcConcurrent(bool)]` | `.WithGcConcurrent(bool)` |
+
+### MemoryRandomization
+
+| Surface | Usage |
+|---------|-------|
+| Attribute | `[MemoryRandomization]` |
+| Config | `.WithMemoryRandomization(true)` |
+| CLI | `--memoryRandomization` |
+
+The `[MemoryRandomization]` attribute causes BDN to allocate random-sized memory between iterations, shifting heap object alignment. This reveals whether benchmark results depend on memory layout (cache line alignment, GC heap position) rather than algorithmic performance.
+
+When enabled, BDN:
+- Allocates random-sized Gen0 and LOH objects between iterations
+- Uses `stackalloc` with random size to shift stack alignment
+- Re-runs `[GlobalCleanup]` and `[GlobalSetup]` after every iteration
+- Disables outlier removal (since multimodal results may be genuine)

--- a/src/lsptoolshost/copilot/skills/microbenchmarking/references/comparison-strategies.md
+++ b/src/lsptoolshost/copilot/skills/microbenchmarking/references/comparison-strategies.md
@@ -1,0 +1,188 @@
+# Comparing benchmark results
+
+BenchmarkDotNet can compare multiple implementations or versions in a single run, producing a side-by-side table with ratio columns and statistical analysis. This is generally preferable to separate runs because it controls for environmental variance.
+
+## Strategy 1: Side-by-side methods (preferred)
+
+When both the old and new implementations can coexist in the same compilation, define separate benchmark methods:
+
+```csharp
+public class SortBenchmark
+{
+    private int[] _data;
+
+    [GlobalSetup]
+    public void Setup() => _data = Enumerable.Range(0, 1000).Reverse().ToArray();
+
+    [Benchmark(Baseline = true)]
+    public void BubbleSort() => Sorting.BubbleSort((int[])_data.Clone());
+
+    [Benchmark]
+    public void QuickSort() => Sorting.QuickSort((int[])_data.Clone());
+}
+```
+
+BDN displays a Ratio column showing each method's mean relative to the baseline. This is the simplest approach and should be preferred whenever both implementations are available at compile time.
+
+## Strategy 2: Comparing runtimes
+
+To compare the same benchmark across different .NET runtime versions, use `--runtimes` on the command line or configure jobs. The `.csproj` must use `<TargetFrameworks>net8.0;net9.0</TargetFrameworks>` (plural) listing all targets:
+
+```
+dotnet run -c Release --framework net9.0 -- --runtimes net8.0 net9.0
+```
+
+```csharp
+var config = DefaultConfig.Instance
+    .AddJob(Job.Default.WithRuntime(CoreRuntime.Core80).AsBaseline())
+    .AddJob(Job.Default.WithRuntime(CoreRuntime.Core90));
+```
+
+Each runtime becomes a separate job. BDN builds separate executables per runtime and shows them side-by-side with ratio columns.
+
+## Strategy 3: Comparing NuGet package versions
+
+To compare different versions of a NuGet dependency, use MSBuild properties to control the package version per job. Each job gets a separate build with the specified version.
+
+**.csproj** — use an MSBuild property for the version:
+```xml
+<PropertyGroup>
+  <MyLibVersion Condition="'$(MyLibVersion)' == ''">2.0.0</MyLibVersion>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="MyLibrary" Version="$(MyLibVersion)" />
+</ItemGroup>
+```
+
+**Config** — create a job per version:
+```csharp
+var config = DefaultConfig.Instance
+    .AddJob(Job.Default
+        .WithMsBuildArguments("/p:MyLibVersion=1.0.0")
+        .WithId("v1.0.0")
+        .AsBaseline())
+    .AddJob(Job.Default
+        .WithMsBuildArguments("/p:MyLibVersion=2.0.0")
+        .WithId("v2.0.0"));
+```
+
+All versions must be source-compatible with the benchmark code (same namespace, same method signatures). BDN builds a separate exe per job because `WithArguments` changes the build partition.
+
+This works with packages from any NuGet source — public registries, private feeds, or local folders created with `dotnet pack`.
+
+## Strategy 4: Comparing a saved build against current source (DLL reference)
+
+When the code is not published as a NuGet package but you want to compare before/after a code change, you can save the build output of the baseline version and reference it directly.
+
+**Step 1** — build and save the baseline:
+```
+dotnet build ../MyLib -c Release -o ./saved-baseline
+```
+
+**Step 2** — make your changes to MyLib.
+
+**Step 3** — set up the benchmark .csproj with conditional references:
+```xml
+<ItemGroup>
+  <ProjectReference Condition="'$(BaselineDll)' == ''" Include="..\MyLib\MyLib.csproj" />
+  <Reference Condition="'$(BaselineDll)' != ''" Include="MyLib">
+    <HintPath>$(BaselineDll)</HintPath>
+  </Reference>
+</ItemGroup>
+```
+
+**Step 4** — configure two jobs:
+```csharp
+var config = DefaultConfig.Instance
+    .AddJob(Job.Default
+        .WithMsBuildArguments("/p:BaselineDll=../saved-baseline/MyLib.dll")
+        .WithId("baseline")
+        .AsBaseline())
+    .AddJob(Job.Default
+        .WithId("current"));
+```
+
+The `baseline` job builds with a direct DLL reference to the saved output. The `current` job builds with the `ProjectReference` to the current source. BDN produces a side-by-side table with ratio columns.
+
+This approach works for any class library. The namespace and public API must be the same between the two versions.
+
+## Strategy 5: Comparing runtime configurations
+
+To compare how different runtime settings (GC mode, JIT options, PGO) affect performance, define multiple jobs with different environment settings. This works with any `Job` setting — GC mode, environment variables, platform, JIT settings:
+
+```csharp
+// GC mode comparison
+var config = DefaultConfig.Instance
+    .AddJob(Job.Default.WithGcServer(false).WithId("Workstation GC").AsBaseline())
+    .AddJob(Job.Default.WithGcServer(true).WithId("Server GC"));
+
+// JIT setting comparison
+var config = DefaultConfig.Instance
+    .AddJob(Job.Default.WithId("Default").AsBaseline())
+    .AddJob(Job.Default.WithEnvironmentVariable("DOTNET_TieredCompilation", "0").WithId("No Tiered"));
+```
+
+## Strategy 6: Comparing across input scale
+
+Use `[Params]` on a size property to understand how performance changes with input size. BDN runs each parameter value as a separate case. Geometrically spaced values (e.g., 10×, 100×) help reveal scaling behavior:
+
+```csharp
+[Params(100, 1_000, 10_000)]
+public int N;
+
+private int[] _data;
+
+[GlobalSetup]
+public void Setup()
+{
+    var rng = new Random(42);
+    _data = Enumerable.Range(0, N).OrderBy(_ => rng.Next()).ToArray();
+}
+
+[Benchmark]
+public void Sort() => Array.Sort((int[])_data.Clone());
+```
+
+## How it works
+
+All multi-version strategies rely on the same BDN mechanism:
+
+1. **Build partitioning** — different MSBuild arguments, runtimes, or platform → separate compiled executables. Each case runs in its own process.
+2. **Ratio calculation** — when a baseline is marked, BDN adds `Ratio` and `RatioSD` columns. `Ratio` is the mean of current/baseline per-operation time ratios. A `Ratio` of `0.85` means ~15% faster.
+
+### Marking a baseline
+
+For side-by-side methods (Strategy 1), mark one method with `[Benchmark(Baseline = true)]`. This compares methods within each job.
+
+For multi-job strategies (Strategies 2–5), mark one job with `.AsBaseline()` in the config. This compares jobs against each other. For `--runtimes`, the first runtime listed is the baseline.
+
+These are separate mechanisms — using the wrong one produces no ratio columns.
+
+Without a baseline, BDN shows absolute numbers only — no ratio columns.
+
+## Apples-to-apples comparison
+
+When comparing across jobs (Strategies 2–5), the default behavior runs each job's pilot stage independently, which may choose different invocation counts per job for the same benchmark case. This creates asymmetric measurement conditions that can bias the comparison.
+
+The `--apples` flag forces symmetric measurement by running in two phases:
+
+1. **Pilot phase** — BDN runs the baseline job once per benchmark case (method × parameter combination) to determine the invocation count for that case. Different cases get different invocation counts based on their speed. This produces a first results table in the log showing only the baseline with `Ratio = 1.00`.
+2. **Measurement phase** — for each benchmark case, ALL jobs run with that case's fixed invocation count, ensuring every job measures the same number of operations per iteration. The final comparison table includes `Ratio` and `InvocationCount` columns and is written to `BenchmarkDotNet.Artifacts/`.
+
+Outlier removal is disabled in this mode since the controlled setup makes outliers more meaningful.
+
+```
+dotnet run -c Release --framework net9.0 -- --runtimes net8.0 net9.0 --apples --job short
+```
+
+Because the pilot runs only once per benchmark case instead of once per job, `--apples` is faster than the default when there are many benchmark cases. The savings grow with the number of methods and parameter combinations.
+
+Requirements:
+- At least two jobs, with exactly one marked as baseline (via `.AsBaseline()` on the job, not `[Benchmark(Baseline = true)]` on the method). When using `--runtimes`, the first runtime listed is automatically treated as the baseline.
+- An explicit iteration count, such as by using `--job short` (which sets `IterationCount=3`) or `--iterationCount N`. Adaptive iteration count is disabled in this mode.
+
+This does not apply to Strategy 1 (side-by-side methods) or Strategy 6 (input scale) because those use a single job — `--apples` requires multiple job objects.
+
+## Mann-Whitney equivalence test
+
+BDN can add a `Faster` / `Same` / `Slower` column based on a Mann-Whitney equivalence test. Add it via config: `.AddColumn(StatisticalTestColumn.Create(threshold: "5%"))`. The `threshold` is the equivalence margin — results within that percentage are reported as `Same`.

--- a/src/lsptoolshost/copilot/skills/microbenchmarking/references/diagnosers-and-exporters.md
+++ b/src/lsptoolshost/copilot/skills/microbenchmarking/references/diagnosers-and-exporters.md
@@ -1,0 +1,146 @@
+# Measurement and diagnostics
+
+BenchmarkDotNet measures wall-clock time by default. This reference covers how to collect additional data (allocations, disassembly, hardware counters), customize statistical output, and export results.
+
+## Diagnosers
+
+Diagnosers add columns or produce artifacts beyond basic timing. They are enabled via class-level attributes or CLI flags.
+
+### MemoryDiagnoser
+
+| Surface | Usage |
+|---------|-------|
+| Attribute | `[MemoryDiagnoser]` or `[MemoryDiagnoser(displayGenColumns: false)]` |
+| Config | `.AddDiagnoser(MemoryDiagnoser.Default)` |
+| CLI | `--memory` |
+
+Tracks managed heap allocations and GC collections per operation.
+
+Adds columns: `Gen0`, `Gen1`, `Gen2` (GC collections per 1000 operations — a value of `1.0000` means one collection per 1000 operations), `Allocated` (bytes per operation).
+
+Set `displayGenColumns: false` if only total allocated bytes matter.
+
+### DisassemblyDiagnoser
+
+| Surface | Usage |
+|---------|-------|
+| Attribute | `[DisassemblyDiagnoser(maxDepth: 2)]` |
+| Config | `.AddDiagnoser(new DisassemblyDiagnoser(new DisassemblyDiagnoserConfig(maxDepth: 2, printSource: true)))` |
+| CLI | `--disasm`, `--disasmDepth N`, `--disasmDiff`, `--disasmFilter "Method*"` |
+
+Captures the JIT-compiled assembly code for the benchmark method.
+
+Produces: a per-benchmark disassembly report (exported as GitHub Markdown and/or HTML).
+
+Config options (`DisassemblyDiagnoserConfig`):
+- `maxDepth` (default 1) — how many levels of called methods to include in the disassembly.
+- `syntax` — `DisassemblySyntax.Masm` (default), `Intel`, or `Att`
+- `printSource` (default false) — include C#/F#/VB source alongside assembly
+- `exportDiff` (default false) — when comparing multiple jobs, export a diff view
+- `exportCombinedDisassemblyReport` (default false) — all benchmarks in a single HTML report for side-by-side comparison
+
+When using `printSource: true`, ensure the benchmark project emits PDB files so BDN can map assembly instructions to source lines:
+
+```xml
+<DebugType>pdbonly</DebugType>
+<DebugSymbols>true</DebugSymbols>
+```
+
+
+### ThreadingDiagnoser
+
+`[ThreadingDiagnoser]` (CLI: `--threading`, Config: `.AddDiagnoser(ThreadingDiagnoser.Default)`) — adds `Completed Work Items` and `Lock Contentions` columns.
+
+### EventPipeProfiler
+
+| Surface | Usage |
+|---------|-------|
+| Attribute | `[EventPipeProfiler(EventPipeProfile.CpuSampling)]` |
+| Config | `.AddDiagnoser(new EventPipeProfiler(EventPipeProfile.CpuSampling))` |
+| CLI | `--profiler EP` |
+
+Collects CPU sampling profiles using .NET's EventPipe infrastructure. Cross-platform.
+
+Profiles available: `CpuSampling`, `GcVerbose`, `GcCollect`, `Jit`.
+
+Produces: `.nettrace` and `.speedscope.json` files. By default (attribute/config), runs an extra benchmark iteration dedicated to profiling so timing results are unaffected.
+
+**CLI note:** `--profiler EP` uses `CpuSampling` with `performExtraBenchmarksRun: false` — profiling is attached to normal measurement runs (no extra iteration, results include profiler overhead, no way to select a different profile). Use the attribute or config API for full control.
+
+
+### HardwareCounters (Windows only, requires elevation)
+
+| Surface | Usage |
+|---------|-------|
+| Attribute | `[HardwareCounters(HardwareCounter.CacheMisses, HardwareCounter.BranchMispredictions)]` |
+| Config | `.AddHardwareCounters(HardwareCounter.CacheMisses, HardwareCounter.BranchMispredictions)` |
+| CLI | `--counters CacheMisses+BranchMispredictions` |
+
+Collects CPU hardware performance counters via ETW.
+
+Available counters include: `TotalCycles`, `InstructionRetired`, `CacheMisses`, `BranchMispredictions`, `BranchInstructions`, `LlcMisses`, `LlcReference`.
+
+Requires: Windows, elevated (admin) process, and ETW support. Not available on all hardware.
+
+
+## Statistical output
+
+### Default columns
+
+| Column | Meaning |
+|--------|---------|
+| `Mean` | Average per-operation time across all measured iterations |
+| `Error` | Half-width of the 99.9% confidence interval — if large relative to Mean, results are noisy |
+| `StdDev` | Standard deviation of measurements (hidden when negligible) |
+| `Median` | Median per-operation time (auto-shown when data is skewed or median diverges from mean) |
+| `P95` | 95th percentile (auto-shown when extreme outliers are present) |
+| `Ratio` | Performance relative to the baseline (current / baseline) — only shown when a baseline is marked. A value of `0.85` means ~15% faster. See [comparison-strategies.md](comparison-strategies.md) for how this is calculated |
+| `RatioSD` | Standard deviation of the ratio distribution |
+
+### Adding columns
+
+Additional statistics can be added via attributes on the benchmark class:
+
+| Attribute | Column added |
+|-----------|-------------|
+| `[MedianColumn]` | Median (P50) |
+| `[MinColumn]`, `[MaxColumn]` | Minimum, Maximum |
+| `[Q1Column]`, `[Q3Column]` | First quartile (P25), Third quartile (P75) |
+| `[AllStatisticsColumn]` | Mean, StdErr, StdDev, Ops/s, Min, Q1, Median, Q3, Max |
+| `[RankColumn]` | Rank (1, 2, 3...) |
+| `[SkewnessColumn]`, `[KurtosisColumn]` | Distribution shape metrics |
+| `[OperationsPerSecond]` | Throughput (ops/sec) |
+
+Percentile columns are available via code: `StatisticColumn.P50`, `StatisticColumn.P85`, `StatisticColumn.P95`, etc.
+
+### Hiding columns
+
+Use `[HideColumns]` to remove unwanted columns from the output:
+
+```csharp
+[HideColumns("Error", "StdDev", "RatioSD")]
+public class MyBenchmark { ... }
+```
+
+## Outlier handling
+
+| Surface | Usage |
+|---------|-------|
+| Attribute | `[Outliers(OutlierMode.DontRemove)]` |
+| Config | `.WithOutlierMode(OutlierMode.DontRemove)` |
+| CLI | `--outliers DontRemove` |
+
+By default, BDN removes upper outliers (unusually slow iterations, typically caused by GC or OS interference). Available modes: `DontRemove`, `RemoveUpper` (default), `RemoveLower`, `RemoveAll`.
+
+## Export formats
+
+BDN exports results in multiple formats. By default it produces Markdown and CSV in the `BenchmarkDotNet.Artifacts/results/` directory.
+
+| Format | Default | Config | CLI flag |
+|--------|---------|--------|----------|
+| JSON (full, indented) | no | `.AddExporter(JsonExporter.Full)` | `--exporters fulljson` |
+| JSON (compressed) | no | `.AddExporter(JsonExporter.Default)` | `--exporters json` |
+| CSV | yes | `.AddExporter(CsvExporter.Default)` | `--exporters csv` |
+| GitHub Markdown | yes | `.AddExporter(MarkdownExporter.GitHub)` | `--exporters github` |
+
+Use `JsonExporter.Full` for individual measurements (needed for programmatic comparison).

--- a/src/lsptoolshost/copilot/skills/microbenchmarking/references/project-setup-and-running.md
+++ b/src/lsptoolshost/copilot/skills/microbenchmarking/references/project-setup-and-running.md
@@ -1,0 +1,179 @@
+# Running benchmarks
+
+This reference covers how to build, run, and read BenchmarkDotNet results. It also covers common CLI flags for controlling output and debugging.
+
+## Entry points: BenchmarkSwitcher vs BenchmarkRunner
+
+BenchmarkDotNet programs use one of two entry points. This determines whether CLI arguments work:
+
+**BenchmarkSwitcher** — passes `args` to BDN, CLI flags work:
+```csharp
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config); // with config
+```
+
+**BenchmarkRunner** — only forwards args if explicitly passed:
+```csharp
+BenchmarkRunner.Run<MyBenchmark>();                     // CLI flags IGNORED
+BenchmarkRunner.Run<MyBenchmark>(args: args);            // CLI flags work
+BenchmarkRunner.Run<MyBenchmark>(config);                // config only, no CLI
+BenchmarkRunner.Run<MyBenchmark>(config, args);          // both config and CLI
+```
+
+Before passing CLI flags like `--filter` or `--job`, check which entry point the program uses. If it uses `BenchmarkRunner.Run<T>()` without args, CLI flags will be silently ignored — configuration must be done through attributes and `ManualConfig` instead.
+
+**Critical**: when `BenchmarkSwitcher` is used, it prompts the user interactively to select which benchmarks to run unless `--filter` is provided. For AI agents, always pass `--filter` to avoid hanging on an interactive prompt. `--filter "*"` matches everything and is the standard way to run all benchmarks non-interactively.
+
+## Config objects
+
+Configs can be built in three ways:
+
+**Modify the default config** — starts with all default loggers, exporters, and columns:
+```csharp
+var config = DefaultConfig.Instance
+    .AddJob(Job.Default.WithRuntime(CoreRuntime.Core90))
+    .AddDiagnoser(MemoryDiagnoser.Default);
+```
+
+**Subclass ManualConfig** — useful when config is complex or reused across classes:
+```csharp
+public class MyConfig : ManualConfig
+{
+    public MyConfig()
+    {
+        AddJob(Job.Default.WithRuntime(CoreRuntime.Core80));
+        AddJob(Job.Default.WithRuntime(CoreRuntime.Core90).AsBaseline());
+        AddDiagnoser(MemoryDiagnoser.Default);
+    }
+}
+```
+
+**Start from empty** — `ManualConfig.CreateEmpty()` removes all defaults (no loggers, no exporters, no columns). Use `ManualConfig.CreateMinimumViable()` instead to start with the default columns and console logger.
+
+Configs can be applied in several ways:
+
+| Method | Scope |
+|--------|-------|
+| `BenchmarkRunner.Run<T>(config)` | All benchmarks in the run |
+| `BenchmarkSwitcher...Run(args, config)` | All benchmarks in the run |
+| `[Config(typeof(MyConfig))]` on class or assembly | That class, or all classes in the assembly |
+
+## Creating a new benchmark project
+
+If there is no existing benchmark project to add to, create a new console project with `dotnet new console` and add the BenchmarkDotNet package. Choose a temporary or permanent location based on the scope of the work.
+
+Use `dotnet add package BenchmarkDotNet` without specifying a version — `dotnet` resolves the latest compatible version automatically. Pinning to a specific version risks missing support for newer runtimes and CLI features.
+
+**Multi-runtime targeting**: to compare across runtimes (e.g., `--runtimes net8.0 net9.0`), the `.csproj` must use the plural `<TargetFrameworks>` property listing all targets:
+
+```xml
+<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+```
+
+If the project uses the singular `<TargetFramework>` with only one TFM, multi-runtime runs will fail at build time.
+
+Then replace `Program.cs` with:
+```csharp
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+```
+
+Adjust the `ProjectReference` path to match the project under test. If benchmarking code that isn't in a separate project, skip `dotnet add reference` and put the code under test directly in the benchmark project.
+
+## Build and run strategy
+
+BenchmarkDotNet console output is extremely verbose — hundreds of lines per case showing pilot, warmup, and actual iteration details. Redirect all output to a file to avoid consuming context on verbose iteration output.
+
+**Recommended approach**: build first, then run with output redirected to a file. Always pass `--noOverwrite` so each run writes results to a timestamped subdirectory instead of `BenchmarkDotNet.Artifacts/results/` — without it, each run overwrites the previous results, making it easy to get confused about which run the results are for.
+
+Each benchmark method can take several minutes. Rather than running all benchmarks at once, use `--filter` to run a subset at a time (e.g. one or two methods per invocation), read the results, then run the next subset. This keeps each invocation short — avoiding session or terminal timeouts — and lets you verify results incrementally.
+
+```
+dotnet build -c Release
+dotnet run -c Release --no-build -- --filter "*MethodName" --noOverwrite > benchmark.log 2>&1
+```
+
+After each run, read the Markdown report (`*-report-github.md`) for the summary table. Only read `benchmark.log` if you need to investigate errors or unexpected results.
+
+## Artifacts directory
+
+By default, BDN writes to `BenchmarkDotNet.Artifacts/` relative to the working directory. Override with:
+
+```
+dotnet run -c Release --no-build -- --artifacts ./my-results
+```
+
+The artifacts directory contains:
+```
+BenchmarkDotNet.Artifacts/
+├── MyBenchmark-20240101-120000.log    # full console log
+└── results/
+    ├── MyBenchmark-report-github.md   # markdown summary table
+    └── MyBenchmark-report.csv         # CSV data
+```
+
+Use `--noOverwrite` to prevent overwriting previous results (writes to `BenchmarkDotNet.Artifacts/<timestamp>/` instead of `BenchmarkDotNet.Artifacts/results/`). Use `--artifacts` with different paths when comparing results from separate runs.
+
+## Useful CLI flags for agents
+
+### Filtering and discovery
+
+| Flag | Purpose |
+|------|---------|
+| `--filter "*"` | Run all benchmarks (avoids interactive prompt from BenchmarkSwitcher) |
+| `--filter "*.MethodName"` | Run specific benchmark methods |
+| `--list flat` | List available benchmark names without running them |
+| `--list tree` | List benchmarks in a tree hierarchy |
+| `--allCategories <name>` | Run only benchmarks matching all specified categories |
+| `--anyCategories <name>` | Run benchmarks matching any specified category |
+
+Tag benchmarks with `[BenchmarkCategory("name")]` (on methods, classes, or assemblies) to enable category-based filtering.
+
+**How `--filter` works**: BDN matches each pattern against two forms of the benchmark name:
+- **Short form**: `Namespace.ClassName.MethodName` (no parameters)
+- **Full form**: `Namespace.ClassName.MethodName(param: value, ...)` (includes parameters when present)
+
+Patterns use glob wildcards (`*` = any characters, `?` = single character), are **case-insensitive**, and must match the **entire** name (anchored). Multiple `--filter` values are OR'd — a case runs if it matches any pattern.
+
+| Goal | Pattern |
+|------|---------|
+| Run all benchmarks | `--filter "*"` |
+| Run one method by name | `--filter "*MyMethod"` |
+| Run all methods in a class | `--filter "*MyClass*"` |
+| Run a specific class.method | `--filter "MyNamespace.MyClass.MyMethod"` |
+| Same, using wildcard for namespace | `--filter "*MyClass.MyMethod"` |
+| Run two specific methods | `--filter "*MethodA" --filter "*MethodB"` |
+| Run methods matching a substring | `--filter "*Sort*"` |
+
+**Tip**: because patterns are anchored, `--filter "MyMethod"` does **not** match `MyNamespace.MyClass.MyMethod` — always use a leading `*` unless matching the short form exactly. Use `--list flat` to see the exact names BDN uses for filtering.
+
+**Category-based filtering**: tag benchmarks with `[BenchmarkCategory("name")]` on methods, classes, or assemblies to enable category filtering. Categories are inherited — a method tagged `"Parsing"` on a class tagged `"Strings"` has both categories.
+
+| Flag | Behavior |
+|------|----------|
+| `--anyCategories Parsing Sorting` | Run benchmarks that have **at least one** of the listed categories |
+| `--allCategories Strings Parsing` | Run benchmarks that have **all** of the listed categories |
+
+When `--filter` and `--allCategories`/`--anyCategories` are used together, a benchmark must satisfy **both** — the glob filter AND the category filter are AND'd together.
+
+### Output control
+
+| Flag | Purpose |
+|------|---------|
+| `--artifacts ./path` | Change where results are written |
+| `--noOverwrite` | Don't overwrite previous result files |
+| `--exporters json` | Add JSON export (useful for programmatic comparison) |
+| `--join` | Combine results from multiple benchmark classes into a single table |
+| `--hide "Error" "StdDev"` | Hide specific columns from the results table |
+| `--keepFiles` | Keep the generated benchmark project files — useful for debugging build failures |
+
+## Dry run validation
+
+Always run `--job Dry` first to catch compilation and runtime errors before committing to a full run:
+
+```
+dotnet run -c Release --no-build -- --filter "*" --job Dry --noOverwrite
+```
+
+A dry run executes each case once (<1 second per case) without meaningful measurement. It validates that setup methods work, parameters are valid, and the benchmark compiles and executes. Only after dry validation passes should you run with default or other job presets.

--- a/src/lsptoolshost/copilot/skills/microbenchmarking/references/writing-benchmarks.md
+++ b/src/lsptoolshost/copilot/skills/microbenchmarking/references/writing-benchmarks.md
@@ -1,0 +1,296 @@
+# Benchmark authoring techniques
+
+This reference covers BenchmarkDotNet features and practices for writing correct benchmark methods. Incorrect benchmarks silently produce misleading results — the techniques here prevent common measurement errors.
+
+## Dead code elimination
+
+The JIT compiler can eliminate code whose result is never used. If a benchmark method returns `void` and doesn't store its result anywhere observable, the JIT may partially or fully optimize away the computation.
+
+**Returning a value from the benchmark method prevents this.** When the method has a non-void return type, the JIT cannot prove the result is unused (the call site in BDN's generated harness is opaque to the JIT), so it must preserve the computation:
+
+```csharp
+// Correct — non-void return prevents DCE
+[Benchmark]
+public int Parse() => int.Parse("12345");
+
+// Wrong — void return, JIT may eliminate the call
+[Benchmark]
+public void Parse() => int.Parse("12345");
+```
+
+For benchmarks that must return `void` (e.g., methods with side effects like `Array.Sort`), DCE is not a concern because the operation itself has observable effects.
+
+For iterating deferred sequences where returning the sequence object doesn't force enumeration, use the `Consumer` class explicitly — see [Deferred execution](#deferred-execution).
+
+## Setup and cleanup
+
+### GlobalSetup / GlobalCleanup
+
+A method marked `[GlobalSetup]` runs once per benchmark case, before all iterations of that case. Use it to allocate buffers, load data, and initialize state that the benchmark reads but does not mutate.
+
+```csharp
+private int[] _array;
+
+[GlobalSetup]
+public void Setup() => _array = Enumerable.Range(0, 1000).ToArray();
+
+[Benchmark]
+public int Sum() => _array.Sum();
+```
+
+Initialization logic inside the benchmark method itself is measured — this is almost never what you want.
+
+When a class has multiple benchmarks needing different setup, use the `Target` or `Targets` property:
+
+```csharp
+[GlobalSetup(Target = nameof(BenchmarkA))]
+public void SetupA() { ... }
+
+[GlobalSetup(Targets = new[] { nameof(BenchmarkB), nameof(BenchmarkC) })]
+public void SetupBC() { ... }
+```
+
+`[GlobalCleanup]` runs once after all iterations. Use it to dispose resources (files, connections) created during setup.
+
+**Note**: when `[MemoryRandomization]` is enabled, BDN re-runs `[GlobalCleanup]` and `[GlobalSetup]` after every iteration (overriding the normal once-only behavior). See [references/bdn-internals-and-tuning.md](references/bdn-internals-and-tuning.md) for details.
+
+### IterationSetup / IterationCleanup
+
+A method marked `[IterationSetup]` runs before every iteration. Use it only when the benchmark mutates state that must be reset — for example, sorting an array in-place.
+
+**Critical constraint**: when `[IterationSetup]` or `[IterationCleanup]` is used, BDN defaults to `InvocationCount=1` and `UnrollFactor=1` (unless explicitly overridden). This means the entire iteration is a single invocation, so the operation should be long enough (generally hundreds of milliseconds or more) for a single-invocation measurement to be reliable — with only one invocation, OS scheduling jitter and timer resolution become a significant fraction of the measured time.
+
+```csharp
+[Params(10_000_000)] // large enough for single-invocation measurement
+public int Size { get; set; }
+
+private int[] _data, _scratch;
+
+[GlobalSetup]
+public void Setup() => _data = Enumerable.Range(0, Size).Reverse().ToArray();
+
+[IterationSetup]
+public void ResetArray() => Array.Copy(_data, _scratch = new int[Size], Size);
+
+[Benchmark]
+public void Sort() => Array.Sort(_scratch);
+```
+
+**If `[GlobalSetup]` is sufficient, do not use `[IterationSetup]`.** It adds overhead and constrains the measurement.
+
+## OperationsPerInvoke
+
+When part of the benchmark setup cannot be moved to `[GlobalSetup]` — typically because it involves a stack-only type like `Span<T>` — use `OperationsPerInvoke` to amortize the setup cost by performing multiple logical operations per invocation.
+
+```csharp
+private byte[] _array = new byte[18];
+
+[Benchmark(OperationsPerInvoke = 16)]
+public Span<byte> Slice()
+{
+    Span<byte> span = new Span<byte>(_array); // setup: can't go in GlobalSetup (stack-only)
+
+    // 16 operations, unrolled without a loop
+    span = span.Slice(1); span = span.Slice(1); span = span.Slice(1); span = span.Slice(1);
+    span = span.Slice(1); span = span.Slice(1); span = span.Slice(1); span = span.Slice(1);
+    span = span.Slice(1); span = span.Slice(1); span = span.Slice(1); span = span.Slice(1);
+    span = span.Slice(1); span = span.Slice(1); span = span.Slice(1); span = span.Slice(1);
+
+    return span;
+}
+```
+
+BDN divides the measured time by `OperationsPerInvoke`, so the reported result reflects a single `Slice` operation with the `Span` creation cost amortized. The operations are manually unrolled (not in a loop) to avoid loop overhead affecting the measurement.
+
+## Avoiding loops
+
+BDN determines how many times to invoke the benchmark method per iteration automatically (the pilot stage). Adding a manual loop inside the benchmark is unnecessary and harmful:
+
+```csharp
+// Wrong — manual loop adds loop overhead and hides per-operation variance
+[Benchmark]
+public int ParseLoop()
+{
+    int result = 0;
+    for (int i = 0; i < 1000; i++)
+        result += int.Parse("12345");
+    return result;
+}
+
+// Correct — BDN handles invocation count
+[Benchmark]
+public int Parse() => int.Parse("12345");
+```
+
+The exception is `OperationsPerInvoke` — when per-invocation setup cannot be avoided, repeating the operation inside the method and declaring the count lets BDN divide the result correctly.
+
+## No side effects
+
+Benchmarks should be idempotent — running the method N times should produce the same performance characteristics as running it once. A benchmark that grows a list on every invocation violates this:
+
+```csharp
+// Wrong — list grows with every invocation, later calls are slower
+List<int> _numbers = new();
+
+[Benchmark]
+public void Add() => _numbers.Add(12345);
+```
+
+If the operation inherently mutates state (e.g., `Array.Sort`), use `[IterationSetup]` to reset state between iterations, with input large enough for reliable single-invocation measurement.
+
+## Async benchmarks
+
+BDN natively supports benchmark methods that return `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>`. BDN awaits the result automatically — there is no special attribute or configuration needed:
+
+```csharp
+[Benchmark]
+public async Task<int> ReadAsync()
+{
+    using var stream = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
+    var buffer = new byte[4096];
+    return await stream.ReadAsync(buffer);
+}
+```
+
+**Async setup/cleanup**: `[GlobalSetup]` and `[GlobalCleanup]` methods can also return `Task` or `ValueTask` — BDN awaits them automatically. `[IterationSetup]` and `[IterationCleanup]` do **not** support async return types; they must be synchronous.
+
+**When NOT to use async**: if the operation being benchmarked is synchronous, do not wrap it in `async`/`await`. The async state machine adds overhead that would be included in the measurement:
+
+```csharp
+// Wrong — adds async state machine overhead to a synchronous operation
+[Benchmark]
+public async Task<int> ParseAsync() => await Task.FromResult(int.Parse("12345"));
+
+// Correct — benchmark the synchronous method directly
+[Benchmark]
+public int Parse() => int.Parse("12345");
+```
+
+## Deferred execution
+
+Returning `IEnumerable<T>`, `IQueryable<T>`, or `Lazy<T>` from a benchmark measures only the creation of the deferred sequence — not its execution. This is almost always a bug:
+
+```csharp
+// Wrong — measures only the creation of the LINQ query object, not its execution
+[Benchmark]
+public IEnumerable<int> WhereQuery() => _numbers.Where(n => n > 50);
+
+// Correct — materialize the result so the query actually executes
+[Benchmark]
+public List<int> WhereQuery() => _numbers.Where(n => n > 50).ToList();
+```
+
+BDN includes a `DeferredExecutionValidator` that detects this mistake and raises a validation error, preventing the benchmark from running. To fix it, either materialize the result (`.ToList()`, `.ToArray()`) or consume it manually using the `.Consume()` extension method:
+
+```csharp
+private Consumer _consumer = new();
+
+[Benchmark]
+public void WhereQuery() => _numbers.Where(n => n > 50).Consume(_consumer);
+```
+
+## Constant folding
+
+The JIT can evaluate expressions at compile time when all inputs are constants or literals. If a benchmark operates on constant inputs, the JIT may fold the computation into a precomputed result, and the benchmark measures nothing:
+
+```csharp
+// Wrong — JIT can compute Math.Sqrt(144.0) at compile time
+[Benchmark]
+public double Sqrt() => Math.Sqrt(144.0);
+
+// Correct — field value is not a compile-time constant
+private double _value = 144.0;
+
+[Benchmark]
+public double Sqrt() => Math.Sqrt(_value);
+```
+
+Store inputs in fields, `[Params]`, or `[Arguments]` — never as literals or `const` values in the benchmark method.
+
+## Randomness and reproducibility
+
+When benchmarks use generated input data, use a fixed seed so results are comparable across runs:
+
+```csharp
+[GlobalSetup]
+public void Setup()
+{
+    var rng = new Random(42); // fixed seed
+    _data = new byte[Size];
+    rng.NextBytes(_data);
+}
+```
+
+## Benchmark class constraints
+
+BDN generates source code for a derived type from the benchmark class, which is compiled as part of its generated project. This imposes constraints:
+- The class must be `public`
+- The class must not be `sealed`, `static`, or `abstract`
+- The class must be a `class`, not a `struct` or `ref struct`
+- Benchmark methods must be `public` and instance (not `static`)
+
+## Parameterization summary
+
+| Feature | Target | Use when |
+|---------|--------|----------|
+| `[Params]` | Field/Property | Values needed in setup; applies to all benchmarks in the class |
+| `[ParamsSource]` | Field/Property | Dynamic or complex values needed in setup |
+| `[ParamsAllValues]` | Field/Property | Enum or bool — test every possible value |
+| `[Arguments]` | Method | Inline values for a specific benchmark method |
+| `[ArgumentsSource]` | Method | Dynamic or complex values for a specific benchmark method |
+| `[GenericTypeArguments]` | Class | Vary type parameters (e.g., value type vs reference type) |
+
+`[Params]` applies to all benchmarks in the class. If different benchmarks need different parameter ranges, split them into separate classes.
+
+`[Arguments]` and `[ArgumentsSource]` are method-specific and their initialization time is excluded from the measurement. `[ArgumentsSource]` methods return `IEnumerable<T>` for single-parameter benchmarks, or `IEnumerable<object[]>` for multi-parameter benchmarks (each array is one set of arguments). `[ParamsSource]` methods return `IEnumerable<T>` (each element is a single value assigned to the field/property).
+
+```csharp
+// Single-parameter: IEnumerable<T>
+[Benchmark]
+[ArgumentsSource(nameof(Inputs))]
+public int Parse(string text) => int.Parse(text);
+
+public IEnumerable<string> Inputs()
+{
+    yield return "12345";
+    yield return "999999999";
+    yield return "-42";
+}
+
+// Multi-parameter: IEnumerable<object[]>
+[Benchmark]
+[ArgumentsSource(nameof(Inputs))]
+public bool TryParse(string text, NumberStyles style) => int.TryParse(text, style, null, out _);
+
+public IEnumerable<object[]> Inputs()
+{
+    yield return new object[] { "12345", NumberStyles.Integer };
+    yield return new object[] { "0xFF", NumberStyles.HexNumber };
+}
+```
+
+`[ParamsSource]` works the same way but targets a field/property and applies to all benchmarks in the class:
+
+```csharp
+[ParamsSource(nameof(Sizes))]
+public int N;
+
+public IEnumerable<int> Sizes() => new[] { 100, 1_000, 10_000 };
+```
+
+`[GenericTypeArguments]` varies type parameters on a generic benchmark class. Each attribute creates a separate closed generic type that BDN runs independently:
+
+```csharp
+[GenericTypeArguments(typeof(int))]
+[GenericTypeArguments(typeof(string))]
+public class CollectionBenchmark<T>
+{
+    private List<T> _list;
+
+    [GlobalSetup]
+    public void Setup() => _list = new List<T>(Enumerable.Repeat(default(T)!, 1000));
+
+    [Benchmark]
+    public bool Contains() => _list.Contains(default!);
+}
+```

--- a/src/lsptoolshost/copilot/skills/skills.lock.json
+++ b/src/lsptoolshost/copilot/skills/skills.lock.json
@@ -1,0 +1,27 @@
+{
+  "upstreamRepo": "dotnet/skills",
+  "upstreamRef": "main",
+  "syncedAt": "2026-05-05T21:20:29.989Z",
+  "skills": {
+    "csharp-scripts": {
+      "sourcePath": "plugins/dotnet/skills/csharp-scripts",
+      "commitSha": "05aeb657e67426e62603002f1d9e9675a59e471b"
+    },
+    "analyzing-dotnet-performance": {
+      "sourcePath": "plugins/dotnet-diag/skills/analyzing-dotnet-performance",
+      "commitSha": "05aeb657e67426e62603002f1d9e9675a59e471b"
+    },
+    "dotnet-trace-collect": {
+      "sourcePath": "plugins/dotnet-diag/skills/dotnet-trace-collect",
+      "commitSha": "05aeb657e67426e62603002f1d9e9675a59e471b"
+    },
+    "dump-collect": {
+      "sourcePath": "plugins/dotnet-diag/skills/dump-collect",
+      "commitSha": "05aeb657e67426e62603002f1d9e9675a59e471b"
+    },
+    "microbenchmarking": {
+      "sourcePath": "plugins/dotnet-diag/skills/microbenchmarking",
+      "commitSha": "05aeb657e67426e62603002f1d9e9675a59e471b"
+    }
+  }
+}


### PR DESCRIPTION
Ship some dotnet skills in box in the C# extension. This includes 
- `csharp-scripts` in [dotnet skills repo](https://github.com/dotnet/skills/blob/main/plugins/dotnet/skills/csharp-scripts)
- `analyzing-dotnet-performance` in [dotnet skills repo](https://github.com/dotnet/skills/tree/main/plugins/dotnet-diag/skills/analyzing-dotnet-performance)
- `dotnet-trace-collect` in [dotnet skills repo](https://github.com/dotnet/skills/tree/main/plugins/dotnet-diag/skills/dotnet-trace-collect)
- `dump-collect` in [dotnet skills repo](https://github.com/dotnet/skills/tree/main/plugins/dotnet-diag/skills/dump-collect)
- `microbenchmarking` in [dotnet skills repo](https://github.com/dotnet/skills/tree/main/plugins/dotnet-diag/skills/microbenchmarking)

These skills are copied directly right now, maybe later we could pull these from the `dotnet skills` repo directly at runtime. I added a skill in this repo that updates these skills by pulling them from the `dotnet skills` repo and update their versioning. Versioning for these `dotnet skills` `.md` files exist in `src/lsptoolshost/copilot/skills/skills.lock.json`. The commits in this file are the SHA commits fron the `dotnet skills repo`. 

 Furthermore, these skills files are added the `vscodeignore` file because there is a rule to exclude `.md` files, but we dont want to exclude these hence the change. 

Users can invoke these skills in the copilot chat with  `\csharp-scripts`, `analyzing-dotnet-performance`, etc.