### PR TITLE
ActiveDocumentLanguageSupport experimental service

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscodeAdapter from '../src/vscodeAdapter';
 import { getFakeVsCode } from '../test/fakes';
 
 // This module creates a manual mock for the vscode module for running in unit tests.
@@ -10,4 +11,5 @@ import { getFakeVsCode } from '../test/fakes';
 
 // We can consider switching to an actual jest mock (instead of this manual fake) once we entirely
 // remove the old test framework (mocha/chai).
-module.exports = getFakeVsCode();
+const vscode: vscodeAdapter.vscode = getFakeVsCode();
+module.exports = vscode;

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscodeAdapter from '../src/vscodeAdapter';
 import { getFakeVsCode } from '../test/fakes';
 
 // This module creates a manual mock for the vscode module for running in unit tests.
@@ -11,26 +10,4 @@ import { getFakeVsCode } from '../test/fakes';
 
 // We can consider switching to an actual jest mock (instead of this manual fake) once we entirely
 // remove the old test framework (mocha/chai).
-class EventEmitter<T> {
-    private readonly listeners: ((event: T) => void)[] = [];
-
-    public readonly event = (listener: (event: T) => void) => {
-        this.listeners.push(listener);
-        return { dispose: () => this.listeners.splice(this.listeners.indexOf(listener), 1) };
-    };
-
-    public fire(event: T): void {
-        for (const listener of this.listeners) {
-            listener(event);
-        }
-    }
-
-    public dispose(): void {
-        this.listeners.length = 0;
-    }
-}
-
-const vscode: vscodeAdapter.vscode & { EventEmitter: typeof EventEmitter } = Object.assign(getFakeVsCode(), {
-    EventEmitter,
-});
-module.exports = vscode;
+module.exports = getFakeVsCode();

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -11,5 +11,26 @@ import { getFakeVsCode } from '../test/fakes';
 
 // We can consider switching to an actual jest mock (instead of this manual fake) once we entirely
 // remove the old test framework (mocha/chai).
-const vscode: vscodeAdapter.vscode = getFakeVsCode();
+class EventEmitter<T> {
+    private readonly listeners: ((event: T) => void)[] = [];
+
+    public readonly event = (listener: (event: T) => void) => {
+        this.listeners.push(listener);
+        return { dispose: () => this.listeners.splice(this.listeners.indexOf(listener), 1) };
+    };
+
+    public fire(event: T): void {
+        for (const listener of this.listeners) {
+            listener(event);
+        }
+    }
+
+    public dispose(): void {
+        this.listeners.length = 0;
+    }
+}
+
+const vscode: vscodeAdapter.vscode & { EventEmitter: typeof EventEmitter } = Object.assign(getFakeVsCode(), {
+    EventEmitter,
+});
 module.exports = vscode;

--- a/src/activateRoslyn.ts
+++ b/src/activateRoslyn.ts
@@ -25,6 +25,7 @@ import { SolutionSnapshotProvider } from './lsptoolshost/solutionSnapshot/soluti
 import { BuildResultDiagnostics } from './lsptoolshost/diagnostics/buildResultReporterService';
 import { getComponentFolder } from './lsptoolshost/extensions/builtInComponents';
 import { ObservableLogOutputChannel } from './lsptoolshost/logging/observableLogOutputChannel';
+import { ActiveDocumentLanguageSupportService } from './lsptoolshost/projectContext/activeDocumentLanguageSupportService';
 
 export function activateRoslyn(
     context: vscode.ExtensionContext,
@@ -65,6 +66,8 @@ export function activateRoslyn(
     const coreClrDebugPromise = getCoreClrDebugPromise(roslynLanguageServerStartedPromise);
 
     const languageServerExport = new RoslynLanguageServerExport(roslynLanguageServerStartedPromise);
+    const activeDocumentLanguageSupport = new ActiveDocumentLanguageSupportService(roslynLanguageServerStartedPromise);
+    context.subscriptions.push(activeDocumentLanguageSupport);
     const exports: CSharpExtensionExports = {
         isLimitedActivation: false,
         initializationFinished: async () => {
@@ -91,6 +94,7 @@ export function activateRoslyn(
             const languageServer = await roslynLanguageServerStartedPromise;
             return createCaptureActivityLogs(languageServer);
         },
+        activeDocumentLanguageSupport,
     };
 
     return exports;

--- a/src/activateRoslyn.ts
+++ b/src/activateRoslyn.ts
@@ -66,7 +66,10 @@ export function activateRoslyn(
     const coreClrDebugPromise = getCoreClrDebugPromise(roslynLanguageServerStartedPromise);
 
     const languageServerExport = new RoslynLanguageServerExport(roslynLanguageServerStartedPromise);
-    const activeDocumentLanguageSupport = new ActiveDocumentLanguageSupportService(roslynLanguageServerStartedPromise);
+    const activeDocumentLanguageSupport = new ActiveDocumentLanguageSupportService(
+        roslynLanguageServerStartedPromise,
+        csharpChannel
+    );
     context.subscriptions.push(activeDocumentLanguageSupport);
     const exports: CSharpExtensionExports = {
         isLimitedActivation: false,

--- a/src/activateRoslyn.ts
+++ b/src/activateRoslyn.ts
@@ -68,7 +68,7 @@ export function activateRoslyn(
     const languageServerExport = new RoslynLanguageServerExport(roslynLanguageServerStartedPromise);
     const activeDocumentLanguageSupport = new ActiveDocumentLanguageSupportService(
         roslynLanguageServerStartedPromise,
-        csharpChannel
+        observableCsharpChannel
     );
     context.subscriptions.push(activeDocumentLanguageSupport);
     const exports: CSharpExtensionExports = {

--- a/src/activateRoslyn.ts
+++ b/src/activateRoslyn.ts
@@ -87,6 +87,7 @@ export function activateRoslyn(
             sendServerRequestWithProgress: async (t, p, pr, ct) =>
                 await languageServerExport.sendRequestWithProgress(t, p, pr, ct),
             languageServerEvents: roslynLanguageServerEvents,
+            activeDocumentLanguageSupport,
         },
         getComponentFolder: (componentName) => {
             return getComponentFolder(componentName, languageServerOptions);
@@ -97,7 +98,6 @@ export function activateRoslyn(
             const languageServer = await roslynLanguageServerStartedPromise;
             return createCaptureActivityLogs(languageServer);
         },
-        activeDocumentLanguageSupport,
     };
 
     return exports;

--- a/src/csharpExtensionExports.ts
+++ b/src/csharpExtensionExports.ts
@@ -65,7 +65,6 @@ export interface CSharpExtensionExports {
     tryToUseVSDbgForMono: (urlStr: string, projectPath: string) => Promise<[string, number, number]>;
     languageServerProcessId: () => number | undefined;
     captureActivityLogs: () => Promise<ActivityLogCapture>;
-    activeDocumentLanguageSupport: ActiveDocumentLanguageSupportService;
 }
 
 export interface CSharpExtensionExperimentalExports {
@@ -87,4 +86,5 @@ export interface CSharpExtensionExperimentalExports {
         token?: vscode.CancellationToken
     ): Promise<Response>;
     languageServerEvents: LanguageServerEvents;
+    activeDocumentLanguageSupport: ActiveDocumentLanguageSupportService;
 }

--- a/src/csharpExtensionExports.ts
+++ b/src/csharpExtensionExports.ts
@@ -33,17 +33,20 @@ export interface ActivityLogResult {
     lspTraceLog: string;
 }
 
+/**
+ * - `unknown` when document language support is still being actively determined.
+ * - `limited` when document language support is incomplete (e.g. miscellaneous file, virtual file, unsupported language, ...).
+ * - `full` when language server has determined full language support is available.
+ */
+export type LanguageSupportState = 'unknown' | 'full' | 'limited';
+
 /** Roslyn's language-support classification for the active C# document. */
 export interface ActiveDocumentLanguageSupport {
     /** Serialized URI of the document to which this snapshot applies. */
     documentUri: string;
-    /**
-     * `unknown` while the project context is still stabilizing, `full` once Roslyn verifies that
-     * full language support is available, or `limited` once Roslyn verifies that it is not.
-     */
-    state: 'unknown' | 'full' | 'limited';
-    /** Labels of the Roslyn project contexts represented by this snapshot. */
-    projectLabels: readonly string[];
+    state: LanguageSupportState;
+    /** Label of the current Roslyn project context represented by this snapshot. */
+    projectLabel: string;
 }
 
 /** Publishes snapshots for the active C# document as Roslyn project information changes. */

--- a/src/csharpExtensionExports.ts
+++ b/src/csharpExtensionExports.ts
@@ -40,7 +40,7 @@ export interface ActivityLogResult {
  */
 export type LanguageSupportState = 'unknown' | 'full' | 'limited';
 
-/** Roslyn's language-support classification for the active C# document. */
+/** Roslyn's language-support classification for the active document. */
 export interface ActiveDocumentLanguageSupport {
     /** Serialized URI of the document to which this snapshot applies. */
     documentUri: string;
@@ -49,7 +49,7 @@ export interface ActiveDocumentLanguageSupport {
     projectLabel: string;
 }
 
-/** Publishes snapshots for the active C# document as Roslyn project information changes. */
+/** Publishes snapshots for the active document as Roslyn project information changes. */
 export interface ActiveDocumentLanguageSupportService {
     /** Most recently published snapshot, or `undefined` when no relevant document is active. */
     readonly current: ActiveDocumentLanguageSupport | undefined;

--- a/src/csharpExtensionExports.ts
+++ b/src/csharpExtensionExports.ts
@@ -33,6 +33,27 @@ export interface ActivityLogResult {
     lspTraceLog: string;
 }
 
+/** Roslyn's language-support classification for the active C# document. */
+export interface ActiveDocumentLanguageSupport {
+    /** Serialized URI of the document to which this snapshot applies. */
+    documentUri: string;
+    /**
+     * `unknown` while the project context is still stabilizing, `full` once Roslyn verifies that
+     * full language support is available, or `limited` once Roslyn verifies that it is not.
+     */
+    state: 'unknown' | 'full' | 'limited';
+    /** Labels of the Roslyn project contexts represented by this snapshot. */
+    projectLabels: readonly string[];
+}
+
+/** Publishes snapshots for the active C# document as Roslyn project information changes. */
+export interface ActiveDocumentLanguageSupportService {
+    /** Most recently published snapshot, or `undefined` when no relevant document is active. */
+    readonly current: ActiveDocumentLanguageSupport | undefined;
+    /** Fires when the active document or its Roslyn language-support classification changes. */
+    readonly onDidChange: vscode.Event<ActiveDocumentLanguageSupport | undefined>;
+}
+
 export interface CSharpExtensionExports {
     isLimitedActivation: false;
     initializationFinished: () => Promise<void>;
@@ -44,6 +65,7 @@ export interface CSharpExtensionExports {
     tryToUseVSDbgForMono: (urlStr: string, projectPath: string) => Promise<[string, number, number]>;
     languageServerProcessId: () => number | undefined;
     captureActivityLogs: () => Promise<ActivityLogCapture>;
+    activeDocumentLanguageSupport: ActiveDocumentLanguageSupportService;
 }
 
 export interface CSharpExtensionExperimentalExports {

--- a/src/lsptoolshost/projectContext/activeDocumentLanguageSupportService.ts
+++ b/src/lsptoolshost/projectContext/activeDocumentLanguageSupportService.ts
@@ -58,9 +58,7 @@ export class ActiveDocumentLanguageSupportService implements IActiveDocumentLang
 
                 return languageServer._projectContextService.refresh();
             })
-            .catch((error) =>
-                this._outputChannel?.error('Failed to initialize active document language support', error)
-            );
+            .catch((error) => this._outputChannel?.error('ActiveDocumentLanguageSupport failed to initialize:', error));
     }
 
     public get current(): ActiveDocumentLanguageSupport | undefined {
@@ -80,7 +78,7 @@ export class ActiveDocumentLanguageSupportService implements IActiveDocumentLang
 
     private updateCurrent(value: ActiveDocumentLanguageSupport | undefined): void {
         this._current = value;
-        this._outputChannel?.debug('Changing active document language support to:', value?.state);
+        this._outputChannel?.debug('ActiveDocumentLanguageSupport changing to:', value);
         this._onDidChangeEmitter.fire(value);
     }
 }

--- a/src/lsptoolshost/projectContext/activeDocumentLanguageSupportService.ts
+++ b/src/lsptoolshost/projectContext/activeDocumentLanguageSupportService.ts
@@ -10,49 +10,57 @@ import {
 } from '../../csharpExtensionExports';
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import { shouldNotifyForMiscellaneousFile } from '../workspace/miscellaneousFileNotifier';
+import { ProjectContextChangeEvent } from './projectContextService';
 
 export class ActiveDocumentLanguageSupportService implements IActiveDocumentLanguageSupportService, vscode.Disposable {
     private readonly _onDidChangeEmitter = new vscode.EventEmitter<ActiveDocumentLanguageSupport | undefined>();
     private readonly _activeEditorSubscription: vscode.Disposable;
+    private readonly _outputChannel: vscode.LogOutputChannel | undefined;
     private _projectContextSubscription: vscode.Disposable | undefined;
     private _current: ActiveDocumentLanguageSupport | undefined;
     private _isDisposed = false;
 
-    constructor(languageServerPromise: Promise<RoslynLanguageServer>) {
+    constructor(languageServerPromise: Promise<RoslynLanguageServer>, outputChannel?: vscode.LogOutputChannel) {
         this._activeEditorSubscription = vscode.window.onDidChangeActiveTextEditor(() => this.updateCurrent(undefined));
+        this._outputChannel = outputChannel;
 
-        void languageServerPromise.then((languageServer) => {
-            if (this._isDisposed) {
-                return;
-            }
-
-            this._projectContextSubscription = languageServer._projectContextService.onActiveFileContextChanged(
-                (event) => {
-                    const activeDocument = vscode.window.activeTextEditor?.document;
-                    if (
-                        event.document.uri.scheme !== 'file' ||
-                        event.document.languageId !== 'csharp' ||
-                        activeDocument?.uri.toString() !== event.document.uri.toString()
-                    ) {
-                        return;
-                    }
-
-                    this.updateCurrent({
-                        documentUri: event.document.uri.toString(),
-                        state: event.context._vs_is_miscellaneous
-                            ? shouldNotifyForMiscellaneousFile(event, languageServer.state)
-                                ? 'limited'
-                                : 'unknown'
-                            : event.context._vs_id
-                              ? 'full'
-                              : 'unknown',
-                        projectLabels: event.context._vs_label ? [event.context._vs_label] : [],
-                    });
+        languageServerPromise
+            .then(async (languageServer) => {
+                if (this._isDisposed) {
+                    return;
                 }
-            );
 
-            void languageServer._projectContextService.refresh();
-        });
+                this._projectContextSubscription = languageServer._projectContextService.onActiveFileContextChanged(
+                    (event: ProjectContextChangeEvent) => {
+                        const activeDocumentUriString = vscode.window.activeTextEditor?.document?.uri.toString();
+                        const eventDocumentUriString = event.document.uri.toString();
+                        if (
+                            event.document.uri.scheme !== 'file' ||
+                            event.document.languageId !== 'csharp' ||
+                            activeDocumentUriString !== eventDocumentUriString
+                        ) {
+                            return;
+                        }
+
+                        this.updateCurrent({
+                            documentUri: event.document.uri.toString(),
+                            state: event.context._vs_is_miscellaneous
+                                ? shouldNotifyForMiscellaneousFile(event, languageServer.state)
+                                    ? 'limited'
+                                    : 'unknown'
+                                : event.context._vs_id
+                                  ? 'full'
+                                  : 'unknown',
+                            projectLabels: event.context._vs_label ? [event.context._vs_label] : [],
+                        });
+                    }
+                );
+
+                return languageServer._projectContextService.refresh();
+            })
+            .catch((error) =>
+                this._outputChannel?.error('Failed to initialize active document language support', error)
+            );
     }
 
     public get current(): ActiveDocumentLanguageSupport | undefined {
@@ -72,6 +80,7 @@ export class ActiveDocumentLanguageSupportService implements IActiveDocumentLang
 
     private updateCurrent(value: ActiveDocumentLanguageSupport | undefined): void {
         this._current = value;
+        this._outputChannel?.debug('Changing active document language support to:', value?.state);
         this._onDidChangeEmitter.fire(value);
     }
 }

--- a/src/lsptoolshost/projectContext/activeDocumentLanguageSupportService.ts
+++ b/src/lsptoolshost/projectContext/activeDocumentLanguageSupportService.ts
@@ -9,7 +9,7 @@ import {
     ActiveDocumentLanguageSupportService as IActiveDocumentLanguageSupportService,
 } from '../../csharpExtensionExports';
 import { RoslynLanguageServer } from '../server/roslynLanguageServer';
-import { shouldNotifyForMiscellaneousFile } from '../workspace/miscellaneousFileNotifier';
+import { getLanguageSupportState } from '../workspace/miscellaneousFileNotifier';
 import { ProjectContextChangeEvent } from './projectContextService';
 
 export class ActiveDocumentLanguageSupportService implements IActiveDocumentLanguageSupportService, vscode.Disposable {
@@ -34,24 +34,14 @@ export class ActiveDocumentLanguageSupportService implements IActiveDocumentLang
                     (event: ProjectContextChangeEvent) => {
                         const activeDocumentUriString = vscode.window.activeTextEditor?.document?.uri.toString();
                         const eventDocumentUriString = event.document.uri.toString();
-                        if (
-                            event.document.uri.scheme !== 'file' ||
-                            event.document.languageId !== 'csharp' ||
-                            activeDocumentUriString !== eventDocumentUriString
-                        ) {
+                        if (activeDocumentUriString !== eventDocumentUriString) {
                             return;
                         }
 
                         this.updateCurrent({
                             documentUri: event.document.uri.toString(),
-                            state: event.context._vs_is_miscellaneous
-                                ? shouldNotifyForMiscellaneousFile(event, languageServer.state)
-                                    ? 'limited'
-                                    : 'unknown'
-                                : event.context._vs_id
-                                  ? 'full'
-                                  : 'unknown',
-                            projectLabels: event.context._vs_label ? [event.context._vs_label] : [],
+                            state: getLanguageSupportState(event, languageServer.state),
+                            projectLabel: event.context._vs_label,
                         });
                     }
                 );
@@ -78,7 +68,7 @@ export class ActiveDocumentLanguageSupportService implements IActiveDocumentLang
 
     private updateCurrent(value: ActiveDocumentLanguageSupport | undefined): void {
         this._current = value;
-        this._outputChannel?.debug('ActiveDocumentLanguageSupport changing to:', value);
+        this._outputChannel?.debug('ActiveDocumentLanguageSupport changed to', value);
         this._onDidChangeEmitter.fire(value);
     }
 }

--- a/src/lsptoolshost/projectContext/activeDocumentLanguageSupportService.ts
+++ b/src/lsptoolshost/projectContext/activeDocumentLanguageSupportService.ts
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import {
+    ActiveDocumentLanguageSupport,
+    ActiveDocumentLanguageSupportService as IActiveDocumentLanguageSupportService,
+} from '../../csharpExtensionExports';
+import { RoslynLanguageServer } from '../server/roslynLanguageServer';
+import { shouldNotifyForMiscellaneousFile } from '../workspace/miscellaneousFileNotifier';
+
+export class ActiveDocumentLanguageSupportService implements IActiveDocumentLanguageSupportService, vscode.Disposable {
+    private readonly _onDidChangeEmitter = new vscode.EventEmitter<ActiveDocumentLanguageSupport | undefined>();
+    private readonly _activeEditorSubscription: vscode.Disposable;
+    private _projectContextSubscription: vscode.Disposable | undefined;
+    private _current: ActiveDocumentLanguageSupport | undefined;
+    private _isDisposed = false;
+
+    constructor(languageServerPromise: Promise<RoslynLanguageServer>) {
+        this._activeEditorSubscription = vscode.window.onDidChangeActiveTextEditor(() => this.updateCurrent(undefined));
+
+        void languageServerPromise.then((languageServer) => {
+            if (this._isDisposed) {
+                return;
+            }
+
+            this._projectContextSubscription = languageServer._projectContextService.onActiveFileContextChanged(
+                (event) => {
+                    const activeDocument = vscode.window.activeTextEditor?.document;
+                    if (
+                        event.document.uri.scheme !== 'file' ||
+                        event.document.languageId !== 'csharp' ||
+                        activeDocument?.uri.toString() !== event.document.uri.toString()
+                    ) {
+                        return;
+                    }
+
+                    this.updateCurrent({
+                        documentUri: event.document.uri.toString(),
+                        state: event.context._vs_is_miscellaneous
+                            ? shouldNotifyForMiscellaneousFile(event, languageServer.state)
+                                ? 'limited'
+                                : 'unknown'
+                            : event.context._vs_id
+                              ? 'full'
+                              : 'unknown',
+                        projectLabels: event.context._vs_label ? [event.context._vs_label] : [],
+                    });
+                }
+            );
+
+            void languageServer._projectContextService.refresh();
+        });
+    }
+
+    public get current(): ActiveDocumentLanguageSupport | undefined {
+        return this._current;
+    }
+
+    public get onDidChange(): vscode.Event<ActiveDocumentLanguageSupport | undefined> {
+        return this._onDidChangeEmitter.event;
+    }
+
+    public dispose(): void {
+        this._isDisposed = true;
+        this._activeEditorSubscription.dispose();
+        this._projectContextSubscription?.dispose();
+        this._onDidChangeEmitter.dispose();
+    }
+
+    private updateCurrent(value: ActiveDocumentLanguageSupport | undefined): void {
+        this._current = value;
+        this._onDidChangeEmitter.fire(value);
+    }
+}

--- a/src/lsptoolshost/projectContext/projectContextService.ts
+++ b/src/lsptoolshost/projectContext/projectContextService.ts
@@ -22,6 +22,12 @@ import { RazorLanguage } from '../../razor/src/razorLanguage';
 export interface ProjectContextChangeEvent {
     document: vscode.TextDocument;
     context: VSProjectContext;
+    /**
+     * False when project context has changed very recently (see {@link VerificationDelay}).
+     * This allows us to gracefully handle situations where a document is briefly a miscellaneous file,
+     * then a design-time build completes, and the document becomes part of a project. (e.g. new/rename document scenarios).
+     * We don't want to warn the user about miscellaneous files in that situation.
+     * */
     isVerified: boolean;
     hasAdditionalContexts: boolean;
 }
@@ -178,7 +184,7 @@ export class ProjectContextService {
         const hasAdditionalContexts = contextList._vs_projectContexts.length > 1;
         this._contextChangeEmitter.fire({ document, context, isVerified: false, hasAdditionalContexts });
 
-        // If we do not recieve a refresh even within the timout period, send a verified event.
+        // If we do not receive a refresh even within the timeout period, send a verified event.
         _verifyTimeout = setTimeout(() => {
             this._contextChangeEmitter.fire({ document, context, isVerified: true, hasAdditionalContexts });
         }, VerificationDelay);

--- a/src/lsptoolshost/projectContext/projectContextService.ts
+++ b/src/lsptoolshost/projectContext/projectContextService.ts
@@ -173,13 +173,8 @@ export class ProjectContextService {
             return;
         }
 
-        const cachedContext = this.getDocumentContext(document.uri);
         const context =
-            contextList._vs_projectContexts.find((candidate) => candidate._vs_id === cachedContext?._vs_id) ??
-            contextList._vs_projectContexts[contextList._vs_defaultIndex];
-        if (contextList._vs_projectContexts.length > 1) {
-            this._keyToActiveProjectContextMap.set(contextList._vs_key, context);
-        }
+            this.getDocumentContext(document.uri) ?? contextList._vs_projectContexts[contextList._vs_defaultIndex];
         const hasAdditionalContexts = contextList._vs_projectContexts.length > 1;
         this._contextChangeEmitter.fire({ document, context, isVerified: false, hasAdditionalContexts });
 

--- a/src/lsptoolshost/projectContext/projectContextService.ts
+++ b/src/lsptoolshost/projectContext/projectContextService.ts
@@ -173,8 +173,13 @@ export class ProjectContextService {
             return;
         }
 
+        const cachedContext = this.getDocumentContext(document.uri);
         const context =
-            this.getDocumentContext(document.uri) ?? contextList._vs_projectContexts[contextList._vs_defaultIndex];
+            contextList._vs_projectContexts.find((candidate) => candidate._vs_id === cachedContext?._vs_id) ??
+            contextList._vs_projectContexts[contextList._vs_defaultIndex];
+        if (contextList._vs_projectContexts.length > 1) {
+            this._keyToActiveProjectContextMap.set(contextList._vs_key, context);
+        }
         const hasAdditionalContexts = contextList._vs_projectContexts.length > 1;
         this._contextChangeEmitter.fire({ document, context, isVerified: false, hasAdditionalContexts });
 

--- a/src/lsptoolshost/projectContext/projectContextService.ts
+++ b/src/lsptoolshost/projectContext/projectContextService.ts
@@ -27,7 +27,7 @@ export interface ProjectContextChangeEvent {
      * This allows us to gracefully handle situations where a document is briefly a miscellaneous file,
      * then a design-time build completes, and the document becomes part of a project. (e.g. new/rename document scenarios).
      * We don't want to warn the user about miscellaneous files in that situation.
-     * */
+     */
     isVerified: boolean;
     hasAdditionalContexts: boolean;
 }

--- a/src/lsptoolshost/workspace/miscellaneousFileNotifier.ts
+++ b/src/lsptoolshost/workspace/miscellaneousFileNotifier.ts
@@ -9,11 +9,13 @@ import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import { ActionOption, showWarningMessage } from '../../shared/observers/utils/showMessage';
 import { languageServerOptions } from '../../shared/options';
 import { ServerState } from '../server/languageServerEvents';
-import { ProjectContextChangeEvent } from '../projectContext/projectContextService';
+import type { ProjectContextChangeEvent } from '../projectContext/projectContextService';
 
 const SuppressMiscellaneousFilesToastsOption = 'dotnet.server.suppressMiscellaneousFilesToasts';
 const NotifiedDocuments = new Set<string>();
 
+// A miscellaneous context is actionable only after project initialization has completed,
+// when the file can no longer move into a project as part of the initial workspace load.
 export function shouldNotifyForMiscellaneousFile(event: ProjectContextChangeEvent, serverState: ServerState): boolean {
     return (
         event.document.uri.scheme === 'file' &&
@@ -28,7 +30,6 @@ export function registerMiscellaneousFileNotifier(
     languageServer: RoslynLanguageServer
 ) {
     languageServer._projectContextService.onActiveFileContextChanged(async (e) => {
-        // Only warn for C# miscellaneous files when the workspace is fully initialized.
         if (!shouldNotifyForMiscellaneousFile(e, languageServer.state)) {
             return;
         }

--- a/src/lsptoolshost/workspace/miscellaneousFileNotifier.ts
+++ b/src/lsptoolshost/workspace/miscellaneousFileNotifier.ts
@@ -47,6 +47,10 @@ export function registerMiscellaneousFileNotifier(
             return;
         }
 
+        if (!e.isVerified) {
+            return;
+        }
+
         if (getLanguageSupportState(e, languageServer.state) !== 'limited') {
             return;
         }

--- a/src/lsptoolshost/workspace/miscellaneousFileNotifier.ts
+++ b/src/lsptoolshost/workspace/miscellaneousFileNotifier.ts
@@ -9,9 +9,19 @@ import { RoslynLanguageServer } from '../server/roslynLanguageServer';
 import { ActionOption, showWarningMessage } from '../../shared/observers/utils/showMessage';
 import { languageServerOptions } from '../../shared/options';
 import { ServerState } from '../server/languageServerEvents';
+import { ProjectContextChangeEvent } from '../projectContext/projectContextService';
 
 const SuppressMiscellaneousFilesToastsOption = 'dotnet.server.suppressMiscellaneousFilesToasts';
 const NotifiedDocuments = new Set<string>();
+
+export function shouldNotifyForMiscellaneousFile(event: ProjectContextChangeEvent, serverState: ServerState): boolean {
+    return (
+        event.document.uri.scheme === 'file' &&
+        event.document.languageId === 'csharp' &&
+        event.context._vs_is_miscellaneous &&
+        serverState === ServerState.ProjectInitializationComplete
+    );
+}
 
 export function registerMiscellaneousFileNotifier(
     context: vscode.ExtensionContext,
@@ -19,13 +29,7 @@ export function registerMiscellaneousFileNotifier(
 ) {
     languageServer._projectContextService.onActiveFileContextChanged(async (e) => {
         // Only warn for C# miscellaneous files when the workspace is fully initialized.
-        if (
-            e.document.uri.scheme !== 'file' ||
-            e.document.languageId !== 'csharp' ||
-            !e.isVerified ||
-            !e.context._vs_is_miscellaneous ||
-            languageServer.state !== ServerState.ProjectInitializationComplete
-        ) {
+        if (!shouldNotifyForMiscellaneousFile(e, languageServer.state)) {
             return;
         }
 

--- a/src/lsptoolshost/workspace/miscellaneousFileNotifier.ts
+++ b/src/lsptoolshost/workspace/miscellaneousFileNotifier.ts
@@ -10,19 +10,27 @@ import { ActionOption, showWarningMessage } from '../../shared/observers/utils/s
 import { languageServerOptions } from '../../shared/options';
 import { ServerState } from '../server/languageServerEvents';
 import type { ProjectContextChangeEvent } from '../projectContext/projectContextService';
+import { LanguageSupportState } from '../../csharpExtensionExports';
+import { getCSharpDevKit } from '../../utils/getCSharpDevKit';
 
 const SuppressMiscellaneousFilesToastsOption = 'dotnet.server.suppressMiscellaneousFilesToasts';
 const NotifiedDocuments = new Set<string>();
 
-// A miscellaneous context is actionable only after project initialization has completed,
-// when the file can no longer move into a project as part of the initial workspace load.
-export function shouldNotifyForMiscellaneousFile(event: ProjectContextChangeEvent, serverState: ServerState): boolean {
-    return (
-        event.document.uri.scheme === 'file' &&
-        event.document.languageId === 'csharp' &&
-        event.context._vs_is_miscellaneous &&
-        serverState === ServerState.ProjectInitializationComplete
-    );
+export function getLanguageSupportState(
+    event: ProjectContextChangeEvent,
+    serverState: ServerState
+): LanguageSupportState {
+    if (serverState !== ServerState.ProjectInitializationComplete) {
+        return 'unknown';
+    }
+
+    // Note: non-empty '_vs_id' is checked for sanity, before concluding that full support is available,
+    // to ensure that full support is not reported for 'ProjectContextService._emptyProjectContext'
+    if (!event.context._vs_is_miscellaneous && event.context._vs_id) {
+        return 'full';
+    }
+
+    return 'limited';
 }
 
 export function registerMiscellaneousFileNotifier(
@@ -30,7 +38,16 @@ export function registerMiscellaneousFileNotifier(
     languageServer: RoslynLanguageServer
 ) {
     languageServer._projectContextService.onActiveFileContextChanged(async (e) => {
-        if (!shouldNotifyForMiscellaneousFile(e, languageServer.state)) {
+        if (getCSharpDevKit()) {
+            // Don't notify if CDK is loaded, since CDK uses its own degraded experience UI separately.
+            return;
+        }
+
+        if (e.document.uri.scheme !== 'file' || e.document.languageId !== 'csharp') {
+            return;
+        }
+
+        if (getLanguageSupportState(e, languageServer.state) !== 'limited') {
             return;
         }
 

--- a/src/vscodeAdapter.ts
+++ b/src/vscodeAdapter.ts
@@ -302,6 +302,11 @@ export interface Event<T> {
     (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]): Disposable;
 }
 
+export interface EventEmitter<T> extends Disposable {
+    readonly event: Event<T>;
+    fire(data: T): void;
+}
+
 export interface Disposable {
     /**
      * Dispose this object.
@@ -957,6 +962,9 @@ export interface Extension<_T> {
 }
 
 export interface vscode {
+    EventEmitter: {
+        new <T>(): EventEmitter<T>;
+    };
     commands: {
         executeCommand: <T>(command: string, ...rest: any[]) => Thenable<T | undefined>;
     };

--- a/test/fakes.ts
+++ b/test/fakes.ts
@@ -180,8 +180,41 @@ export function getUnresolvedDependenices(fileName: string): OmnisharpServerUnre
     });
 }
 
+class EventEmitter<T> implements vscode.EventEmitter<T> {
+    private readonly listeners: { listener: (event: T) => any; thisArgs?: any }[] = [];
+
+    public readonly event: vscode.Event<T> = (listener, thisArgs, disposables) => {
+        const entry = { listener, thisArgs };
+        this.listeners.push(entry);
+        let isDisposed = false;
+        const disposable = {
+            dispose: () => {
+                if (isDisposed) {
+                    return;
+                }
+
+                isDisposed = true;
+                this.listeners.splice(this.listeners.indexOf(entry), 1);
+            },
+        };
+        disposables?.push(disposable);
+        return disposable;
+    };
+
+    public fire(event: T): void {
+        for (const { listener, thisArgs } of this.listeners) {
+            listener.call(thisArgs, event);
+        }
+    }
+
+    public dispose(): void {
+        this.listeners.length = 0;
+    }
+}
+
 export function getFakeVsCode(): vscode.vscode {
     return {
+        EventEmitter,
         commands: {
             executeCommand: <_T>(_command: string, ..._rest: any[]) => {
                 throw new Error('Not Implemented');

--- a/test/lsptoolshost/unitTests/activeDocumentLanguageSupportService.test.ts
+++ b/test/lsptoolshost/unitTests/activeDocumentLanguageSupportService.test.ts
@@ -61,6 +61,26 @@ describe('ActiveDocumentLanguageSupportService', () => {
         expect(refresh).toHaveBeenCalled();
         service.dispose();
     });
+
+    test('logs a failure from the initial project context refresh', async () => {
+        (vscode.window as any).onDidChangeActiveTextEditor = () => ({ dispose: jest.fn() });
+        const error = new Error('refresh failed');
+        const logError = jest.fn();
+        const languageServer = {
+            _projectContextService: {
+                onActiveFileContextChanged: () => ({ dispose: jest.fn() }),
+                refresh: async () => Promise.reject(error),
+            },
+        };
+
+        const service = new ActiveDocumentLanguageSupportService(Promise.resolve(languageServer as any), {
+            error: logError,
+        } as any);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(logError).toHaveBeenCalledWith('Failed to initialize active document language support', error);
+        service.dispose();
+    });
 });
 
 function createEvent(

--- a/test/lsptoolshost/unitTests/activeDocumentLanguageSupportService.test.ts
+++ b/test/lsptoolshost/unitTests/activeDocumentLanguageSupportService.test.ts
@@ -37,23 +37,23 @@ describe('ActiveDocumentLanguageSupportService', () => {
         const service = new ActiveDocumentLanguageSupportService(Promise.resolve(languageServer as any));
         await Promise.resolve();
 
-        projectContextChanged?.(createEvent(document, false, true));
+        projectContextChanged?.(createEvent(document, { isVerified: false, isMiscellaneous: true }));
         expect(service.current?.state).toBe('unknown');
 
         languageServer.state = ServerState.ProjectInitializationComplete;
-        projectContextChanged?.(createEvent(document, false, true));
+        projectContextChanged?.(createEvent(document, { isVerified: false, isMiscellaneous: true }));
         expect(service.current?.state).toBe('limited');
 
-        projectContextChanged?.(createEvent(document, false, false));
+        projectContextChanged?.(createEvent(document, { isVerified: false, isMiscellaneous: false }));
         expect(service.current?.state).toBe('full');
 
-        projectContextChanged?.(createEvent(document, false, false, ''));
-        expect(service.current?.state).toBe('unknown');
-
-        projectContextChanged?.(createEvent(document, true, true));
+        projectContextChanged?.(createEvent(document, { isVerified: false, isMiscellaneous: false, projectId: '' }));
         expect(service.current?.state).toBe('limited');
 
-        projectContextChanged?.(createEvent(document, true, false));
+        projectContextChanged?.(createEvent(document, { isVerified: true, isMiscellaneous: true }));
+        expect(service.current?.state).toBe('limited');
+
+        projectContextChanged?.(createEvent(document, { isVerified: true, isMiscellaneous: false }));
         expect(service.current?.state).toBe('full');
 
         activeEditorChanged?.();
@@ -78,26 +78,28 @@ describe('ActiveDocumentLanguageSupportService', () => {
         } as any);
         await new Promise((resolve) => setImmediate(resolve));
 
-        expect(logError).toHaveBeenCalledWith('Failed to initialize active document language support', error);
+        expect(logError).toHaveBeenCalledWith(expect.stringContaining('ActiveDocumentLanguageSupport'), error);
         service.dispose();
     });
 });
 
 function createEvent(
     document: vscode.TextDocument,
-    isVerified: boolean,
-    isMiscellaneous: boolean,
-    projectId = 'project'
+    args: {
+        isVerified: boolean;
+        isMiscellaneous: boolean;
+        projectId?: string;
+    }
 ): ProjectContextChangeEvent {
     return {
         document,
         context: {
-            _vs_id: projectId,
+            _vs_id: args.projectId === undefined ? 'project' : args.projectId,
             _vs_kind: 'CSharp',
             _vs_label: 'Program.cs',
-            _vs_is_miscellaneous: isMiscellaneous,
+            _vs_is_miscellaneous: args.isMiscellaneous,
         },
-        isVerified,
+        isVerified: args.isVerified,
         hasAdditionalContexts: false,
     };
 }

--- a/test/lsptoolshost/unitTests/activeDocumentLanguageSupportService.test.ts
+++ b/test/lsptoolshost/unitTests/activeDocumentLanguageSupportService.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, jest, test } from '@jest/globals';
+import * as vscode from 'vscode';
+import { ActiveDocumentLanguageSupportService } from '../../../src/lsptoolshost/projectContext/activeDocumentLanguageSupportService';
+import type { ProjectContextChangeEvent } from '../../../src/lsptoolshost/projectContext/projectContextService';
+import { ServerState } from '../../../src/lsptoolshost/server/languageServerEvents';
+
+describe('ActiveDocumentLanguageSupportService', () => {
+    test('tracks changing support for the active document and clears it on editor change', async () => {
+        let activeEditorChanged: (() => void) | undefined;
+        let projectContextChanged: ((event: ProjectContextChangeEvent) => void) | undefined;
+        (vscode.window as any).onDidChangeActiveTextEditor = (listener: () => void) => {
+            activeEditorChanged = listener;
+            return { dispose: jest.fn() };
+        };
+
+        const document = {
+            uri: { scheme: 'file', toString: () => 'file:///repo/Program.cs' },
+            languageId: 'csharp',
+        } as vscode.TextDocument;
+        (vscode.window as any).activeTextEditor = { document };
+        const refresh = jest.fn(async () => {});
+        const languageServer = {
+            state: ServerState.ProjectInitializationStarted,
+            _projectContextService: {
+                onActiveFileContextChanged: (listener: (event: ProjectContextChangeEvent) => void) => {
+                    projectContextChanged = listener;
+                    return { dispose: jest.fn() };
+                },
+                refresh,
+            },
+        };
+        const service = new ActiveDocumentLanguageSupportService(Promise.resolve(languageServer as any));
+        await Promise.resolve();
+
+        projectContextChanged?.(createEvent(document, false, true));
+        expect(service.current?.state).toBe('unknown');
+
+        languageServer.state = ServerState.ProjectInitializationComplete;
+        projectContextChanged?.(createEvent(document, false, true));
+        expect(service.current?.state).toBe('limited');
+
+        projectContextChanged?.(createEvent(document, false, false));
+        expect(service.current?.state).toBe('full');
+
+        projectContextChanged?.(createEvent(document, false, false, ''));
+        expect(service.current?.state).toBe('unknown');
+
+        projectContextChanged?.(createEvent(document, true, true));
+        expect(service.current?.state).toBe('limited');
+
+        projectContextChanged?.(createEvent(document, true, false));
+        expect(service.current?.state).toBe('full');
+
+        activeEditorChanged?.();
+        expect(service.current).toBeUndefined();
+        expect(refresh).toHaveBeenCalled();
+        service.dispose();
+    });
+});
+
+function createEvent(
+    document: vscode.TextDocument,
+    isVerified: boolean,
+    isMiscellaneous: boolean,
+    projectId = 'project'
+): ProjectContextChangeEvent {
+    return {
+        document,
+        context: {
+            _vs_id: projectId,
+            _vs_kind: 'CSharp',
+            _vs_label: 'Program.cs',
+            _vs_is_miscellaneous: isMiscellaneous,
+        },
+        isVerified,
+        hasAdditionalContexts: false,
+    };
+}


### PR DESCRIPTION
Internal PR: https://devdiv.visualstudio.com/DevDiv/_git/vs-green/pullrequest/774658

Expose an experimental service which allows subscribing to whether language services are fully available for the active file.

This is essentially reusing/migrating part of the logic used by the C# extension, to decide whether to show a miscellaneous file toast. This logic is informed by the Roslyn LS's file-based app loading and [classification](https://github.com/dotnet/roslyn/blob/main/docs/features/file-based-programs-vscode.md#file-based-app-detection) of loose files.