### PR TITLE
Reduce macOS integration tests on PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,14 +146,31 @@ stages:
   variables:
     ROSLYN_SKIP_TEST_FILE_BASED_PROGRAMS: 'true'
   jobs:
-  - template: azure-pipelines/test-matrix.yml
-    parameters:
-      os: macos
-      installDotNet: true
-      testVSCodeVersion: $(testVSCodeVersion)
-      pool:
-        name: Azure Pipelines
-        vmImage: macOS-15
+  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    - template: azure-pipelines/test-matrix.yml
+      parameters:
+        os: macos
+        installDotNet: true
+        testVSCodeVersion: $(testVSCodeVersion)
+        pool:
+          name: Azure Pipelines
+          vmImage: macOS-15
+        matrix:
+          CSharpAndDevKitSanityTests:
+            npmCommand: test:integration:macos-pr
+            isIntegration: true
+          RazorCohostTests:
+            npmCommand: test:integration:razor:cohost
+            isIntegration: true
+  - ${{ else }}:
+    - template: azure-pipelines/test-matrix.yml
+      parameters:
+        os: macos
+        installDotNet: true
+        testVSCodeVersion: $(testVSCodeVersion)
+        pool:
+          name: Azure Pipelines
+          vmImage: macOS-15
 
 - stage: Test_OmniSharp
   displayName: Test OmniSharp

--- a/azure-pipelines/test-matrix.yml
+++ b/azure-pipelines/test-matrix.yml
@@ -13,11 +13,9 @@ parameters:
     default: false
   - name: testVSCodeVersion
     type: string
-
-jobs:
-- job:
-  strategy:
-    matrix:
+  - name: matrix
+    type: object
+    default:
       UnitTests:
         npmCommand: test:unit
         isIntegration: false
@@ -33,6 +31,11 @@ jobs:
       UntrustedWorkspaceTest:
         npmCommand: test:integration:untrusted
         isIntegration: true
+
+jobs:
+- job:
+  strategy:
+    matrix: ${{ parameters.matrix }}
   pool: ${{ parameters.pool }}
   ${{ if parameters.containerName }}:
     container: ${{ parameters.containerName }}

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "test:integration": "npm run test:integration:csharp && npm run test:integration:devkit && npm run test:integration:razor:cohost && npm run test:integration:untrusted",
     "test:integration:csharp": "npm run packageDev && npx ts-node tasks/tests/testIntegrationCsharp.ts",
     "test:integration:devkit": "npm run packageDev && npx ts-node tasks/tests/testIntegrationDevkit.ts",
+    "test:integration:macos-pr": "npm run packageDev && npx ts-node tasks/tests/testIntegrationMacOspr.ts",
     "test:integration:razor:cohost": "npm run packageDev && npx ts-node tasks/tests/testIntegrationRazorCohost.ts",
     "test:integration:untrusted": "npm run packageDev && npx ts-node tasks/tests/testIntegrationUntrusted.ts",
     "test:unit": "npm run compileDev && npx ts-node tasks/tests/testUnit.ts",

--- a/tasks/tests/testIntegrationMacOspr.ts
+++ b/tasks/tests/testIntegrationMacOspr.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testIntegrationMacOSPR } from './testTasks';
+import { runTask } from '../runTask';
+
+runTask(testIntegrationMacOSPR);

--- a/tasks/tests/testTasks.ts
+++ b/tasks/tests/testTasks.ts
@@ -4,11 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { integrationTestProjects, runDevKitIntegrationTests, runIntegrationTest, runJestTest } from './testHelpers';
+import {
+    basicSlnTestProject,
+    integrationTestProjects,
+    runDevKitIntegrationTests,
+    runIntegrationTest,
+    runJestTest,
+} from './testHelpers';
 import { jestArtifactTestsProjectName } from '../../test/lsptoolshost/artifactTests/jest.config';
 import { jestUnitTestProjectName } from '../../test/lsptoolshost/unitTests/jest.config';
 import { razorTestProjectName } from '../../test/razor/razorTests/jest.config';
 import { jestTasksTestProjectName } from '../../test/tasks/jest.config';
+import { rootPath } from '../projectPaths';
 
 const razorIntegrationTestProjects = ['RazorApp'];
 
@@ -30,6 +37,29 @@ export async function testIntegrationDevkit(): Promise<void> {
             `DevKit-${projectName}`
         );
     }
+}
+
+// Full macOS integration runs are frequently the PR long pole. Exercise extension activation, project loading,
+// and completion through both C# and Dev Kit here.  Full feature coverage is handled by both non-macOS legs
+// and in non-PR builds for macOS.
+export async function testIntegrationMacOSPR(): Promise<void> {
+    const testFolderName = path.join('lsptoolshost', 'integrationTests');
+    const completionTestFile = path.join(rootPath, 'test', testFolderName, 'completion.integration.test.ts');
+
+    await runIntegrationTest(
+        basicSlnTestProject,
+        testFolderName,
+        'CSharp-macOS-PR',
+        `${basicSlnTestProject}.code-workspace`,
+        completionTestFile
+    );
+    await runIntegrationTest(
+        basicSlnTestProject,
+        testFolderName,
+        'DevKit-macOS-PR',
+        `devkit_${basicSlnTestProject}.code-workspace`,
+        completionTestFile
+    );
 }
 
 export async function testIntegrationRazorCohost(): Promise<void> {


### PR DESCRIPTION
## Summary

- run focused C# and C# Dev Kit completion sanity coverage on macOS for pull requests
- retain the full Razor cohost suite in the macOS PR matrix
- continue running the complete macOS test matrix for non-PR builds

Recent successful PR runs showed macOS finishing last in 9 of 12 runs. The two longest macOS jobs were C# integration tests (20.5 minute median) and Dev Kit integration tests (20 minute median), roughly twice their Windows/Linux runtime.

## Testing

- `npm run compile`
- parsed the changed pipeline YAML and asserted the PR and non-PR matrix shapes