### PR TITLE
Update roslyn to 5.12.0-1.26459.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 # 2.152.x
 
-* Update Roslyn to 5.12.0-1.26459.1 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+* Update Roslyn to 5.12.0-1.26459.1 (PR: [#9743](https://github.com/dotnet/vscode-csharp/pull/9743))
   * Centralize Language Server workspace folder tracking (PR: [#85105](https://github.com/dotnet/roslyn/pull/85105))
 * Update Roslyn to 5.12.0-1.26453.19 (PR: [#9731](https://github.com/dotnet/vscode-csharp/pull/9731))
   * Allow Razor to supply editorconfig options during code action cleanup (PR: [#85128](https://github.com/dotnet/roslyn/pull/85128))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 # 2.152.x
 
+* Update Roslyn to 5.12.0-1.26459.1 (PR: [#](https://github.com/dotnet/vscode-csharp/pull/))
+  * Centralize Language Server workspace folder tracking (PR: [#85105](https://github.com/dotnet/roslyn/pull/85105))
 * Update Roslyn to 5.12.0-1.26453.19 (PR: [#9731](https://github.com/dotnet/vscode-csharp/pull/9731))
   * Allow Razor to supply editorconfig options during code action cleanup (PR: [#85128](https://github.com/dotnet/roslyn/pull/85128))
   * Fix completion crash with stale linked documents (PR: [#85134](https://github.com/dotnet/roslyn/pull/85134))

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "workspace"
   ],
   "defaults": {
-    "roslyn": "5.12.0-1.26453.19",
+    "roslyn": "5.12.0-1.26459.1",
     "omniSharp": "1.39.14",
     "razorOmnisharp": "7.0.0-preview.23363.1",
     "xamlTools": "18.10.12014.341",


### PR DESCRIPTION
Roslyn build: [dotnet-roslyn-official build 3070675](https://dev.azure.com/dnceng/internal/_build/results?buildId=3070675&view=results)

[View Complete Diff of Changes](https://github.com/dotnet/roslyn/compare/2a7f0cf7f1fb033d1b4c23a80b6a097ff198ebfd...38a51ec2d3a23600078f62be5b581464954c6e9f?w=1)
* Correct stale Roslyn guidance references (PR: [#85211](https://github.com/dotnet/roslyn/pull/85211))
* Trigger CI on PRs to dev/* branches (PR: [#85216](https://github.com/dotnet/roslyn/pull/85216))
* Remove instructions causing unecessary updates to instructions files (PR: [#85214](https://github.com/dotnet/roslyn/pull/85214))
* Test for line endings and long paths (PR: [#85127](https://github.com/dotnet/roslyn/pull/85127))
* Include NuGet.config in Helix test payloads (PR: [#85210](https://github.com/dotnet/roslyn/pull/85210))
* Fix missing PDBs in Editorconfig DLLs (PR: [#85192](https://github.com/dotnet/roslyn/pull/85192))
* Centralize Language Server workspace folder tracking (PR: [#85105](https://github.com/dotnet/roslyn/pull/85105))
* Delete the DiagnosticsToolWindow (PR: [#85152](https://github.com/dotnet/roslyn/pull/85152))
* Import EditorConfig templates from dotnet/templates (PR: [#85157](https://github.com/dotnet/roslyn/pull/85157))
* Improve parser recovery for misplaced 'partial' modifiers (PR: [#83216](https://github.com/dotnet/roslyn/pull/83216))
* Add instructions for how to build with analyzers (PR: [#83228](https://github.com/dotnet/roslyn/pull/83228))
* Make VB SDK samples strict (`Option Strict On`) (PR: [#85124](https://github.com/dotnet/roslyn/pull/85124))
* Sync FBA sources (PR: [#85065](https://github.com/dotnet/roslyn/pull/85065))
* Record partial lambda parsing baselines (PR: [#85166](https://github.com/dotnet/roslyn/pull/85166))
* Visit left operand conversion in a fast path of nullable analysis (PR: [#85115](https://github.com/dotnet/roslyn/pull/85115))
* Localized file check-in by OneLocBuild Task: Build definition ID 10077: Build ID 8742256 (PR: [#799](https://github.com/dotnet/roslyn/pull/799))
* Fix EditorConfig at solution level (PR: [#782](https://github.com/dotnet/roslyn/pull/782))
* Localized file check-in by OneLocBuild Task: Build definition ID 10077: Build ID 6347393  (PR: [#678](https://github.com/dotnet/roslyn/pull/678))
* enable nullable  (PR: [#692](https://github.com/dotnet/roslyn/pull/692))
* Fix a NullReferenceException in the DeclarePublicAPI analyzer (PR: [#677](https://github.com/dotnet/roslyn/pull/677))
* Merge pull request #644 from jmarolf/features/update-default-editorconfig-settings (PR: [#644](https://github.com/dotnet/roslyn/pull/644))
* Localized file check-in by OneLocBuild Task: Build definition ID 10077: Build ID 4901452  (PR: [#511](https://github.com/dotnet/roslyn/pull/511))
* Localized file check-in by OneLocBuild Task: Build definition ID 10077: Build ID 4901402  (PR: [#510](https://github.com/dotnet/roslyn/pull/510))
* Localized file check-in by OneLocBuild Task: Build definition ID 10077: Build ID 4900535  (PR: [#509](https://github.com/dotnet/roslyn/pull/509))
* Localized file check-in by OneLocBuild Task: Build definition ID 10077: Build ID 4905189  (PR: [#512](https://github.com/dotnet/roslyn/pull/512))
* Set VSSDKTargetPlatformRegRootSuffix (PR: [#461](https://github.com/dotnet/roslyn/pull/461))
* Update VS SDK  (PR: [#487](https://github.com/dotnet/roslyn/pull/487))
* Update VSSDK  (PR: [#479](https://github.com/dotnet/roslyn/pull/479))
* Localized file check-in by OneLocBuild Task: Build definition ID 10077: Build ID 4718492  (PR: [#478](https://github.com/dotnet/roslyn/pull/478))
* Fix Editor config issues (PR: [#206](https://github.com/dotnet/roslyn/pull/206))
* fix EditorConfig templates names (PR: [#193](https://github.com/dotnet/roslyn/pull/193))
* Fix vs dev (PR: [#134](https://github.com/dotnet/roslyn/pull/134))
* Add new classlib templates (PR: [#132](https://github.com/dotnet/roslyn/pull/132))
* do not build tasks and use nuget package instead  (PR: [#92](https://github.com/dotnet/roslyn/pull/92))
* move-to-arcade  (PR: [#90](https://github.com/dotnet/roslyn/pull/90))
* Correcting two option names
  (PR: [#83](https://github.com/dotnet/roslyn/pull/83))
* Trim trailing whitespace in EditorConfig item templates  (PR: [#73](https://github.com/dotnet/roslyn/pull/73))
* Update editorconfig default name  (PR: [#65](https://github.com/dotnet/roslyn/pull/65))
* Fix access to resources  (PR: [#64](https://github.com/dotnet/roslyn/pull/64))
* LOC CHECKIN | dotnet/templates master | 20180629  (PR: [#61](https://github.com/dotnet/roslyn/pull/61))
* adding VB editorconfig templates  (PR: [#56](https://github.com/dotnet/roslyn/pull/56))
* Merge dev15.8 preview2 to master  (PR: [#55](https://github.com/dotnet/roslyn/pull/55))
* fix setup  (PR: [#54](https://github.com/dotnet/roslyn/pull/54))
* Merges/dev15.8 preview2 to master  (PR: [#52](https://github.com/dotnet/roslyn/pull/52))
* Update setup authoring  (PR: [#50](https://github.com/dotnet/roslyn/pull/50))
* Merges/dev15.7.x to dev15.8 preview2  (PR: [#48](https://github.com/dotnet/roslyn/pull/48))
* reset to defaults  (PR: [#47](https://github.com/dotnet/roslyn/pull/47))
* Fix aspnet node order  (PR: [#46](https://github.com/dotnet/roslyn/pull/46))
* Merges/dev15.8 preview2 to master  (PR: [#45](https://github.com/dotnet/roslyn/pull/45))
* Refactor  (PR: [#44](https://github.com/dotnet/roslyn/pull/44))
* update vb authoring  (PR: [#41](https://github.com/dotnet/roslyn/pull/41))
* adding localized resources  (PR: [#40](https://github.com/dotnet/roslyn/pull/40))
* fixing Kaseys comments  (PR: [#39](https://github.com/dotnet/roslyn/pull/39))
* Editorconifg changes  (PR: [#38](https://github.com/dotnet/roslyn/pull/38))