### PR TITLE
Update roslyn to 5.12.0-1.26453.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 # 2.152.x
 
+* Update Roslyn to 5.12.0-1.26453.19 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Allow Razor to supply editorconfig options during code action cleanup (PR: [#85128](https://github.com/dotnet/roslyn/pull/85128))
+  * Fix completion crash with stale linked documents (PR: [#85134](https://github.com/dotnet/roslyn/pull/85134))
+  * Use vscode-uri semantics for parsing URIs (PR: [#83593](https://github.com/dotnet/roslyn/pull/83593))
+  * Prevent type rename from renaming ordinary Finalize methods (PR: [#85126](https://github.com/dotnet/roslyn/pull/85126))
+  * Update the condition used to include the CodeStyle .globalconfig (PR: [#80540](https://github.com/dotnet/roslyn/pull/80540))
+
 # 2.151.x
 * Update Roslyn to 5.12.0-1.26452.1 (PR: [#9725](https://github.com/dotnet/vscode-csharp/pull/9725))
   * Ignore spurious TypeScript diagnostics caused by Razor code (PR: [#85129](https://github.com/dotnet/roslyn/pull/85129))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 # 2.152.x
 
-* Update Roslyn to 5.12.0-1.26453.19 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.12.0-1.26453.19 (PR: [#9731](https://github.com/dotnet/vscode-csharp/pull/9731))
   * Allow Razor to supply editorconfig options during code action cleanup (PR: [#85128](https://github.com/dotnet/roslyn/pull/85128))
   * Fix completion crash with stale linked documents (PR: [#85134](https://github.com/dotnet/roslyn/pull/85134))
   * Use vscode-uri semantics for parsing URIs (PR: [#83593](https://github.com/dotnet/roslyn/pull/83593))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.12.0-1.26452.1",
+    "roslyn": "5.12.0-1.26453.19",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.10.12014.341",


### PR DESCRIPTION
Official Roslyn build: [20260903.19 (build 3066125)](https://dev.azure.com/dnceng/internal/_build/results?buildId=3066125&view=results)

[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/e42c0e42e89e41522593d0816707e71781ecbee2...2a7f0cf7f1fb033d1b4c23a80b6a097ff198ebfd?w=1)
* [main] Source code updates from dotnet/dotnet (PR: [#85160](https://github.com/dotnet/roslyn/pull/85160))
* Allow Razor to supply editorconfig options during code action cleanup (PR: [#85128](https://github.com/dotnet/roslyn/pull/85128))
* Stabilize transitive directive reload test (PR: [#85138](https://github.com/dotnet/roslyn/pull/85138))
* Rationalize and simplify telemetry logging apis (PR: [#85062](https://github.com/dotnet/roslyn/pull/85062))
* Fix completion crash with stale linked documents (PR: [#85134](https://github.com/dotnet/roslyn/pull/85134))
* Fix AI artifact audit Copilot startup (PR: [#85139](https://github.com/dotnet/roslyn/pull/85139))
* [main] Source code updates from dotnet/dotnet (PR: [#85088](https://github.com/dotnet/roslyn/pull/85088))
* [main] Update dependencies from dotnet/roslyn (PR: [#85099](https://github.com/dotnet/roslyn/pull/85099))
* Enable CI for dev/* branches (PR: [#85144](https://github.com/dotnet/roslyn/pull/85144))
* Publish Windows PDBs for Roslyn SDK (PR: [#85133](https://github.com/dotnet/roslyn/pull/85133))
* Use CollectionsMarshal to get span from list in collection expression (PR: [#85007](https://github.com/dotnet/roslyn/pull/85007))
* Skip Roslyn SDK VSIX preparation under Core MSBuild (PR: [#85137](https://github.com/dotnet/roslyn/pull/85137))
* Add GetValueConversion extension methods for ICoalesceOperation (PR: [#85029](https://github.com/dotnet/roslyn/pull/85029))
* Use vscode-uri semantics for parsing URIs (PR: [#83593](https://github.com/dotnet/roslyn/pull/83593))
* Remove testRunName from MacOS CI leg (PR: [#85136](https://github.com/dotnet/roslyn/pull/85136))
* Unsafe evolution: fix a race in version decoding (PR: [#85131](https://github.com/dotnet/roslyn/pull/85131))
* Prevent type rename from renaming ordinary Finalize methods (PR: [#85126](https://github.com/dotnet/roslyn/pull/85126))
* Update the condition used to include the CodeStyle .globalconfig (PR: [#80540](https://github.com/dotnet/roslyn/pull/80540))