### PR TITLE
Enable native ESM extension bundle

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/dist/*.js"],
+            "outFiles": ["${workspaceRoot}/dist/*.{js,mjs}"],
             "preLaunchTask": "packageDev"
         },
         {
@@ -33,7 +33,7 @@
           },
           "sourceMaps": true,
           "outFiles": [
-            "${workspaceRoot}/dist/*.js",
+            "${workspaceRoot}/dist/*.{js,mjs}",
             "${workspaceRoot}/out/test/**/*.js"
           ],
           "resolveSourceMapLocations": [
@@ -66,7 +66,7 @@
                 "RoslynWaiterEnabled": "true"
             },
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/dist/*.js", "${workspaceRoot}/out/test/**/*.js"],
+            "outFiles": ["${workspaceRoot}/dist/*.{js,mjs}", "${workspaceRoot}/out/test/**/*.js"],
             "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
             "preLaunchTask": "packageDev",
             "internalConsoleOptions": "openOnSessionStart"
@@ -94,7 +94,7 @@
                 "RoslynWaiterEnabled": "true"
             },
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/dist/*.js", "${workspaceRoot}/out/test/**/*.js"],
+            "outFiles": ["${workspaceRoot}/dist/*.{js,mjs}", "${workspaceRoot}/out/test/**/*.js"],
             "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
             "preLaunchTask": "packageDev",
             "internalConsoleOptions": "openOnSessionStart"
@@ -121,7 +121,7 @@
                 "TEST_FILE_FILTER": "${file}"
             },
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/dist/*.js", "${workspaceRoot}/out/test/**/*.js"],
+            "outFiles": ["${workspaceRoot}/dist/*.{js,mjs}", "${workspaceRoot}/out/test/**/*.js"],
             "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
             "preLaunchTask": "packageDev",
             "internalConsoleOptions": "openOnSessionStart"
@@ -147,7 +147,7 @@
                 "TEST_FILE_FILTER": "${file}"
             },
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/dist/*.js", "${workspaceRoot}/out/test/**/*.js"],
+            "outFiles": ["${workspaceRoot}/dist/*.{js,mjs}", "${workspaceRoot}/out/test/**/*.js"],
             "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
             "preLaunchTask": "packageDev"
         },
@@ -172,7 +172,7 @@
                 "TEST_FILE_FILTER": "${file}"
             },
             "sourceMaps": true,
-            "outFiles": ["${workspaceRoot}/dist/*.js", "${workspaceRoot}/out/test/**/*.js"],
+            "outFiles": ["${workspaceRoot}/dist/*.{js,mjs}", "${workspaceRoot}/out/test/**/*.js"],
             "resolveSourceMapLocations": ["${workspaceFolder}/**", "!**/node_modules/**"],
             "preLaunchTask": "packageDev"
         },

--- a/esbuild.js
+++ b/esbuild.js
@@ -48,12 +48,15 @@ async function main() {
             'src/main.ts'
         ],
         bundle: true,
-        format: 'cjs',
+        format: 'esm',
+        banner: {
+            js: `import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);`,
+        },
         minify: production,
         sourcemap: !production,
         sourcesContent: false,
         platform: 'node',
-        outfile: 'dist/extension.js',
+        outfile: 'dist/extension.mjs',
         external: ['vscode', 'applicationinsights-native-metrics', '@opentelemetry/tracing'],
         logLevel: 'info',
         plugins: [

--- a/esbuild.js
+++ b/esbuild.js
@@ -50,7 +50,15 @@ async function main() {
         bundle: true,
         format: 'esm',
         banner: {
-            js: `import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);`,
+            js: [
+                `import { createRequire } from 'node:module';`,
+                `import { dirname as commonJsDirname } from 'node:path';`,
+                `import { fileURLToPath as commonJsFileURLToPath } from 'node:url';`,
+                `const require = createRequire(import.meta.url);`,
+                `// Temporary CommonJS globals until bundled source usages are converted to ESM.`,
+                `const __filename = commonJsFileURLToPath(import.meta.url);`,
+                `const __dirname = commonJsDirname(__filename);`,
+            ].join('\n'),
         },
         minify: production,
         sourcemap: !production,

--- a/msbuild/signing/signJs/signJs.proj
+++ b/msbuild/signing/signJs/signJs.proj
@@ -21,5 +21,8 @@
         <FilesToSign Include="$(OutDir)*.js">
             <Authenticode>MicrosoftSHA2</Authenticode>
         </FilesToSign>
+        <FilesToSign Include="$(OutDir)*.mjs">
+            <Authenticode>MicrosoftSHA2</Authenticode>
+        </FilesToSign>
     </ItemGroup>
 </Project>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "xamlTools": "18.10.12014.341",
     "testDiscovery": "9.9.223-ge3811b"
   },
-  "main": "./dist/extension",
+  "main": "./dist/extension.mjs",
   "l10n": "./l10n",
   "brokeredServices": [
     {
@@ -81,7 +81,7 @@
     "omnisharptest": "npm run packageDev && npx ts-node tasks/tests/omnisharptest.ts",
     "omnisharptest:integration": "npm run packageDev && npx ts-node tasks/tests/omnisharptestIntegration.ts",
     "omnisharptest:unit": "npm run compileDev && npx ts-node tasks/tests/omnisharptestUnit.ts",
-    "package": "npm run compile && npm run signJs && node esbuild.js --production",
+    "package": "npm run compile && node esbuild.js --production && npm run signJs",
     "packageDev": "npm run compileDev && node esbuild.js",
     "prepare": "npm run installDependencies",
     "profiling": "npm run package && npx ts-node tasks/profiling/profiling.ts",


### PR DESCRIPTION
## Summary

- Emit the packaged extension as `dist/extension.mjs` using esbuild's ESM format.
- Preserve CommonJS dependency compatibility with `createRequire(import.meta.url)`.
- Update debugging and signing to include `.mjs`, and bundle before signing.

This replaces #9614 so the rebuilt branch runs the `dev/*` CI trigger on current `main`. The original PR remains open.

## Follow-up dependency work

46 bundled modules currently need `createRequire`. The highest-priority dependencies that call `require("vscode")` are `vscode-languageclient`, `microsoft.aspnetcore.razor.vscode`, and `@vscode/extension-telemetry`; these will be evaluated in a later stack layer.

## Validation

- `npm run package`
- `npm run test:unit` — 514 tests passed
- `npm run test:integration:untrusted` — 1 test passed
- C# integration harness — 21 suites passed; 73 tests passed, 3 skipped