### PR TITLE
Test removing libdrm2 from Linux Docker prerequisites

### DIFF
--- a/azure-pipelines/test-linux-docker-prereqs.yml
+++ b/azure-pipelines/test-linux-docker-prereqs.yml
@@ -13,7 +13,7 @@ steps:
 # Installing the dependencies requires root, but the docker image we're using doesn't have root permissions (nor sudo)
 # We can exec as root from outside the container from the host machine.
 # Really we should create our own image with these pre-installed, but we'll need to figure out how to publish the image.
-- script: docker exec --user root $(containerId) bash -c 'apt-get update -y && apt-get install -y libglib2.0-0 libnss3 libatk-bridge2.0-dev libdrm2 libgtk-3-0 libgbm-dev libasound2t64 xvfb'
+- script: docker exec --user root $(containerId) bash -c 'apt-get update -y && apt-get install -y libglib2.0-0 libnss3 libatk-bridge2.0-dev libgtk-3-0 libgbm-dev libasound2t64 xvfb'
   displayName: 'Install additional Linux dependencies'
   target: host
   condition: eq(variables['Agent.OS'], 'Linux')


### PR DESCRIPTION
This is an isolated experiment that removes only the `libdrm2` package from the Linux Docker prerequisites. CI will determine whether this package is still required by the Docker integration-test images. This PR should not be merged until the CI results have been assessed.