### PR TITLE
Update roslyn to 5.12.0-1.26428.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.150.x
+* Update Roslyn to 5.12.0-1.26428.6 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Prevent Introduce Constant crash in top-level lambdas (PR: [#85071](https://github.com/dotnet/roslyn/pull/85071))
 * Update Roslyn to 5.12.0-1.26428.1 (PR: [#9712](https://github.com/dotnet/vscode-csharp/pull/9712))
   * Fix extra newline after primary constructor parameter (PR: [#85030](https://github.com/dotnet/roslyn/pull/85030))
   * Read unopened LSP files from disk without persisting them (PR: [#85061](https://github.com/dotnet/roslyn/pull/85061))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Debug from .csproj and .sln [#5876](https://github.com/dotnet/vscode-csharp/issues/5876)
 
 # 2.150.x
-* Update Roslyn to 5.12.0-1.26428.6 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.12.0-1.26428.6 (PR: [#9714](https://github.com/dotnet/vscode-csharp/pull/9714))
   * Prevent Introduce Constant crash in top-level lambdas (PR: [#85071](https://github.com/dotnet/roslyn/pull/85071))
 * Update Roslyn to 5.12.0-1.26428.1 (PR: [#9712](https://github.com/dotnet/vscode-csharp/pull/9712))
   * Fix extra newline after primary constructor parameter (PR: [#85030](https://github.com/dotnet/roslyn/pull/85030))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.12.0-1.26428.1",
+    "roslyn": "5.12.0-1.26428.6",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.10.12014.341",


### PR DESCRIPTION
[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/7e23e9d7d1a90e50319cbe2be17ecda58e3a5c83...92a36efa9ae1a26a14872f87798526a1c3dd050b?w=1)
* Prevent Introduce Constant crash in top-level lambdas (PR: [#85071](https://github.com/dotnet/roslyn/pull/85071))
* Enable function resolution for SymbolOnly processes (PR: [#85033](https://github.com/dotnet/roslyn/pull/85033))
* Use VSEng-MicroBuildVSStable pool (PR: [#85079](https://github.com/dotnet/roslyn/pull/85079))
* Parse misplaced 'ref' modifier on type declarations (PR: [#84935](https://github.com/dotnet/roslyn/pull/84935))

