### PR TITLE
Remove unused Linux Docker prerequisites

### DIFF
--- a/azure-pipelines/test-linux-docker-prereqs.yml
+++ b/azure-pipelines/test-linux-docker-prereqs.yml
@@ -13,7 +13,7 @@ steps:
 # Installing the dependencies requires root, but the docker image we're using doesn't have root permissions (nor sudo)
 # We can exec as root from outside the container from the host machine.
 # Really we should create our own image with these pre-installed, but we'll need to figure out how to publish the image.
-- script: docker exec --user root $(containerId) bash -c 'apt-get update -y && apt-get install -y libglib2.0-0 libnss3 libatk-bridge2.0-dev libdrm2 libgtk-3-0 libgbm-dev libasound2t64 xvfb'
+- script: docker exec --user root $(containerId) bash -c 'apt-get update -y && apt-get install -y libnss3 libgtk-3-0 libasound2t64 xvfb'
   displayName: 'Install additional Linux dependencies'
   target: host
   condition: eq(variables['Agent.OS'], 'Linux')


### PR DESCRIPTION
## Summary

Remove Linux Docker prerequisite packages whose isolated CI experiments passed every Linux integration-test matrix:

- `libglib2.0-0` ([#9624](https://github.com/dotnet/vscode-csharp/pull/9624))
- `libatk-bridge2.0-dev` ([#9622](https://github.com/dotnet/vscode-csharp/pull/9622))
- `libdrm2` ([#9623](https://github.com/dotnet/vscode-csharp/pull/9623))
- `libgbm-dev` ([#9626](https://github.com/dotnet/vscode-csharp/pull/9626))

The isolated removals of `libnss3`, `libgtk-3-0`, `libasound2t64`, and `xvfb` failed the Docker-backed Linux integration runs, so those packages remain installed.

## Testing

Each removed package was tested independently across the Linux .NET 8, 9, 10, and 11 CSharpIntegrationTests, DevKitTests, RazorCohostTests, and UntrustedWorkspaceTest jobs.