### PR TITLE
Migrate VSIX publisher to a C# file-based app

### DIFF
--- a/azure-pipelines/Publish-Vsix.cs
+++ b/azure-pipelines/Publish-Vsix.cs
@@ -1,10 +1,13 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 var path = GetSourceDirectory();
 var preRelease = false;
 var dryRun = false;
 var ci = false;
+const string AlreadyPublishedPattern =
+    @"^\s*ERROR\s+[A-Za-z0-9]+(?:[.-][A-Za-z0-9]+)*(?:\s+\([^)]+\))?\s+v[0-9.]+(?:-[0-9a-z.]+)*\s+already exists\.\s*$";
 
 for (var index = 0; index < args.Length; index++)
 {
@@ -111,7 +114,25 @@ foreach (var package in packages)
     }
     else
     {
-        RunVsce(arguments);
+        var publishArguments = GetVsceArguments(arguments);
+        var result = RunCommandWithOutput(npx, publishArguments);
+        if (result.ExitCode == 0)
+        {
+            continue;
+        }
+
+        if (Regex.IsMatch(
+            result.Output,
+            AlreadyPublishedPattern,
+            RegexOptions.Multiline))
+        {
+            Console.WriteLine(
+                $"{Path.GetFileName(package.PackagePath)} was already published.");
+            continue;
+        }
+
+        throw new InvalidOperationException(
+            $"'{npx}' exited with code {result.ExitCode}.");
     }
 }
 
@@ -127,6 +148,45 @@ static void RunCommand(string fileName, IReadOnlyList<string> arguments)
 {
     PrintCommand(fileName, arguments, "##[command]");
 
+    using var process = Process.Start(CreateStartInfo(fileName, arguments))
+        ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+    process.WaitForExit();
+
+    if (process.ExitCode != 0)
+    {
+        throw new InvalidOperationException(
+            $"'{fileName}' exited with code {process.ExitCode}.");
+    }
+}
+
+static (int ExitCode, string Output) RunCommandWithOutput(
+    string fileName,
+    IReadOnlyList<string> arguments)
+{
+    PrintCommand(fileName, arguments, "##[command]");
+
+    var startInfo = CreateStartInfo(fileName, arguments);
+    startInfo.RedirectStandardOutput = true;
+    startInfo.RedirectStandardError = true;
+
+    using var process = Process.Start(startInfo)
+        ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+    var standardOutput = process.StandardOutput.ReadToEndAsync();
+    var standardError = process.StandardError.ReadToEndAsync();
+    process.WaitForExit();
+
+    var capturedStandardOutput = standardOutput.GetAwaiter().GetResult();
+    var capturedStandardError = standardError.GetAwaiter().GetResult();
+    Console.Write(capturedStandardOutput);
+    Console.Error.Write(capturedStandardError);
+
+    return (process.ExitCode, $"{capturedStandardOutput}{Environment.NewLine}{capturedStandardError}");
+}
+
+static ProcessStartInfo CreateStartInfo(
+    string fileName,
+    IReadOnlyList<string> arguments)
+{
     // Disabling shell execution keeps stdout and stderr attached to the pipeline console.
     // In this mode Windows does not resolve extensionless command shims, so GetCommandName appends .cmd.
     var startInfo = new ProcessStartInfo(fileName)
@@ -138,15 +198,7 @@ static void RunCommand(string fileName, IReadOnlyList<string> arguments)
         startInfo.ArgumentList.Add(argument);
     }
 
-    using var process = Process.Start(startInfo)
-        ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
-    process.WaitForExit();
-
-    if (process.ExitCode != 0)
-    {
-        throw new InvalidOperationException(
-            $"'{fileName}' exited with code {process.ExitCode}.");
-    }
+    return startInfo;
 }
 
 static void PrintCommand(

--- a/azure-pipelines/Publish-Vsix.cs
+++ b/azure-pipelines/Publish-Vsix.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+var path = GetSourceDirectory();
+var preRelease = false;
+var dryRun = false;
+var ci = false;
+
+for (var index = 0; index < args.Length; index++)
+{
+    switch (args[index])
+    {
+        case "--path":
+            if (++index >= args.Length)
+            {
+                throw new ArgumentException("--path requires a directory.");
+            }
+
+            path = Path.GetFullPath(args[index]);
+            break;
+        case "--pre-release":
+            preRelease = true;
+            break;
+        case "--dry-run":
+            dryRun = true;
+            break;
+        case "--ci":
+            ci = true;
+            break;
+        default:
+            throw new ArgumentException($"Unknown argument '{args[index]}'.");
+    }
+}
+
+if (!Directory.Exists(path))
+{
+    throw new DirectoryNotFoundException($"Path '{path}' does not exist.");
+}
+
+if (!ci)
+{
+    RunCommand(GetCommandName("az"), ["account", "show"]);
+}
+
+var packages = Directory.GetFiles(path, "*.vsix", SearchOption.TopDirectoryOnly)
+    .Order(StringComparer.OrdinalIgnoreCase)
+    .Select(packagePath =>
+    {
+        var basePath = Path.Combine(
+            Path.GetDirectoryName(packagePath)!,
+            Path.GetFileNameWithoutExtension(packagePath));
+        return (
+            PackagePath: packagePath,
+            ManifestPath: $"{basePath}.manifest",
+            SignaturePath: $"{basePath}.signature.p7s");
+    })
+    .ToArray();
+
+if (packages.Length == 0)
+{
+    Console.WriteLine($"No .vsix files found in '{path}'. Nothing to publish.");
+    return 0;
+}
+
+foreach (var package in packages)
+{
+    if (!File.Exists(package.ManifestPath))
+    {
+        throw new FileNotFoundException(
+            $"Manifest file not found for '{package.PackagePath}'.",
+            package.ManifestPath);
+    }
+
+    if (!File.Exists(package.SignaturePath))
+    {
+        throw new FileNotFoundException(
+            $"Signature file not found for '{package.PackagePath}'.",
+            package.SignaturePath);
+    }
+}
+
+var npx = GetCommandName("npx");
+if (dryRun)
+{
+    RunVsce(["verify-pat", "--azure-credential", "ms-dotnettools"]);
+}
+
+foreach (var package in packages)
+{
+    var arguments = new List<string>
+    {
+        "publish",
+        "--packagePath",
+        package.PackagePath,
+        "--manifestPath",
+        package.ManifestPath,
+        "--signaturePath",
+        package.SignaturePath,
+    };
+
+    if (preRelease)
+    {
+        arguments.Add("--pre-release");
+    }
+
+    arguments.Add("--azure-credential");
+
+    if (dryRun)
+    {
+        PrintCommand(npx, GetVsceArguments(arguments), "DryRun: ");
+    }
+    else
+    {
+        RunVsce(arguments);
+    }
+}
+
+return 0;
+
+void RunVsce(IReadOnlyList<string> arguments)
+    => RunCommand(npx, GetVsceArguments(arguments));
+
+static string[] GetVsceArguments(IReadOnlyList<string> arguments)
+    => ["--yes", "--package", "@vscode/vsce", "vsce", .. arguments];
+
+static void RunCommand(string fileName, IReadOnlyList<string> arguments)
+{
+    PrintCommand(fileName, arguments, "##[command]");
+
+    // Disabling shell execution keeps stdout and stderr attached to the pipeline console.
+    // In this mode Windows does not resolve extensionless command shims, so GetCommandName appends .cmd.
+    var startInfo = new ProcessStartInfo(fileName)
+    {
+        UseShellExecute = false,
+    };
+    foreach (var argument in arguments)
+    {
+        startInfo.ArgumentList.Add(argument);
+    }
+
+    using var process = Process.Start(startInfo)
+        ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+    process.WaitForExit();
+
+    if (process.ExitCode != 0)
+    {
+        throw new InvalidOperationException(
+            $"'{fileName}' exited with code {process.ExitCode}.");
+    }
+}
+
+static void PrintCommand(
+    string fileName,
+    IReadOnlyList<string> arguments,
+    string prefix)
+{
+    Console.WriteLine(
+        $"{prefix}{fileName} {string.Join(' ', arguments.Select(argument => $"\"{argument}\""))}");
+}
+
+static string GetCommandName(string name)
+    => OperatingSystem.IsWindows() ? $"{name}.cmd" : name;
+
+static string GetSourceDirectory([CallerFilePath] string sourcePath = "")
+    => Path.GetDirectoryName(sourcePath)!;

--- a/azure-pipelines/Publish-Vsix.cs
+++ b/azure-pipelines/Publish-Vsix.cs
@@ -61,8 +61,8 @@ var packages = Directory.GetFiles(path, "*.vsix", SearchOption.TopDirectoryOnly)
 
 if (packages.Length == 0)
 {
-    Console.WriteLine($"No .vsix files found in '{path}'. Nothing to publish.");
-    return 0;
+    throw new InvalidOperationException(
+        $"No .vsix files found in '{path}'.");
 }
 
 foreach (var package in packages)

--- a/azure-pipelines/Publish-Vsix.ps1
+++ b/azure-pipelines/Publish-Vsix.ps1
@@ -1,37 +1,11 @@
 <#
 .SYNOPSIS
-    Publishes signed VSIX packages in this folder to the Visual Studio Marketplace using vsce.
+    Publishes signed VSIX packages using the Publish-Vsix.cs file-based app.
 
 .DESCRIPTION
-    For every *.vsix in the target directory, this script locates the matching
-    .manifest and .signature.p7s files and publishes the package with vsce (run via
-    npx @vscode/vsce), passing --packagePath, --manifestPath and --signaturePath.
-
-    Publishing is tolerant of failures: duplicate-package responses are treated as
-    successful, transient failures are retried, and the script continues with the
-    remaining packages. A summary is printed at the end and the script exits with a
-    non-zero code only if at least one package failed.
-
-.PARAMETER Path
-    Directory containing the .vsix/.manifest/.signature.p7s files. Defaults to the
-    script's own directory.
-
-.PARAMETER PreRelease
-    Publish the packages as pre-release versions.
-
-.PARAMETER DryRun
-    Enables DryRun behavior and verifies Marketplace credentials without publishing.
-
-.PARAMETER CI
-    Skips az credentials check when running in CI.
-
-.NOTES
-    Authentication uses Azure credentials (vsce --azure-credential). You must have the
-    Azure CLI (az) installed and be logged in (run 'az login') before publishing.
-
-.EXAMPLE
-    az login
-    ./Publish-Vsix.ps1 -PreRelease
+    This compatibility wrapper remains in the build artifact while release pipelines
+    transition to the .NET implementation. Older artifacts contain the original
+    PowerShell implementation, so release.yml must continue invoking this script.
 #>
 [CmdletBinding(SupportsShouldProcess = $false)]
 param(
@@ -42,255 +16,28 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$publisher = 'ms-dotnettools'
-$maxOutputExcerptLength = 200
-$retryDelaysInMinutes = @(1, 3, 5)
-$secondsPerMinute = 60
-$vscePackage = '@vscode/vsce'
 
-if (-not $CI) {
-    # Publishing authenticates with Azure credentials, so the Azure CLI must be installed
-    # and a user must be signed in (az login).
-    $azCmd = Get-Command az -ErrorAction SilentlyContinue
-    if (-not $azCmd) {
-        throw "The Azure CLI (az) was not found on PATH. Install it from https://aka.ms/azcli and run 'az login', then try again."
-    }
-
-    az account show 1>$null 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        throw "You are not logged in to the Azure CLI. Run 'az login' and try again."
-    }
+$dotnetCommand = Get-Command dotnet -ErrorAction SilentlyContinue
+if (-not $dotnetCommand) {
+    throw 'The .NET 10 SDK was not found on PATH. Install it from https://aka.ms/dotnet/download, then try again.'
 }
 
-# Run vsce via npx so no global install is required. npx will fetch @vscode/vsce
-# on demand (and reuse it from the cache on subsequent runs).
-$npxCmd = Get-Command npx -ErrorAction SilentlyContinue
-if (-not $npxCmd) {
-    throw "npx was not found on PATH. Install Node.js (which includes npx) and try again."
+$appPath = Join-Path $PSScriptRoot 'Publish-Vsix.cs'
+if (-not (Test-Path -LiteralPath $appPath -PathType Leaf)) {
+    throw "The VSIX publisher app was not found at '$appPath'."
 }
 
-$npx = $npxCmd.Source
-
-$vsceVersionPattern = 'v[0-9.]+(?:-[0-9a-z.]+)*'
-$vscePackageNamePattern = '[A-Za-z0-9]+(?:[.-][A-Za-z0-9]+)*(?:\s+\([^)]+\))?'
-
-# Keep this regex aligned with the duplicate-package error format emitted by vsce in release pipeline logs.
-$alreadyPublishedRegex = [regex]"^\s*ERROR\s+$vscePackageNamePattern\s+$vsceVersionPattern\s+already exists\.\s*$"
-
-function Test-AlreadyPublishedFailure {
-    param(
-        [string[]]$CommandOutputLines
-    )
-
-    if ($null -eq $CommandOutputLines -or $CommandOutputLines.Length -eq 0) {
-        return $false
-    }
-
-    foreach ($commandOutputLine in $CommandOutputLines) {
-        if ($alreadyPublishedRegex.IsMatch($commandOutputLine)) {
-            return $true
-        }
-    }
-
-    return $false
+$appArguments = @('run', '--file', $appPath, '--', '--path', $Path)
+if ($PreRelease) {
+    $appArguments += '--pre-release'
 }
-
-function Get-LastOutputExcerpt {
-    param(
-        [string[]]$CommandOutputLines
-    )
-
-    $lastNonEmptyOutputLine = $CommandOutputLines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1
-    if ([string]::IsNullOrWhiteSpace($lastNonEmptyOutputLine)) {
-        return 'No output captured from vsce.'
-    }
-
-    if ($lastNonEmptyOutputLine.Length -gt $maxOutputExcerptLength) {
-        return $lastNonEmptyOutputLine.Substring(0, $maxOutputExcerptLength) + '...'
-    }
-
-    return $lastNonEmptyOutputLine
-}
-
-function Invoke-Vsce {
-    param(
-        [string[]]$Arguments,
-        [switch]$DryRun
-    )
-
-    $commandArgs = @(@('--yes', '--package', $vscePackage, 'vsce') + $Arguments)
-
-    if ($DryRun) {
-        Write-Host "DryRun: $npx $($commandArgs -join ' ')"
-        return @{
-            OutputLines = @()
-            ExitCode = 0
-        }
-    }
-
-    Write-Host "##[command]$npx $($commandArgs -join ' ')"
-    $commandOutputLines = & $npx @commandArgs 2>&1 | Out-String -Stream
-    $exitCode = $LASTEXITCODE
-
-    if ($null -ne $commandOutputLines -and $commandOutputLines.Length -gt 0) {
-        Write-Host ($commandOutputLines -join [Environment]::NewLine)
-    }
-
-    return @{
-        OutputLines = $commandOutputLines
-        ExitCode = $exitCode
-    }
-}
-
-function Invoke-VscePublish {
-    param(
-        [string]$PackagePath,
-        [string]$ManifestPath,
-        [string]$SignaturePath
-    )
-
-    $vsceArgs = @(
-        'publish',
-        '--packagePath',   $PackagePath
-        '--manifestPath',  $ManifestPath
-        '--signaturePath', $SignaturePath
-    )
-    if ($PreRelease) {
-        # Use the Marketplace CLI pre-release channel flag when publishing pre-release VSIX packages.
-        $vsceArgs += '--pre-release'
-    }
-    $vsceArgs += '--azure-credential'
-
-    if ($DryRun) {
-        Invoke-Vsce -Arguments $vsceArgs -DryRun | Out-Null
-        return @{
-            Status = 'DryRun'
-            Detail = ''
-        }
-    }
-
-    $totalAttempts = $retryDelaysInMinutes.Length + 1
-
-    for ($attemptIndex = 0; $attemptIndex -lt $totalAttempts; $attemptIndex++) {
-        $attempt = $attemptIndex + 1
-        Write-Host "Publish attempt $attempt of $totalAttempts."
-
-        $publishResult = Invoke-Vsce -Arguments $vsceArgs
-        $publishOutputLines = $publishResult.OutputLines
-        $exitCode = $publishResult.ExitCode
-
-        if ($exitCode -eq 0) {
-            Write-Host 'vsce publish succeeded.'
-            return @{
-                Status = 'Published'
-                Detail = ''
-            }
-        }
-
-        if (Test-AlreadyPublishedFailure -CommandOutputLines $publishOutputLines) {
-            Write-Warning 'vsce publish reported that the package version already exists. Treating this duplicate-package result as successful.'
-            return @{
-                Status = 'AlreadyPublished'
-                Detail = ''
-            }
-        }
-
-        $lastOutputExcerpt = Get-LastOutputExcerpt -CommandOutputLines $publishOutputLines
-        if ($attempt -lt $totalAttempts) {
-            $delayMinutes = $retryDelaysInMinutes[$attemptIndex]
-            Write-Warning "vsce publish failed with exit code $exitCode on attempt $attempt of $totalAttempts. Last output: $lastOutputExcerpt. Retrying in $delayMinutes minute(s)."
-            Start-Sleep -Seconds ($delayMinutes * $secondsPerMinute)
-            continue
-        }
-
-        return @{
-            Status = 'Failed'
-            Detail = "vsce publish failed after $totalAttempts attempts. Last output: $lastOutputExcerpt"
-        }
-    }
-}
-
-if (-not (Test-Path -LiteralPath $Path)) {
-    throw "Path '$Path' does not exist."
-}
-
-$vsixFiles = Get-ChildItem -LiteralPath $Path -Filter '*.vsix' -File | Sort-Object Name
-if (-not $vsixFiles) {
-    Write-Warning "No .vsix files found in '$Path'. Nothing to publish."
-    return
-}
-
-Write-Host "Verifying companion files for all packages..."
-$packages = [System.Collections.Generic.List[object]]::new()
-$missingCompanionFiles = @()
-foreach ($vsix in $vsixFiles) {
-    $vsixBaseName = [System.IO.Path]::GetFileNameWithoutExtension($vsix.Name)
-    $manifestPath = Join-Path $vsix.DirectoryName "$vsixBaseName.manifest"
-    $signaturePath = Join-Path $vsix.DirectoryName "$vsixBaseName.signature.p7s"
-
-    if (-not (Test-Path -LiteralPath $manifestPath))  { $missingCompanionFiles += "manifest ($manifestPath)" }
-    if (-not (Test-Path -LiteralPath $signaturePath)) { $missingCompanionFiles += "signature ($signaturePath)" }
-
-    $packages.Add([pscustomobject]@{
-        PackagePath   = $vsix.FullName
-        PackageName   = $vsix.Name
-        ManifestPath  = $manifestPath
-        SignaturePath = $signaturePath
-    })
-}
-if ($missingCompanionFiles.Count -gt 0) {
-    throw "Verification check failed. Missing companion file(s):`n  $($missingCompanionFiles -join "`n  ")`nNo packages were published."
-}
-Write-Host "All companion files present." -ForegroundColor Green
-
 if ($DryRun) {
-    Write-Host "Dry run mode enabled. Verifying Marketplace credentials."
-    $verifyArgs = @('verify-pat', '--azure-credential', $publisher)
-    $verifyResult = Invoke-Vsce -Arguments $verifyArgs
-    if ($verifyResult.ExitCode -ne 0) {
-        throw "Marketplace credential verification failed with exit code $($verifyResult.ExitCode)."
-    }
+    $appArguments += '--dry-run'
+}
+if ($CI) {
+    $appArguments += '--ci'
 }
 
-$results = New-Object System.Collections.Generic.List[object]
-
-foreach ($package in $packages) {
-    Write-Host ""
-    Write-Host "=== Publishing $($package.PackageName) ===" -ForegroundColor Cyan
-
-    try {
-        $publishResult = Invoke-VscePublish -PackagePath $package.PackagePath -ManifestPath $package.ManifestPath -SignaturePath $package.SignaturePath
-        if ($publishResult.Status -eq 'Published') {
-            Write-Host "Published $($package.PackageName)" -ForegroundColor Green
-            $results.Add([pscustomobject]@{ Package = $package.PackageName; Status = 'Published'; Detail = '' })
-        }
-        elseif ($publishResult.Status -eq 'AlreadyPublished') {
-            Write-Host "$($package.PackageName) was already published" -ForegroundColor Yellow
-            $results.Add([pscustomobject]@{ Package = $package.PackageName; Status = 'AlreadyPublished'; Detail = '' })
-        }
-        elseif ($publishResult.Status -eq 'DryRun') {
-            $results.Add([pscustomobject]@{ Package = $package.PackageName; Status = 'DryRun'; Detail = '' })
-        }
-        else {
-            $reason = $publishResult.Detail
-            Write-Warning $reason
-            $results.Add([pscustomobject]@{ Package = $package.PackageName; Status = 'Failed'; Detail = $reason })
-        }
-    }
-    catch {
-        Write-Warning "Error publishing $($package.PackageName): $($_.Exception.Message)"
-        $results.Add([pscustomobject]@{ Package = $package.PackageName; Status = 'Failed'; Detail = $_.Exception.Message })
-    }
-}
-
-Write-Host ""
-Write-Host "=== Summary ===" -ForegroundColor Cyan
-$results | Format-Table -AutoSize
-
-$failed = @($results | Where-Object { $_.Status -eq 'Failed' })
-if ($failed.Count -gt 0) {
-    Write-Warning "$($failed.Count) package(s) failed to publish. See summary above."
-    exit 1
-}
-
-exit 0
+Write-Host "##[command]& $($dotnetCommand.Source) $($appArguments -join ' ')"
+& $dotnetCommand.Source @appArguments
+exit $LASTEXITCODE

--- a/azure-pipelines/build-vsix.yml
+++ b/azure-pipelines/build-vsix.yml
@@ -111,10 +111,12 @@ stages:
         TargetFolder: '$(Build.SourcesDirectory)/Packages/VSIX_$(channel)'
 
     - task: CopyFiles@2
-      displayName: 'Copy Publish-Vsix script to Packages'
+      displayName: 'Copy VSIX publisher to Packages'
       inputs:
         SourceFolder: '$(Build.SourcesDirectory)/azure-pipelines'
-        Contents: 'Publish-Vsix.ps1'
+        Contents: |
+          Publish-Vsix.cs
+          Publish-Vsix.ps1
         TargetFolder: '$(Build.SourcesDirectory)/Packages'
 
     - ${{ if eq(parameters.isOfficial, true) }}:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -73,6 +73,10 @@ extends:
                   Write-Host "##vso[build.updatebuildnumber]$buildNumberName"
                 displayName: Set BuildNumber
               - template: /azure-pipelines/install-node.yml@self
+              - task: UseDotNet@2
+                displayName: 'Install .NET SDK'
+                inputs:
+                  version: 10.0.x
               - task: AzureCLI@2
                 displayName: '🚀 Publish to Marketplace'
                 name: PublishToMarketplaceStep


### PR DESCRIPTION
## Summary
- move VSIX Marketplace publishing to a .NET 10 file-based app
- retain `Publish-Vsix.ps1` as a compatibility wrapper for releases of older build artifacts
- include the app in build artifacts and install the required SDK in the release job

## Validation
- exercised dry-run and pre-release argument forwarding
- verified stdout and stderr reach the pipeline console
- verified non-zero command exits fail the app