### PR TITLE
Use WIF for OneLocBuild package access

### DIFF
--- a/azure-pipelines/loc.yml
+++ b/azure-pipelines/loc.yml
@@ -73,6 +73,15 @@ extends:
           displayName: 'Generate bundle.l10.json'
         - pwsh: npm run l10nDevGenerateXlf
           displayName: 'Generate xlf files from bundle.10n.json'
+        - task: AzureCLI@2
+          displayName: 'Get ceapex token'
+          inputs:
+            azureSubscription: 'dnceng-onelocbuild-ceapex'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+              Write-Host "##vso[task.setvariable variable=CeapexEntraToken;issecret=true]${token}"
         - task: OneLocBuild@2
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -80,7 +89,7 @@ extends:
             locProj: loc/LocProject.json
             outDir: '$(Build.SourcesDirectory)/loc'
             isCreatePrSelected: false
-            patVariable: $(dn-bot-ceapex-package-r)
+            patVariable: $(CeapexEntraToken)
             packageSourceAuth: patAuth
             lclSource: lclFilesfromPackage
             LclPackageId: 'LCL-JUNO-PROD-VSCODECS'

--- a/azure-pipelines/loc.yml
+++ b/azure-pipelines/loc.yml
@@ -27,10 +27,6 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
-variables:
-# Variable group contains the credential for the localization package source.
-- group: OneLocBuildVariables
-
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
@@ -80,7 +76,9 @@ extends:
             scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
-              $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+              # Azure DevOps first-party resource ID used to request a short-lived package-access token.
+              $azureDevOpsResourceId = '499b84ac-1321-427f-aa17-267ca6975798'
+              $token = az account get-access-token --query accessToken --resource $azureDevOpsResourceId -o tsv
               Write-Host "##vso[task.setvariable variable=CeapexEntraToken;issecret=true]${token}"
         - task: OneLocBuild@2
           env:


### PR DESCRIPTION
Acquire a short-lived Azure DevOps token through the existing DevDiv dnceng-onelocbuild-ceapex workload identity service connection instead of reading dn-bot-ceapex-package-r from OneLocBuildVariables.

Tracking: AB#10151