### PR TITLE
Migrate Roslyn Copilot publisher to GitHub App authentication

### DIFF
--- a/azure-pipelines/publish-roslyn-copilot.yml
+++ b/azure-pipelines/publish-roslyn-copilot.yml
@@ -1,10 +1,6 @@
 trigger: none
 pr: none
 
-variables:
-# Variable group contains PAT for bot account.
-- group: dotnet-vscode-insertion-variables
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -68,7 +64,21 @@ extends:
             npm install
           displayName: 'Install tools'
 
+        - task: AzureCLI@2
+          displayName: 'Get GitHub App installation token'
+          inputs:
+            azureSubscription: 'devdiv-oneloc-githubapp'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              & "$(Build.SourcesDirectory)/azure-pipelines/Get-GitHubAppToken.ps1" `
+                -KeyVaultName 'EngKeyVault' `
+                -KeyName 'oneloc-localization-app-key' `
+                -AppClientId 'Iv23lijBU8x3gc9lDOc9' `
+                -InstallationOwner 'dotnet' `
+                -OutputVariableName 'GitHubAppInstallationToken'
+
         - pwsh: npm run publishRoslynCopilot -- --userName dotnet-maestro-bot --email dotnet-maestro-bot@microsoft.com --stagingDirectory '$(Build.ArtifactStagingDirectory)/staging'
           displayName: 'Create component update PR'
           env:
-            GitHubPAT: $(BotAccount-dotnet-maestro-bot-PAT)
+            GitHubToken: $(GitHubAppInstallationToken)

--- a/tasks/components/publishRoslynCopilot.ts
+++ b/tasks/components/publishRoslynCopilot.ts
@@ -58,9 +58,9 @@ async function publishRoslynCopilot() {
     const safeVersion = version.replace(/[^A-Za-z0-9_.-]/g, '-');
     const branch = `update/roslyn-copilot-${safeVersion}`;
 
-    const pat = process.env['GitHubPAT'];
-    if (!pat) {
-        throw 'No GitHub PAT found.';
+    const githubToken = process.env['GitHubToken'];
+    if (!githubToken) {
+        throw 'No GitHub token found.';
     }
 
     const owner = 'dotnet';
@@ -73,7 +73,7 @@ async function publishRoslynCopilot() {
         console.log(`##vso[task.logissue type=warning]${branch} already exists in origin. Skip pushing.`);
         return;
     }
-    const existingPRUrl = await findPRByTitle(pat, owner, repo, title);
+    const existingPRUrl = await findPRByTitle(githubToken, owner, repo, title);
     if (existingPRUrl) {
         console.log(
             `##vso[task.logissue type=warning] Pull request with the same name already exists: ${existingPRUrl}`
@@ -98,8 +98,8 @@ async function publishRoslynCopilot() {
     await createCommit(branch, ['package.json'], `Update RoslynCopilot version to ${version}`);
 
     // Push branch and create PR
-    await pushBranch(branch, pat, owner, repo);
-    await createPullRequest(pat, owner, repo, branch, title, body);
+    await pushBranch(branch, githubToken, owner, repo);
+    await createPullRequest(githubToken, owner, repo, branch, title, body);
 }
 
 /**


### PR DESCRIPTION
## Summary

- replace `BotAccount-dotnet-maestro-bot-PAT` in the Roslyn Copilot publisher with a short-lived GitHub App installation token
- use the existing DevDiv project-scoped `devdiv-oneloc-githubapp` WIF connection and the Key Vault-backed OneLoc App already installed for this repository
- rename the task environment variable from `GitHubPAT` to credential-neutral `GitHubToken`

## Context

DevDiv pipeline [27222](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=27222) actively targets `azure-pipelines/publish-roslyn-copilot.yml`. The App is already installed for `dotnet/vscode-csharp` and has proven pull-request write access through the repository's localization flow. Azure DevOps service connections are project-scoped: this DevDiv pipeline uses `devdiv-oneloc-githubapp`; the repository's `loc.yml` runs in `dnceng/internal` and uses its counterpart, `dnceng-oneloc-githubapp`.

The DevDiv connection is ready and pipeline 27222 is explicitly authorized to use it.

Tracking: [DNCENG 12420](https://dev.azure.com/dnceng/internal/_workitems/edit/12420)