### PR TITLE
Fix roslyn-tools installation

### DIFF
--- a/.github/skills/update-roslyn-version/SKILL.md
+++ b/.github/skills/update-roslyn-version/SKILL.md
@@ -15,7 +15,7 @@ This skill describes how to update the Roslyn language server version in the vsc
   - If unable to find local roslyn repo, ask the user for its location.
 2. The `roslyn-tools` CLI tool must be installed as a global .NET tool:
    ```powershell
-   dotnet tool install -g Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+   dotnet tool install -g Microsoft.RoslynTools --prerelease --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
    ```
    **Note**: After installation, the tool is invoked as `roslyn-tools` (not `dotnet roslyn-tools`)
 3. You must have authenticated with GitHub for `roslyn-tools`:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install roslyn-tools
-        run: dotnet tool install -g Microsoft.RoslynTools --prerelease --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+        run: dotnet tool install -g Microsoft.RoslynTools --prerelease --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
       - name: Install NodeJS
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Using `--source` makes the provided feed the only one considered. Using `--add-source` allowed failures from the nuget.config configured feed to fail the installation.