### PR TITLE
Fix generated watch task project path

### DIFF
--- a/src/shared/assets.ts
+++ b/src/shared/assets.ts
@@ -272,7 +272,7 @@ export class AssetGenerator {
     private createWatchTaskDescription(): tasks.TaskDescription {
         const commandArgs = ['watch', 'run'];
 
-        const buildProject = this.getBuildProjectPath();
+        const buildProject = this.getBuildProjectPath(/*useSolutionPath*/ false);
         if (buildProject) {
             commandArgs.push('--project');
             commandArgs.push(buildProject);
@@ -300,13 +300,13 @@ export class AssetGenerator {
         commandArgs.push('/consoleloggerparameters:NoSummary;ForceNoAlign');
     }
 
-    private getBuildProjectPath(): string | null {
+    private getBuildProjectPath(useSolutionPath = true): string | null {
         let buildProject = this.startupProject;
         if (!buildProject) {
             buildProject = this.fallbackBuildProject;
         }
         if (buildProject) {
-            if (buildProject.solutionPath) {
+            if (useSolutionPath && buildProject.solutionPath) {
                 return this.getBuildPath(buildProject.solutionPath);
             } else {
                 return this.getBuildPath(buildProject.projectPath);

--- a/test/omnisharp/omnisharpUnitTests/assets.test.ts
+++ b/test/omnisharp/omnisharpUnitTests/assets.test.ts
@@ -39,6 +39,27 @@ describe('Asset generation: csproj', () => {
         expect(segments).toStrictEqual(['${workspaceFolder}', 'testApp.csproj']);
     });
 
+    test("Generated 'watch' task uses the project path when the solution path is available", () => {
+        const rootPath = path.resolve('testRoot');
+        const info = createMSBuildWorkspaceInformation(
+            path.join(rootPath, 'testApp.csproj'),
+            'testApp',
+            'netcoreapp1.0'
+        );
+        info[0].solutionPath = path.join(rootPath, 'testApp.sln');
+        const generator = new AssetGenerator(info, createMockWorkspaceFolder(rootPath));
+        generator.setStartupProject(0);
+        const tasksJson = generator.createTasksConfiguration();
+
+        const buildTask = tasksJson.tasks!.find((task) => task.label === 'build');
+        isNotNull(buildTask?.args);
+        expect(buildTask.args).toContain('${workspaceFolder}/testApp.sln');
+
+        const watchTask = tasksJson.tasks!.find((task) => task.label === 'watch');
+        isNotNull(watchTask?.args);
+        expect(watchTask.args).toStrictEqual(['watch', 'run', '--project', '${workspaceFolder}/testApp.csproj']);
+    });
+
     test("Generated 'build' and 'publish' tasks have the property GenerateFullPaths set to true ", () => {
         const rootPath = path.resolve('testRoot');
         const info = createMSBuildWorkspaceInformation(


### PR DESCRIPTION
## Summary

- generate `dotnet watch` tasks with the selected project path instead of the containing solution path
- preserve existing solution-path behavior for build and publish tasks
- add regression coverage for projects with a non-null `solutionPath`

Fixes #7886

## Testing

- `npx eslint src\shared\assets.ts test\omnisharp\omnisharpUnitTests\assets.test.ts --fix`
- OmniSharp Unit Tests: 37 suites, 402 tests passed